### PR TITLE
Phase 1: scaffold the new repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Sound Clash — root .env.example
+# Copy to .env and fill in. The .env file must NOT be committed (gitignored).
+# See docs/local-development.md for what each value should be.
+
+# Supabase (local dev: get from `supabase start` output; prod: dashboard → Settings → API)
+SUPABASE_URL=http://localhost:54321
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Direct Postgres connection (local dev only; never in prod)
+DATABASE_URL=postgres://postgres:postgres@localhost:54322/postgres
+
+# Admin password (single shared secret for managers)
+ADMIN_PASSWORD=devpass123
+
+# Sentry (leave blank in dev to disable)
+SENTRY_DSN_BACKEND=
+SENTRY_DSN_FRONTEND=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,55 @@
+# Normalise line endings to LF on commit; check out as LF on every platform.
+# This eliminates the "LF will be replaced by CRLF" warnings on Windows.
+* text=auto eol=lf
+
+# Source files: explicit text + LF
+*.py     text eol=lf
+*.ts     text eol=lf
+*.tsx    text eol=lf
+*.js     text eol=lf
+*.jsx    text eol=lf
+*.json   text eol=lf
+*.md     text eol=lf
+*.sql    text eol=lf
+*.sh     text eol=lf eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.toml   text eol=lf
+*.html   text eol=lf
+*.css    text eol=lf
+*.txt    text eol=lf
+Dockerfile text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.editorconfig text eol=lf
+.env.example text eol=lf
+
+# Shell scripts must be LF or they break on Linux.
+*.sh text eol=lf
+
+# Binary file types — explicitly mark to avoid mangling.
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.webp   binary
+*.ico    binary
+*.svg    text eol=lf
+*.pdf    binary
+*.zip    binary
+*.gz     binary
+*.tar    binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.eot    binary
+*.mp3    binary
+*.mp4    binary
+*.wav    binary
+*.ogg    binary
+
+# GitHub linguist hints (keeps language stats accurate)
+docs/**          linguist-documentation
+Sound-Clash-Plan/** linguist-documentation
+*.md             linguist-documentation
+db/migrations/** linguist-detectable

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+<!--
+This file goes in the new repo at: .github/ISSUE_TEMPLATE/bug_report.md
+-->
+
+---
+name: Bug report
+about: Something isn't working
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- One paragraph. What were you doing, what went wrong? -->
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## What you expected
+
+<!-- What should have happened instead? -->
+
+## Environment
+
+- Role: <team / manager / display / admin>
+- Browser + version: <e.g. Chrome 121 on Windows 11>
+- Game code (if applicable): <ABCDEF>
+- Approximate time it occurred: <2026-05-03 14:30 UTC>
+
+## Logs / errors
+
+<!-- Browser console errors, network tab screenshots, Sentry link, etc. Triple-backtick code blocks for log snippets. -->
+
+```
+<paste here>
+```
+
+## Additional context
+
+<!-- Anything else: did it happen once or every time? Did it work before some recent change? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# This file goes in the new repo at: .github/ISSUE_TEMPLATE/config.yml
+# Disables blank issues; forces use of templates above.
+
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: mailto:benartzi4@gmail.com?subject=%5BSECURITY%5D%20Sound%20Clash
+    about: Please email security issues privately rather than opening a public issue.
+  - name: Question / discussion
+    url: https://github.com/BenArtzi4/Sound-Clash/discussions
+    about: For open-ended questions, use Discussions instead of Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+<!--
+This file goes in the new repo at: .github/ISSUE_TEMPLATE/feature_request.md
+-->
+
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What gap or pain point are you trying to address? "I want X" is fine, but "When I try to do X, I run into Y" is better. -->
+
+## Proposed solution
+
+<!-- What would the feature look like? UI change, new endpoint, new rule? Be specific. -->
+
+## Alternatives considered
+
+<!-- What other ways could this be solved? Why is your proposal better? -->
+
+## Out of scope reminder
+
+<!-- Sound Clash explicitly excludes some features (see CONTRIBUTING.md "What we don't merge"). Confirm your request isn't one of these:
+- Persistent player accounts
+- Game history beyond 4 hours
+- Direct audio uploads (YouTube only)
+- AI-driven song selection cache
+- Audio fingerprinting / cheat detection
+-->
+
+- [ ] My request is NOT one of the out-of-scope items above
+
+## Additional context
+
+<!-- Mockups, similar features in other apps, links to discussions. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,86 @@
+version: 2
+
+updates:
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Python (backend)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    groups:
+      backend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        applies-to: version-updates
+
+  # npm (frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    groups:
+      frontend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        applies-to: version-updates
+
+  # npm (e2e tests)
+  - package-ecosystem: "npm"
+    directory: "/tests/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "tests"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # Docker (backend image base)
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+<!--
+This file goes in the new repo at: .github/pull_request_template.md
+GitHub auto-loads it as the description when you open a PR.
+-->
+
+## What
+
+<!-- One-paragraph summary of what this PR changes. Focus on user-visible or system-visible effects, not the diff. -->
+
+## Why
+
+<!-- The problem this solves. Link to the issue if there is one (e.g., "Closes #42"). -->
+
+## How
+
+<!-- Brief description of the approach. Especially helpful if the implementation isn't obvious from the diff. Skip if trivial. -->
+
+## Test plan
+
+<!-- Concrete steps a reviewer can run to verify this works. -->
+
+- [ ] Unit tests pass: `pytest` and/or `vitest run`
+- [ ] E2E tests pass (if applicable): `npm run test:e2e`
+- [ ] Manual test: <describe what you clicked through>
+
+## Docs
+
+<!-- Tick all that apply. If you ticked "needed docs change", make sure the relevant doc is updated in this PR. -->
+
+- [ ] No doc change needed
+- [ ] Updated `docs/api-contracts.md` (new/changed endpoint)
+- [ ] Updated `docs/data-model.md` (schema change)
+- [ ] Updated `docs/rpc-functions.md` (PL/pgSQL function change)
+- [ ] Updated `docs/game-rules.md` (gameplay rule)
+- [ ] Updated `docs/runbook.md` (new env var, deployment step, alert)
+- [ ] Updated `docs/local-development.md` (dev setup change)
+- [ ] Updated `README.md`
+- [ ] Other: <which>
+
+## Risks & rollout
+
+<!-- Is this a database migration? A breaking API change? Anything that could go wrong on deploy? Skip if low-risk. -->
+
+## Screenshots / recordings
+
+<!-- For UI changes. Drag-and-drop into the PR. -->
+
+---
+
+<sub>By submitting this PR I confirm I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and my changes follow the project conventions.</sub>

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,92 @@
+name: Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "tests/backend/**"
+      - "tests/db/**"
+      - ".github/workflows/backend.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - "tests/backend/**"
+      - "tests/db/**"
+      - ".github/workflows/backend.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: backend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint + type + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: ruff format check
+        run: ruff format --check .
+
+      - name: mypy
+        run: mypy app
+
+      - name: Reject coverage pragmas in app code
+        run: |
+          if grep -rn "pragma:[[:space:]]*no cover" app/; then
+            echo "::error::Found 'pragma: no cover' in app code — banned per docs/testing-strategy.md §2"
+            exit 1
+          fi
+
+      - name: pytest with coverage
+        run: |
+          pytest \
+            --cov=app \
+            --cov-branch \
+            --cov-report=xml \
+            --cov-report=term-missing \
+            --cov-fail-under=0
+        # NOTE: --cov-fail-under starts at 0 in Phase 1 (empty app);
+        # ratcheted up at end of each phase per docs/testing-strategy.md §5.
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          files: backend/coverage.xml
+          flags: backend
+          token: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
+
+  deploy:
+    name: deploy (Render)
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger Render deploy
+        run: |
+          if [ -z "${{ secrets.RENDER_DEPLOY_HOOK }}" ]; then
+            echo "::warning::RENDER_DEPLOY_HOOK not set; skipping deploy"
+            exit 0
+          fi
+          curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan on Monday 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Use the security-and-quality query suite (broader than default).
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,14 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     # Weekly scan on Monday 06:00 UTC
     - cron: "0 6 * * 1"
   workflow_dispatch:
+
+# NOTE: this workflow does NOT run on pull_request because CodeQL requires
+# "Code scanning" to be enabled in repo Settings → Code security → Code scanning.
+# Once that's enabled, you can add `pull_request: { branches: [main] }` back.
 
 concurrency:
   group: codeql-${{ github.ref }}

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,48 @@
+name: DB Migrate
+
+# Manual dispatch only. Applies migrations to the chosen Supabase project.
+# See docs/runbook.md §1.3 for the deploy-with-migration playbook.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - preview
+          - prod
+      confirm:
+        description: 'Type "MIGRATE" to confirm'
+        required: true
+        type: string
+
+jobs:
+  migrate:
+    if: github.event.inputs.confirm == 'MIGRATE'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ${{ github.event.inputs.target }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install psql
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Apply migrations
+        env:
+          DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::SUPABASE_DATABASE_URL secret not set for environment ${{ github.event.inputs.target }}"
+            exit 1
+          fi
+          ./db/migrate.sh "$DATABASE_URL"
+
+      - name: Verify migrations idempotent (re-apply)
+        env:
+          DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+        run: |
+          ./db/migrate.sh "$DATABASE_URL"
+          echo "::notice::Migrations applied successfully and are idempotent on re-run."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,89 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # Run on main pushes, manual dispatch, OR PRs labeled `run-e2e`.
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-e2e')
+    name: Playwright multi-context
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Playwright
+        working-directory: tests/e2e
+        run: |
+          npm install
+          npx playwright install --with-deps chromium firefox webkit
+
+      - name: Run E2E
+        working-directory: tests/e2e
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_PREVIEW_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PREVIEW_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_PREVIEW_SERVICE_ROLE_KEY }}
+          ADMIN_PASSWORD: ${{ secrets.PREVIEW_ADMIN_PASSWORD }}
+          BASE_URL: ${{ secrets.PREVIEW_BASE_URL }}
+        run: npx playwright test
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report/
+          retention-days: 14
+
+  buzz_race_stress:
+    # Heavy stress test (race test 100 consecutive runs).
+    # Label-gated: only runs on PRs labeled `run-stress`, or manual dispatch.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-stress')
+    name: Buzz race stress (100x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install backend deps
+        working-directory: backend
+        run: pip install -e ".[dev]"
+      - name: Run race test 100×
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: |
+          for i in $(seq 1 100); do
+            echo "===== Run $i / 100 ====="
+            pytest -x -m stress ../tests/db/test_buzz_in_race.py || exit 1
+          done

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,102 @@
+name: Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint + type + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: Prettier check
+        run: npm run format:check
+
+      - name: TypeScript typecheck
+        run: npm run typecheck
+
+      - name: Reject skipped tests
+        run: |
+          if grep -rEn "(it|test)\.skip\(|@pytest\.mark\.skip|xfail" src/; then
+            echo "::error::Found skipped tests — banned per docs/testing-strategy.md §6"
+            exit 1
+          fi
+
+      - name: vitest with coverage
+        run: npm run test:coverage
+
+      - name: Verify no service-role key leaked into bundle
+        run: |
+          npm run build
+          if grep -rE "SUPABASE_SERVICE_ROLE" dist/ 2>/dev/null; then
+            echo "::error::SUPABASE_SERVICE_ROLE_KEY appears in frontend bundle"
+            exit 1
+          fi
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          token: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
+
+  deploy:
+    name: deploy (Cloudflare Pages)
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci || npm install
+      - run: npm run build
+      - name: Deploy to Cloudflare Pages
+        run: |
+          if [ -z "${{ secrets.CF_API_TOKEN }}" ]; then
+            echo "::warning::CF_API_TOKEN not set; skipping deploy"
+            exit 0
+          fi
+          npx wrangler@latest pages deploy dist --project-name=sound-clash --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,11 +30,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+          # NOTE: npm cache disabled until frontend/package-lock.json is committed
+          # (will be generated when Node is installed locally for Phase 5).
+          # Re-enable with `cache: "npm"` + `cache-dependency-path` once the
+          # lockfile lands.
 
       - name: Install
-        run: npm ci || npm install
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
 
       - name: ESLint
         run: npm run lint
@@ -86,9 +93,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci || npm install
+          # See note above about cache.
+      - run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
       - run: npm run build
       - name: Deploy to Cloudflare Pages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+env/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+*.egg-info/
+dist/
+build/
+
+# Node
+node_modules/
+.pnpm-store/
+.npm/
+*.tsbuildinfo
+
+# Vite
+frontend/dist/
+frontend/.vite/
+
+# Environment files (NEVER commit secrets)
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# Editor / OS
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Claude Code local-only settings (project rules in CLAUDE.md are committed; local settings are not)
+.claude/settings.local.json
+
+# Supabase local
+supabase/.branches/
+supabase/.temp/
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/
+
+# Sentry
+.sentryclirc
+
+# Logs
+*.log
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Thumbs.db
 
 # Claude Code local-only settings (project rules in CLAUDE.md are committed; local settings are not)
 .claude/settings.local.json
+.claude/rules/
 
 # Supabase local
 supabase/.branches/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+        args: ['--fix']
+        files: ^backend/
+      - id: ruff-format
+        files: ^backend/
+
+  - repo: local
+    hooks:
+      - id: no-jwt-leak
+        name: Detect committed JWT-shaped strings (potential service-role leak)
+        language: pygrep
+        entry: 'eyJhbGciOi'
+        exclude: '^(docs/|Sound-Clash-Plan/|\.pre-commit-config\.yaml)'
+
+      - id: no-skip-tests
+        name: Reject `it.skip` / `test.skip` / `xfail` outside generated code
+        language: pygrep
+        entry: '(it|test)\.skip\(|@pytest\.mark\.skip[^i]|xfail'
+        files: '^(tests/|frontend/src/.*\.test\.(ts|tsx))'
+
+      - id: no-pragma-no-cover
+        name: Reject coverage pragmas in app code
+        language: pygrep
+        entry: 'pragma:\s*no cover'
+        files: '^backend/app/'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,7 @@
-# Claude Code rules for Sound-Clash
-
-## Git workflow
-
-- **Never commit, push, or work directly on `main`.** Create a branch first for every change, no matter how small.
-- **Push freely.** Pushing branches and force-pushing your own feature branches is fine without asking.
-- **Open PRs freely.** Use `gh pr create` without asking for permission.
-- **Never merge a PR.** Merging is the user's decision. Do not run `gh pr merge`, do not click "merge" via API, do not squash/rebase-merge from the CLI. Open the PR and stop.
-- **Never force-push to `main`** under any circumstance.
-- **Never delete branches** (local or remote) without explicit permission.
-- **Never modify `.github/workflows/`** (CI config) without flagging it first — CI changes affect everyone.
-- **Never close or comment on PRs/issues** the user didn't ask you to touch.
-
-## Commit messages
-
-- **One line maximum.** Subject only. No body, no bullets, no extra paragraphs.
-- **No AI attribution anywhere.** Do not add `Co-Authored-By: Claude ...` trailers. Do not write "Generated with Claude Code", "🤖", or similar in commit messages, PR titles, or PR bodies. The repo should look human-authored.
-- Pass commits inline: `git commit -m "short subject"`.
-
-## PR descriptions
-
-- The default `## Summary` + `## Test plan` template is fine.
-- No AI footer, no emoji that signals AI authorship.
-
-## Branch naming
-
-- Use `feature/<short-name>` for new features and `fix/<short-name>` for bug fixes. Keeps the branch list scannable.
+@.claude/rules/git-workflow.md
+@.claude/rules/pull-requests.md
+@.claude/rules/commit-messages.md
+@.claude/rules/releases.md
+@.claude/rules/ci-and-repo-config.md
+@.claude/rules/dependencies.md
+@.claude/rules/binary-assets.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Claude Code rules for Sound-Clash
+
+## Git workflow
+
+- **Never commit, push, or work directly on `main`.** Create a branch first for every change, no matter how small.
+- **Push freely.** Pushing branches and force-pushing your own feature branches is fine without asking.
+- **Open PRs freely.** Use `gh pr create` without asking for permission.
+- **Never merge a PR.** Merging is the user's decision. Do not run `gh pr merge`, do not click "merge" via API, do not squash/rebase-merge from the CLI. Open the PR and stop.
+- **Never force-push to `main`** under any circumstance.
+- **Never delete branches** (local or remote) without explicit permission.
+- **Never modify `.github/workflows/`** (CI config) without flagging it first — CI changes affect everyone.
+- **Never close or comment on PRs/issues** the user didn't ask you to touch.
+
+## Commit messages
+
+- **One line maximum.** Subject only. No body, no bullets, no extra paragraphs.
+- **No AI attribution anywhere.** Do not add `Co-Authored-By: Claude ...` trailers. Do not write "Generated with Claude Code", "🤖", or similar in commit messages, PR titles, or PR bodies. The repo should look human-authored.
+- Pass commits inline: `git commit -m "short subject"`.
+
+## PR descriptions
+
+- The default `## Summary` + `## Test plan` template is fine.
+- No AI footer, no emoji that signals AI authorship.
+
+## Branch naming
+
+- Use `feature/<short-name>` for new features and `fix/<short-name>` for bug fixes. Keeps the branch list scannable.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for everything
+* @BenArtzi4
+
+# Critical-path files require explicit attention
+/db/migrations/      @BenArtzi4
+/backend/app/middleware/admin_auth.py  @BenArtzi4
+/.github/workflows/  @BenArtzi4
+/docs/security-rls.md @BenArtzi4
+/docs/realtime-design.md @BenArtzi4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to Sound Clash
+
+Thanks for your interest. This is a small project; the contribution bar is "is it correct, tested, and consistent with the docs."
+
+## Before you start
+
+1. Read [`docs/architecture.md`](docs/architecture.md) (one page).
+2. Skim [`docs/roadmap.md`](docs/roadmap.md) to know what phase the project is in.
+3. Check [open issues](https://github.com/BenArtzi4/Sound-Clash/issues) — pick one or open a new one to discuss before doing significant work.
+4. For substantive changes, open the issue first. Code without a discussed direction may be closed without merge.
+
+## Local setup
+
+See [`docs/local-development.md`](docs/local-development.md). TL;DR: `supabase start`, `pip install -e backend[dev]`, `npm install` in frontend.
+
+## Branching
+
+- Main branch: `main` (protected; PRs only).
+- Branch naming: `<type>/<short-desc>` where `<type>` is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`. Examples: `feat/team-kick-button`, `fix/buzzer-race-on-reconnect`.
+- Keep branches short-lived. Rebase rather than merge from `main` if your branch falls behind.
+
+## Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>(<scope>): <subject>`.
+- Examples:
+  - `feat(buzzer): add server-time skew correction`
+  - `fix(rls): tighten anon SELECT policy on game_teams`
+  - `docs(runbook): add Sentry alert thresholds`
+- Subject line < 72 chars. Imperative mood ("add", not "added").
+- Body explains *why*, not *what* (the diff shows what).
+
+## Pull requests
+
+1. Open against `main`.
+2. Fill in the PR template (auto-loaded from `.github/pull_request_template.md`).
+3. CI must be green: `backend.yml`, `frontend.yml`, and `e2e.yml` (if labeled `run-e2e`).
+4. At least one approval. Solo maintainer admin override is acceptable for trivial changes.
+5. Squash-merge by default. Merge commits only for substantial multi-commit features where individual commits matter.
+
+## Code style
+
+### Backend (Python)
+
+- **Formatter**: `ruff format`
+- **Linter**: `ruff check`
+- **Type checker**: `mypy app/`
+- **Tests**: `pytest`
+- All four must pass locally before pushing. Pre-commit hook enforces formatter + linter on commit.
+
+Conventions:
+- Type hints on all public functions.
+- No `print()` — use the `logging` module.
+- No catch-all `except Exception` unless you re-raise or log + re-raise.
+- Imports sorted by ruff (isort-compatible).
+- Module docstrings only when non-obvious.
+
+### Frontend (TypeScript)
+
+- **Formatter**: `prettier`
+- **Linter**: `eslint`
+- **Type check**: `tsc --noEmit`
+- **Tests**: `vitest run`
+
+Conventions:
+- Strict mode TypeScript; no `any` without a `// reason` comment.
+- Functional components + hooks; no class components.
+- Co-locate component tests next to the component (`Foo.tsx` + `Foo.test.tsx`).
+- No CSS-in-JS dependencies; use plain CSS modules.
+- No state management library (Redux, Zustand, etc.) — local React state and Supabase Realtime are sufficient.
+
+### SQL (migrations)
+
+- One purpose per migration file. Use the numeric prefix to enforce order.
+- All migrations idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, etc.
+- DDL changes that affect callers require a corresponding code change in the same PR.
+- `psql -f` must succeed against an empty Postgres 15 instance with `pg_cron` and `pgcrypto` extensions.
+
+## Testing requirements
+
+| Change | Required tests |
+|---|---|
+| New REST endpoint | `tests/backend/` — happy path + auth + at least one validation case |
+| New PL/pgSQL function | `tests/db/` — happy path + at least one error case |
+| New React component with logic | `tests/` co-located — at least one render + one interaction test |
+| Buzzer-related change | A relevant `tests/e2e/` Playwright scenario |
+| Migration | Re-run `db/migrate.sh` from a clean DB; commit only if successful |
+| Bug fix | A regression test that fails on `main` and passes on your branch |
+
+Coverage isn't gated, but PRs that *reduce* coverage will get a polite poke.
+
+## Documentation
+
+If your change touches anything covered by `docs/`, **update the doc in the same PR**. Out-of-date docs are worse than missing ones.
+
+Specifically:
+- New endpoint → update `docs/api-contracts.md`
+- New table or column → update `docs/data-model.md`
+- New PL/pgSQL function → update `docs/rpc-functions.md`
+- New env var or secret → update `docs/runbook.md` and `docs/local-development.md`
+- New gameplay rule → update `docs/game-rules.md`
+
+## What we don't merge
+
+- Changes that re-introduce dropped features (see `docs/data-model.md` §9 — `play_count`, `is_active`, AI selection cache, etc.) without a discussed plan.
+- Changes that put Python in the buzzer hot path. The `<200ms` requirement is structural; see `docs/realtime-design.md` §2.
+- Changes that increase free-tier consumption substantially without an alert or upgrade plan in `docs/free-tier-budget.md`.
+- "Cleanup" PRs that mix refactoring with feature work. Split them.
+- Code without tests when tests are the obvious medium for verification.
+- Generated code or AI-completed code that the author can't explain on review.
+
+## Reporting bugs
+
+Use the **Bug report** issue template. Include:
+- What you did
+- What happened
+- What you expected
+- Browser + OS (for frontend), Python version (for backend)
+- Logs / Sentry link if you have it
+
+## Reporting security issues
+
+**Don't open a public issue for security bugs.** Email the maintainer at `benartzi4@gmail.com` with `[SECURITY] Sound Clash` in the subject. We'll triage and disclose responsibly.
+
+## License
+
+By contributing, you agree your contribution is licensed under the MIT License (the project's license).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ben Artzi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# Sound Clash
+
+A real-time multiplayer music trivia game. Teams compete to identify songs by buzzing in fastest, with a manager-evaluated scoring system.
+
+[![CI](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/backend.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/backend.yml)
+[![Frontend](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml)
+[![Coverage](https://codecov.io/gh/BenArtzi4/Sound-Clash/branch/main/graph/badge.svg)](https://codecov.io/gh/BenArtzi4/Sound-Clash)
+
+## What is this?
+
+Sound Clash is a buzzer game played in groups. Three roles connect to a shared game code:
+
+- **Manager** — picks genres, advances rounds, judges answers
+- **Teams** (typically on phones) — race to buzz in when they recognize the song
+- **Display** — public scoreboard for the room ("TV screen")
+
+Each round, the manager plays a YouTube clip. Teams buzz; first wins the lock. The manager evaluates the team's verbal answer and awards points (title=10, artist=5, source=5). Game ends after N rounds; scoreboard is shown; data is auto-deleted after 4 hours.
+
+## Stack
+
+100% free-tier (excluding domain):
+
+- **Backend**: Python 3.11 + FastAPI on Render
+- **Database + Realtime + RPC**: Supabase (Postgres 15)
+- **Frontend**: React 18 + TypeScript + Vite on Cloudflare Pages
+- **CI/CD**: GitHub Actions
+- **Errors**: Sentry
+
+The architectural keystone: the buzzer is a Postgres PL/pgSQL function called directly from the browser via Supabase RPC, with row-change events fanned out to all clients via Supabase Realtime. Python is **not** in the buzzer hot path — this is what makes <200ms buzzer latency possible on free hosting. See [`docs/realtime-design.md`](docs/realtime-design.md).
+
+## Quick start
+
+```bash
+git clone https://github.com/BenArtzi4/Sound-Clash.git
+cd Sound-Clash
+
+# Start local Supabase (requires Docker)
+supabase start
+
+# Backend
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+uvicorn app.main:app --reload
+
+# Frontend (separate terminal)
+cd ../frontend
+npm install
+npm run dev
+```
+
+Open http://localhost:5173. Full setup details: [`docs/local-development.md`](docs/local-development.md).
+
+## Documentation
+
+| Doc | When to read |
+|---|---|
+| [`docs/architecture.md`](docs/architecture.md) | Start here — overview with links |
+| [`docs/realtime-design.md`](docs/realtime-design.md) | The central design decision |
+| [`docs/tech-stack.md`](docs/tech-stack.md) | Service-by-service rationale |
+| [`docs/game-rules.md`](docs/game-rules.md) | Gameplay flow + edge cases |
+| [`docs/data-model.md`](docs/data-model.md) | Schema |
+| [`docs/rpc-functions.md`](docs/rpc-functions.md) | The 5 PL/pgSQL functions |
+| [`docs/security-rls.md`](docs/security-rls.md) | Auth + threat model |
+| [`docs/api-contracts.md`](docs/api-contracts.md) | REST + Realtime contracts |
+| [`docs/free-tier-budget.md`](docs/free-tier-budget.md) | Capacity planning |
+| [`docs/local-development.md`](docs/local-development.md) | Dev setup |
+| [`docs/runbook.md`](docs/runbook.md) | Production ops |
+
+## Project status
+
+- [ ] Phase 1 — Infrastructure setup
+- [ ] Phase 2 — Data migration
+- [ ] Phase 3 — Postgres logic
+- [ ] Phase 4 — Backend port
+- [ ] Phase 5 — Realtime wiring & frontend port
+- [ ] Phase 6 — End-to-end testing
+- [ ] Phase 7 — Deploy & cutover
+
+Full plan: [`docs/roadmap.md`](docs/roadmap.md).
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). PRs welcome; issues for bugs and feature requests.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).
+
+## Predecessor
+
+The legacy AWS version is at https://github.com/BenArtzi4/Sound-Clash-legacy (archived).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please don't open a public GitHub issue for security bugs.**
+
+Email **benartzi4@gmail.com** with `[SECURITY] Sound Clash` in the subject. Include:
+
+- A description of the issue
+- Steps to reproduce
+- The version (commit SHA or tag) where you observed it
+- Your assessment of the impact
+
+I'll acknowledge within 7 days and provide a target fix timeline within 14 days. Researchers acting in good faith will be credited (or kept anonymous on request) once the issue is fixed.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| latest `main` | ✅ |
+| anything else | ❌ — fix forward in `main` |
+
+This is a small project; there are no LTS branches.
+
+## Threat model
+
+The system has a deliberately small attack surface (no PII, no payments, no user accounts, ephemeral data). The full threat model is in [`docs/security-rls.md`](docs/security-rls.md) §4. Headline concerns:
+
+- Service-role key leakage (the only true secret)
+- Game-code enumeration (low impact; a known limitation)
+- DoS on free-tier infrastructure
+- XSS via team-name input
+
+## What's NOT in scope
+
+- Vulnerabilities in third-party services we depend on (Supabase, Render, Cloudflare). Report those upstream.
+- Bugs that require physical access to the host's device.
+- Reports about missing best practices that don't lead to an exploit (e.g., "you should use header X"). Open an issue or PR for those.
+- Issues in the [legacy AWS repo](https://github.com/BenArtzi4/Sound-Clash-legacy). That codebase is archived and won't receive security fixes.
+
+## Disclosure policy
+
+Coordinated disclosure preferred. I'll work with the reporter on a public disclosure timeline once a fix is available, typically 30–90 days after the report.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Sound Clash backend — copy to backend/.env for local dev.
+SUPABASE_URL=http://localhost:54321
+SUPABASE_SERVICE_ROLE_KEY=
+ADMIN_PASSWORD=devpass123
+PORT=8000
+CORS_ORIGINS=http://localhost:5173
+LOG_LEVEL=DEBUG
+SENTRY_DSN=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,31 @@
+# Sound Clash backend — multi-stage Dockerfile (placeholder; fleshed out in Phase 4).
+# See docs/tech-stack.md and docs/local-development.md for context.
+
+# ---- builder ----
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY pyproject.toml ./
+COPY app ./app
+RUN pip install --no-cache-dir -e .
+
+# ---- runtime ----
+FROM python:3.11-slim AS runtime
+
+# Non-root user
+RUN useradd --create-home --shell /bin/bash app
+USER app
+WORKDIR /home/app
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8000
+
+EXPOSE 8000
+
+# Render sets PORT; uvicorn picks it up.
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+"""Sound Clash backend (FastAPI). See ../docs/architecture.md."""
+
+__version__ = "0.0.0"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+"""FastAPI app entry point.
+
+Phase 1 placeholder: only /health is implemented.
+Routers, middleware, and Sentry integration are added in Phase 4.
+See docs/api-contracts.md.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app import __version__
+
+app = FastAPI(title="Sound Clash API", version=__version__)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness probe."""
+    return {"status": "ok", "version": __version__}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,122 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sound-clash-backend"
+version = "0.0.0"
+description = "Sound Clash — FastAPI backend"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Ben Artzi", email = "benartzi4@gmail.com" }]
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "supabase>=2.9",
+    "pydantic>=2.9",
+    "python-multipart>=0.0.18",
+    "slowapi>=0.1.9",
+    "sentry-sdk[fastapi]>=2.18",
+    "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=6.0",
+    "httpx>=0.27",
+    "testcontainers[postgres]>=4.8",
+    "ruff>=0.7",
+    "mypy>=1.13",
+    "types-requests",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+testpaths = ["../tests/backend", "../tests/db"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "--tb=short",
+    "-p", "no:randomly",
+]
+asyncio_mode = "auto"
+markers = [
+    "slow: tests that take >1s; excluded from quick local runs",
+    "stress: stress tests (e.g., race tests run 100x); label-gated in CI",
+    "needs_docker: tests that require Docker (testcontainers)",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["app"]
+omit = [
+    "app/main.py",  # bootstrap; covered indirectly
+    "*/conftest.py",
+]
+
+[tool.coverage.report]
+# Phase 1 starts low; ratchet up at end of each phase per docs/testing-strategy.md §5
+fail_under = 0
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+    "S",   # flake8-bandit (security)
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific
+]
+ignore = [
+    "S101",  # assert in tests is fine (we use pytest)
+    "E501",  # line length handled by formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "S106"]  # asserts and hardcoded test passwords are fine
+"app/main.py" = ["S104"]  # 0.0.0.0 bind is intentional in containers
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+check_untyped_defs = true
+ignore_missing_imports = true  # supabase-py et al lack stubs
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false  # tests can be looser

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,52 @@
+# Database
+
+Postgres-as-code. Schema, RPC functions, RLS policies, and the pg_cron job all live here as ordered SQL migrations.
+
+**Phase 3 deliverable.** Empty in Phase 1.
+
+## Layout
+
+```
+db/
+├── README.md         (this file)
+├── migrate.sh        (applies migrations in order; used locally and in CI)
+├── migrations/       (numbered SQL files)
+│   ├── 001_extensions.sql
+│   ├── 002_durable_tables.sql
+│   ├── 003_ephemeral_tables.sql
+│   ├── 004_indexes.sql
+│   ├── 005_rpc_functions.sql
+│   ├── 006_rls_policies.sql
+│   ├── 007_cron_jobs.sql
+│   └── 008_seed_genres.sql
+└── seed/
+    └── (one-time seed data not tied to migrations)
+```
+
+## Authority
+
+Each migration is spec'd in the docs:
+
+| Migration | Spec |
+|---|---|
+| 002, 003, 004 | [`docs/data-model.md`](../docs/data-model.md) |
+| 005 | [`docs/rpc-functions.md`](../docs/rpc-functions.md) |
+| 006 | [`docs/security-rls.md`](../docs/security-rls.md) |
+
+If you change a migration, update the corresponding doc in the same PR.
+
+## Idempotency
+
+All migrations must be **idempotent** — running them twice on the same DB must be a no-op. Use `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. CI verifies this by running migrations twice.
+
+## Running
+
+```bash
+# Local
+./db/migrate.sh "postgres://postgres:postgres@localhost:54322/postgres"
+
+# Preview / prod (via GitHub Actions)
+# Use the `db-migrate.yml` workflow with manual dispatch + confirmation.
+```
+
+See [`docs/runbook.md`](../docs/runbook.md) §1.3 for the deploy-with-migration playbook.

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Apply all migrations in db/migrations/ to a Postgres database, in order.
+#
+# Usage:
+#   ./db/migrate.sh "postgres://user:pass@host:port/db"
+#
+# Phase 1 placeholder: the migrations/ directory is empty until Phase 3.
+# This script intentionally exits 0 if no migrations exist yet, so CI passes.
+
+set -euo pipefail
+
+DATABASE_URL="${1:-${DATABASE_URL:-}}"
+
+if [[ -z "$DATABASE_URL" ]]; then
+  echo "Usage: $0 <DATABASE_URL>" >&2
+  echo "Or set DATABASE_URL env var." >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="$SCRIPT_DIR/migrations"
+
+shopt -s nullglob
+migrations=("$MIGRATIONS_DIR"/*.sql)
+
+if [[ ${#migrations[@]} -eq 0 ]]; then
+  echo "No migrations found in $MIGRATIONS_DIR (Phase 3 will add them)."
+  exit 0
+fi
+
+# Sort to enforce numeric prefix ordering (BSD/GNU sort compatible).
+IFS=$'\n' sorted=($(LC_ALL=C sort <<<"${migrations[*]}"))
+unset IFS
+
+echo "Applying ${#sorted[@]} migration(s) to target..."
+for f in "${sorted[@]}"; do
+  echo "→ $(basename "$f")"
+  psql --set ON_ERROR_STOP=1 --quiet "$DATABASE_URL" -f "$f"
+done
+
+echo "✓ Migrations applied."

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,97 @@
+# Sound Clash — Documentation
+
+Design and operational documentation for Sound Clash. Each file has a single, distinct purpose; cross-references use bare filenames so links work on GitHub, in an IDE, or as plain Markdown.
+
+## Read in this order
+
+1. **[architecture.md](architecture.md)** — executive summary; one-page overview with links to depth.
+2. **[realtime-design.md](realtime-design.md)** — THE central design decision: why no Python in the buzzer path; how <200ms is achieved on free hosting.
+3. **[tech-stack.md](tech-stack.md)** — the concrete services (Supabase, Render, Cloudflare Pages, …) with free-tier limits and alternatives considered.
+4. **[game-rules.md](game-rules.md)** — gameplay flow, state machine, scoring, edge cases. Read this first if you don't know what Sound Clash is.
+5. **[data-model.md](data-model.md)** — schema, indexes, ER diagram.
+6. **[rpc-functions.md](rpc-functions.md)** — the five PL/pgSQL functions that hold the system's logic.
+7. **[security-rls.md](security-rls.md)** — auth model, RLS policies, threat model, rate limits, CSP.
+8. **[api-contracts.md](api-contracts.md)** — REST + Realtime wire-format contracts.
+9. **[testing-strategy.md](testing-strategy.md)** — test types, coverage gates, CI enforcement; the doc CI gates against.
+10. **[free-tier-budget.md](free-tier-budget.md)** — quota analysis; how many games/month before any service runs out.
+11. **[local-development.md](local-development.md)** — how to run the stack on your laptop.
+12. **[runbook.md](runbook.md)** — day-2+ operations: deploy, rollback, secrets, incidents.
+13. **[roadmap.md](roadmap.md)** — eight-phase migration plan with exit criteria.
+14. **[tasks.md](tasks.md)** — granular checkboxed task list grouped by area.
+15. **[aws-teardown-checklist.md](aws-teardown-checklist.md)** — step-by-step Phase 7 cutover script for tearing down the legacy AWS stack.
+
+## Suggested reading paths
+
+### "I'm reviewing the design"
+1. `architecture.md` (overview + links)
+2. `realtime-design.md` (validate the central trick)
+3. `security-rls.md` (audit the auth model)
+4. `free-tier-budget.md` (sanity-check capacity claims)
+
+### "I'm about to start implementing"
+1. `architecture.md`
+2. `roadmap.md` (find your phase)
+3. `local-development.md` (set up dev env)
+4. `tasks.md` (find your tickets)
+5. Open the doc each task links to (`rpc-functions.md`, `api-contracts.md`, etc.) as you go.
+
+### "I just need to know how to run it locally"
+1. `local-development.md` only.
+
+### "I need to operate it in production"
+1. `runbook.md`
+2. `free-tier-budget.md` (alert thresholds)
+3. `security-rls.md` §3 (secret inventory) and §10 (auth failures)
+
+### "I'm doing the AWS cutover"
+1. `aws-teardown-checklist.md` (top to bottom)
+2. `runbook.md` §2.4 (DNS rollback if needed)
+
+### "I want to know what's NOT in scope"
+- `architecture.md` §10 — pointer index of what each doc doesn't cover
+- `roadmap.md` "Out of Scope" section
+- `game-rules.md` §13 (NOT a game rule)
+- Each doc has a "doesn't cover" or "out of scope" section near the end
+
+## Conventions
+
+- **Bold service names** (`**Render**`, `**Supabase**`) for first reference.
+- ``code`` formatting for file paths, env vars, function names, and SQL identifiers.
+- Latency budgets always given as ranges with explicit units (ms).
+- Free-tier limits cited inline with the alert threshold from `free-tier-budget.md`.
+- Cross-links use bare filenames so docs work on GitHub, in an IDE, or as plain Markdown.
+
+## Updating these docs
+
+These docs ARE the spec. If you change behavior in code that contradicts a doc, **update the doc in the same PR**. CONTRIBUTING.md enforces this:
+
+| Code change | Doc to update |
+|---|---|
+| New REST endpoint | `api-contracts.md` |
+| New table or column | `data-model.md` |
+| New PL/pgSQL function | `rpc-functions.md` |
+| New env var or secret | `runbook.md`, `local-development.md` |
+| New gameplay rule | `game-rules.md` |
+
+Out-of-date docs are worse than missing ones.
+
+## File summary
+
+| File | Purpose |
+|---|---|
+| `README.md` (this file) | Index and reading guide |
+| `architecture.md` | Executive summary + links |
+| `realtime-design.md` | Buzzer hot-path, race correctness, failure modes |
+| `tech-stack.md` | Service list with free-tier limits |
+| `game-rules.md` | Gameplay, state machine, edge cases |
+| `data-model.md` | Schema + indexes + ER |
+| `rpc-functions.md` | The 5 PL/pgSQL functions |
+| `security-rls.md` | RLS, threat model, rate limits, CSP |
+| `api-contracts.md` | REST + Realtime contracts |
+| `testing-strategy.md` | Test categories + CI gates |
+| `free-tier-budget.md` | Quota analysis + alert thresholds |
+| `local-development.md` | Dev setup + troubleshooting |
+| `runbook.md` | Operational procedures |
+| `roadmap.md` | 8-phase migration plan |
+| `tasks.md` | Granular task checklist |
+| `aws-teardown-checklist.md` | Phase 7 step-by-step cutover script |

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -1,0 +1,404 @@
+# Sound Clash — API Contracts
+
+This is the wire-format contract between the frontend and the backend (FastAPI on Render + Supabase). It is the document the frontend codes against and the backend implements. Drift between this doc and reality is a bug.
+
+## 1. Overview
+
+Three categories of API:
+
+| Category | Transport | Endpoint | Authn |
+|---|---|---|---|
+| **REST (FastAPI)** | HTTPS | `https://api.soundclash.org` | Optional `X-Admin-Password` header for admin/manager ops |
+| **Postgres RPC (PostgREST)** | HTTPS | `https://<project>.supabase.co/rest/v1/rpc/<fn>` | Supabase **anon key** in `apikey` + `Authorization` headers |
+| **Realtime (Supabase)** | WebSocket | `wss://<project>.supabase.co/realtime/v1` | Supabase **anon key** |
+
+All payloads are JSON. All timestamps are ISO 8601 UTC with `Z` suffix (e.g., `2026-05-03T14:23:01.234Z`).
+
+All responses include the conventional fields:
+- Success: HTTP 2xx + body specified per endpoint.
+- Error: HTTP 4xx/5xx + `{ "error": "<machine_code>", "message": "<human readable>", "details": <optional> }`.
+
+Canonical error codes: `validation_error`, `unauthorized`, `forbidden`, `not_found`, `conflict`, `gone`, `rate_limited`, `internal_error`.
+
+---
+
+## 2. REST Endpoints (FastAPI)
+
+### 2.1 `GET /health`
+
+Liveness probe. No auth.
+
+**Response 200**:
+```json
+{ "status": "ok", "version": "<git_sha>", "supabase": "ok" }
+```
+
+`supabase` is `"ok"` if the server can reach Supabase, `"degraded"` otherwise (still 200 — the server is up).
+
+---
+
+### 2.2 `POST /games`
+
+Create a new game. **Admin auth required.**
+
+**Headers**: `X-Admin-Password: <password>`
+
+**Request body**:
+```json
+{
+  "total_rounds": 10,
+  "selected_genres": ["<genre_uuid>", "..."]
+}
+```
+
+Validation:
+- `total_rounds`: integer, 1–50 (default 10 if omitted)
+- `selected_genres`: at least 1 genre UUID
+
+**Response 201**:
+```json
+{
+  "game_code": "ABCDEF",
+  "status": "waiting",
+  "total_rounds": 10,
+  "selected_genres": ["..."],
+  "started_at": "2026-05-03T14:23:01.234Z",
+  "expires_at": "2026-05-03T18:23:01.234Z"
+}
+```
+
+Game-code generation: 6 chars from `ABCDEFGHJKMNPQRSTUVWXYZ23456789` (no 0/O, 1/I/L, no lowercase). On collision (UNIQUE violation), retry up to 5 times then 500.
+
+**Errors**: `validation_error` (400), `unauthorized` (401).
+
+---
+
+### 2.3 `POST /games/{game_code}/teams`
+
+Team joins a game. **No auth.** Anyone with the game code can call this.
+
+**Request body**:
+```json
+{ "name": "Team Awesome" }
+```
+
+Validation:
+- `name`: 1–30 chars, trimmed; no leading/trailing whitespace; uniqueness within the game enforced by UNIQUE constraint.
+
+**Response 201**:
+```json
+{
+  "id": "<team_uuid>",
+  "game_code": "ABCDEF",
+  "name": "Team Awesome",
+  "score": 0,
+  "joined_at": "2026-05-03T14:25:11.000Z"
+}
+```
+
+The frontend stores `id` in `localStorage` keyed by `game_code` for reconnection.
+
+**Errors**: `validation_error` (400 — bad name), `not_found` (404 — game doesn't exist), `gone` (410 — game expired or ended), `conflict` (409 — name already taken).
+
+---
+
+### 2.4 `POST /games/{game_code}/select-song`
+
+Manager: pick the next song (random within `selected_genres`, excluding songs already played in this game) and start the round. **Admin auth required.**
+
+**Headers**: `X-Admin-Password: <password>`
+
+**Request body**: `{}` (reserved; future may include `song_id` for manual pick)
+
+**Response 200**:
+```json
+{
+  "round_id": "<round_uuid>",
+  "round_number": 3,
+  "song": {
+    "id": "<song_uuid>",
+    "title": "Song Title",
+    "artist": "Artist Name",
+    "youtube_id": "dQw4w9WgXcQ",
+    "start_time": 30,
+    "is_soundtrack": false,
+    "source": null
+  }
+}
+```
+
+Server-side: calls Postgres `start_round(p_game_code, p_song_id)` RPC. Returns the new round id.
+
+**Errors**: `not_found` (404), `gone` (410), `conflict` (409 — game not in `playing` state, or all songs in selected genres exhausted).
+
+---
+
+### 2.5 `POST /games/{game_code}/award-points`
+
+Manager: evaluate the buzzed team's answer and award points. **Admin auth required.**
+
+**Headers**: `X-Admin-Password: <password>`
+
+**Request body**:
+```json
+{
+  "round_id": "<round_uuid>",
+  "title_correct": true,
+  "artist_correct": true,
+  "source_correct": false,
+  "timeout": false
+}
+```
+
+Server translates to point values:
+- `title_correct: true` → +10
+- `artist_correct: true` → +5
+- `source_correct: true` → +5 (only valid if the song `is_soundtrack`)
+- `timeout: true` → −2 timeout penalty (only valid if `buzzed_team_id IS NULL`); if true, the other booleans are ignored.
+
+**Response 200**:
+```json
+{
+  "round_id": "<round_uuid>",
+  "team_id": "<team_uuid_or_null>",
+  "points_awarded": 15,
+  "team_total_score": 35
+}
+```
+
+Server-side: calls Postgres `award_points` RPC.
+
+**Errors**: `not_found` (404), `validation_error` (400 — source_correct on non-soundtrack song; multiple non-mutually-exclusive flags).
+
+---
+
+### 2.6 `POST /games/{game_code}/end`
+
+Manager: end the game manually. **Admin auth required.**
+
+**Response 200**:
+```json
+{
+  "game_code": "ABCDEF",
+  "status": "ended",
+  "ended_at": "2026-05-03T15:48:00.000Z"
+}
+```
+
+**Errors**: `not_found` (404), `conflict` (409 — already ended).
+
+---
+
+### 2.7 `DELETE /games/{game_code}/teams/{team_id}`
+
+Manager: kick a team. **Admin auth required.**
+
+**Response 204** (no body).
+
+Cascade: any future actions by the kicked team are rejected because their row is gone. Their browser detects the Realtime DELETE event and redirects to a "you've been kicked" screen.
+
+**Errors**: `not_found` (404).
+
+---
+
+### 2.8 `GET /genres`
+
+Public. List all genres.
+
+**Response 200**:
+```json
+[
+  { "id": "<uuid>", "name": "Rock", "slug": "rock" },
+  { "id": "<uuid>", "name": "Pop",  "slug": "pop"  }
+]
+```
+
+---
+
+### 2.9 Admin Songs CRUD
+
+All under `/admin/songs/*`. **Admin auth required** on every endpoint.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET`    | `/admin/songs` | List songs (paginated, `?page=1&per_page=50&search=&genre=`) |
+| `GET`    | `/admin/songs/{id}` | Get one song |
+| `POST`   | `/admin/songs` | Create a song (body: `title, artist, youtube_id, start_time, is_soundtrack, source, genre_ids[]`) |
+| `PUT`    | `/admin/songs/{id}` | Update a song (full replacement; partial use PATCH if needed later) |
+| `DELETE` | `/admin/songs/{id}` | Delete a song (cascades to `song_genres`) |
+| `POST`   | `/admin/songs/bulk-import` | Multipart CSV upload; columns: `title, artist, youtube_id, start_time, is_soundtrack, source, genres` (semicolon-separated genre slugs) |
+
+Bulk import is idempotent on `youtube_id`: existing songs are updated, new ones are inserted.
+
+---
+
+## 3. Postgres RPC (PostgREST)
+
+Called by the **browser** with the anon key. Only one function is exposed to anon: `buzz_in`.
+
+### 3.1 `POST /rest/v1/rpc/buzz_in`
+
+**Headers**:
+- `apikey: <SUPABASE_ANON_KEY>`
+- `Authorization: Bearer <SUPABASE_ANON_KEY>`
+- `Content-Type: application/json`
+
+**Body**:
+```json
+{ "p_game_code": "ABCDEF", "p_team_id": "<team_uuid>" }
+```
+
+**Response 200** (single-row return; PostgREST returns an array):
+```json
+[
+  { "locked": true, "locked_team_id": "<team_uuid>", "locked_at": "2026-05-03T14:30:12.123Z" }
+]
+```
+
+- `locked: true` → this caller won the lock.
+- `locked: false` → the lock was already held; `locked_team_id` is whoever holds it.
+
+This call must complete in <100ms (RTT to Supabase). Fan-out to other clients via Realtime takes another ~50–100ms.
+
+**Errors**: PostgREST returns 4xx with `code`, `message`, `hint`. Treat anything non-200 as "buzz failed; refresh state from Realtime."
+
+---
+
+## 4. Supabase Realtime (Subscriptions)
+
+The frontend uses `@supabase/supabase-js`'s `channel()` API to subscribe to row-level changes. Three subscriptions per game.
+
+### 4.1 Channel: `game:{game_code}`
+
+Subscribes to row changes on three tables, filtered by `game_code`:
+
+```ts
+supabase
+  .channel(`game:${gameCode}`)
+  .on('postgres_changes', {
+    event: '*',
+    schema: 'public',
+    table: 'active_games',
+    filter: `game_code=eq.${gameCode}`
+  }, handleGameChange)
+  .on('postgres_changes', {
+    event: '*',
+    schema: 'public',
+    table: 'game_teams',
+    filter: `game_code=eq.${gameCode}`
+  }, handleTeamChange)
+  .on('postgres_changes', {
+    event: '*',
+    schema: 'public',
+    table: 'game_rounds',
+    filter: `game_code=eq.${gameCode}`
+  }, handleRoundChange)
+  .subscribe();
+```
+
+### 4.2 Event payloads
+
+Each `postgres_changes` callback receives:
+```ts
+{
+  schema: 'public',
+  table: 'active_games' | 'game_teams' | 'game_rounds',
+  commit_timestamp: string,
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE',
+  new: <row | {}>,    // present on INSERT and UPDATE
+  old: <row | {}>,    // present on UPDATE and DELETE (only PK by default)
+  errors: null | string[]
+}
+```
+
+The frontend maintains derived state:
+- **Game state**: latest `active_games` row.
+- **Teams**: full team list, updated on INSERT/UPDATE/DELETE.
+- **Current round**: the `game_rounds` row whose id matches `active_games.current_round_id`.
+
+### 4.3 Buzz lock event (specifically)
+
+When a team buzzes:
+1. `buzz_in` UPDATEs `active_games` setting `buzzed_team_id` and `locked_at`.
+2. Realtime fires `postgres_changes` on `active_games` with `eventType: 'UPDATE'` and the new row.
+3. All subscribed clients see `new.buzzed_team_id` go non-null and update their UI.
+
+There is no separate "buzzer_locked" event type. The data model IS the event stream.
+
+### 4.4 Reconnection
+
+`supabase-js` auto-reconnects with exponential backoff. On reconnect, it re-fetches the current state via the channel. The frontend should re-fetch the latest `active_games` row via `select()` after `subscribe()` to handle missed events during the disconnect.
+
+```ts
+channel.subscribe(async (status) => {
+  if (status === 'SUBSCRIBED') {
+    const { data } = await supabase
+      .from('active_games')
+      .select('*, game_teams(*), game_rounds(*)')
+      .eq('game_code', gameCode)
+      .single();
+    setGameState(data);
+  }
+});
+```
+
+### 4.5 Quotas
+
+Free tier: 200 concurrent peers, 2M messages/month, 100 channels per client. See `free-tier-budget.md` for capacity analysis.
+
+---
+
+## 5. Headers and CORS
+
+### CORS
+
+FastAPI allows: `https://soundclash.org`, `https://www.soundclash.org`, and (in dev) `http://localhost:5173`.
+
+Methods: `GET, POST, PUT, DELETE, OPTIONS`. Headers: `Content-Type, X-Admin-Password`.
+
+### Cache-Control
+
+- `GET /genres`: `public, max-age=600` (genres rarely change)
+- All game-state endpoints: `no-store` (game state is live)
+- `GET /admin/songs`: `private, no-cache`
+
+### Versioning
+
+The API is unversioned at MVP. Breaking changes will introduce `/v2/` prefix. The frontend pins a known-good API SHA in `VITE_API_VERSION` for diagnostics.
+
+---
+
+## 6. Rate Limits (server-side)
+
+FastAPI uses `slowapi` (Redis-free, in-memory):
+
+| Endpoint | Limit | Reason |
+|---|---|---|
+| `POST /games` | 10 / minute / IP | Prevent game-code spam |
+| `POST /games/*/teams` | 30 / minute / IP | Prevent team-spam DoS |
+| `POST /admin/songs/bulk-import` | 5 / minute / IP | Heavy operation |
+| All admin endpoints | 100 / minute / IP | Conservative cap |
+
+`buzz_in` RPC is not rate-limited at the API layer (Postgres handles concurrency safely). Future: add Postgres-side rate limit if abuse seen.
+
+---
+
+## 7. Idempotency
+
+- `POST /games`: not idempotent (each call creates a new game). Frontend must not retry on network error without user confirmation.
+- `POST /games/{code}/teams`: idempotent on `(game_code, name)` — UNIQUE constraint catches retries.
+- `POST /games/{code}/select-song`: not idempotent — each call advances the round number. Frontend must not retry without user confirmation.
+- `POST /games/{code}/award-points`: idempotent on `round_id` — server checks `game_rounds.ended_at IS NULL` before applying points.
+- `POST /games/{code}/end`: idempotent — calling on an already-`ended` game is a 409 (conflict), not a no-op, to surface the inconsistency to the manager UI.
+- `buzz_in` RPC: implicitly idempotent (the `IS NULL` predicate prevents double-claim).
+
+---
+
+## 8. Out of Scope (for MVP)
+
+- Pagination cursor for `/admin/songs` (offset pagination only)
+- WebHooks
+- API key for third parties
+- Public songs API
+- OpenAPI / Swagger UI (will be auto-generated by FastAPI but not formally maintained)
+- gRPC, GraphQL

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,143 @@
+# Sound Clash — Architecture Overview
+
+This is the executive summary of the system. It points to the deeper docs rather than restating them.
+
+- For the central design decision (no-Python-in-the-buzzer-path), see **`realtime-design.md`**.
+- For the concrete service choices and free-tier limits, see **`tech-stack.md`**.
+- For schema and RPC functions, see **`data-model.md`** and **`rpc-functions.md`**.
+- For security model and RLS, see **`security-rls.md`**.
+- For game rules and edge cases, see **`game-rules.md`**.
+- For wire-level API contracts, see **`api-contracts.md`**.
+- For operational procedures, see **`runbook.md`**.
+- For local dev, see **`local-development.md`**.
+- For free-tier capacity planning, see **`free-tier-budget.md`**.
+
+## 1. Goals
+
+- **100% free tier** (excluding the `soundclash.org` domain).
+- **Python primary** for backend (FastAPI).
+- **< 200ms buzzer latency** end-to-end.
+- **Ephemeral game data** — auto-deleted 4 hours after game start.
+- **Professional standards** — automated tests, CI/CD, clear service boundaries.
+
+## 2. The System in One Diagram
+
+```
+                        ┌──────────────────────────────────┐
+                        │        soundclash.org            │
+                        │     (Cloudflare Pages CDN)       │
+                        │  React + TS + Vite SPA           │
+                        │  Roles: team / manager / display │
+                        └─────┬─────────────────┬──────────┘
+                              │                 │
+                 (anon key,   │                 │  (admin password,
+                  RLS-gated)  │                 │   for song CRUD &
+                              │                 │   game creation)
+                              ▼                 ▼
+┌─────────────────────────────────────┐   ┌────────────────────────┐
+│           Supabase                  │   │   FastAPI on Render    │
+│  ┌───────────────────────────────┐  │   │       (free tier)      │
+│  │ Postgres 15                   │  │   │                        │
+│  │  • tables (songs, games...)   │◄─┼───┤  POST /games           │
+│  │  • PL/pgSQL RPC (buzz_in...)  │  │   │  POST /games/.../song  │
+│  │  • RLS policies               │  │   │  CRUD /admin/songs     │
+│  │  • pg_cron 4h cleanup         │  │   │                        │
+│  └──────────────┬────────────────┘  │   │   uses service-role    │
+│                 │ logical repl.     │   │   key (server-only)    │
+│                 ▼                   │   └────────────────────────┘
+│  ┌───────────────────────────────┐  │
+│  │ Realtime broadcast            │  │
+│  │ (row UPDATEs → subscribers)   │──┼──→ all browser clients
+│  └───────────────────────────────┘  │   via WebSocket
+│  ┌───────────────────────────────┐  │
+│  │ PostgREST                     │◄─┼─── browser RPC
+│  │ /rest/v1/rpc/buzz_in          │  │    (the <200ms path)
+│  └───────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
+Three browser roles (team / manager / display) connect to:
+- **Supabase** — for live game state (Realtime subscriptions) and the buzzer (PostgREST RPC). The browser uses the **anon key**; RLS gates what's allowed.
+- **FastAPI on Render** — for game creation, song selection, admin endpoints. Authenticated by an admin-password header. FastAPI uses the **service-role key** server-side.
+
+The system has two networking paths but one source of truth (Postgres). Everything either reads from or writes to the Supabase database.
+
+## 3. The Central Architectural Insight
+
+A **<200ms buzzer** + **free Python hosting** is impossible if Python sits in the buzzer path (cold starts of 2–30s).
+
+**Resolution**: take Python out of the buzzer path. The buzzer is a Postgres PL/pgSQL function (`buzz_in`) that browsers call directly via PostgREST RPC. Postgres does the atomic conditional UPDATE. Realtime fans out the result. Python (Render) keeps only the cold-start-tolerant operations.
+
+Latency budget: ~80–180ms total, comfortably inside 200ms. Full walkthrough in **`realtime-design.md`**.
+
+## 4. Component Responsibilities
+
+| Component | Responsibility | Why here |
+|---|---|---|
+| Browser (React) | UI, Realtime subscriptions, direct RPC for buzzing | Only place clients run |
+| Supabase Postgres | Storage, atomic state transitions (RPC functions), 4h TTL via pg_cron | Authoritative state |
+| Supabase Realtime | Broadcast row changes to all browser subscribers | Native; no Python needed |
+| Supabase PostgREST | HTTP entry to RPC functions (used by browser for `buzz_in`) | Always-on, no cold starts |
+| FastAPI on Render | Game creation, song selection logic, admin/song CRUD | Cold-start tolerant; needs Python for app logic |
+| Cloudflare Pages | Frontend static hosting, CDN | Unlimited bandwidth |
+
+## 5. Auth Model (summary)
+
+Two principals:
+
+- **Anonymous teams** — Supabase anon key in the browser; RLS allows SELECT on game-scoped tables and EXECUTE on `buzz_in` RPC. Nothing else.
+- **Admin (host)** — env-var password compared in FastAPI middleware; FastAPI uses the service-role key (which bypasses RLS) to write game state.
+
+No user accounts, no JWTs, no password hashing. Matches today's behavior. Full details and threat model in **`security-rls.md`**.
+
+## 6. Ephemerality
+
+- `active_games.expires_at` = `started_at + interval '4 hours'` (fixed).
+- pg_cron sweeps hourly: `DELETE FROM active_games WHERE expires_at < now()`.
+- Cascades to `game_teams` and `game_rounds`.
+- `songs`, `genres`, `song_genres` are durable.
+
+Mid-game truncation (>4h sessions) is an accepted limitation.
+
+## 7. YouTube-Only Audio
+
+The catalog stores only `youtube_id` and `start_time`. The browser embeds the YouTube IFrame Player. No object storage involved. This eliminates an entire infrastructure concern (no R2, no Uploadcare, no S3).
+
+## 8. Trade-offs Accepted
+
+| Trade-off | Why we accept it |
+|---|---|
+| 30s cold start on Render after idle | Only affects game creation, not gameplay; mitigated by 14-min keepalive ping |
+| Single-region Postgres | Free tier limitation; pick region matching primary user geography |
+| No game history persistence | By user choice; matches today's on-demand mode |
+| Single-tenant admin password | Matches today's behavior; Supabase Auth is the multi-tenant escape hatch |
+| 200 concurrent Realtime peers | Comfortable for 1–10 parallel games; Pro tier gives 500 if needed |
+| 4h fixed TTL truncates marathons | Accepted; future "sliding TTL" is a low-priority enhancement |
+
+## 9. Scale-Out Path
+
+If free tier is outgrown, the design upgrades cleanly without architecture changes:
+
+1. **Supabase Pro** ($25/mo) — first upgrade; raises Realtime peers, DB size, adds PITR.
+2. **Render Starter** ($7/mo) — eliminates idle sleep; useful for tournament days.
+3. **Migrate FastAPI to Fly.io machines** — multi-region if user base globalizes.
+4. **Sentry Team** ($26/mo) — if error volume grows past 5k/mo.
+
+Total possible spend if everything is upgraded: ~$58/mo. Still cheap relative to the ~$1,260/yr always-on AWS baseline.
+
+## 10. What This Document Doesn't Cover
+
+- Concrete service URLs, free-tier limits, alternatives considered → **`tech-stack.md`**
+- Buzzer flow, race correctness, latency budget → **`realtime-design.md`**
+- Schema, indexes, ER → **`data-model.md`**
+- PL/pgSQL function bodies → **`rpc-functions.md`**
+- Auth mechanics, RLS policies, threat model → **`security-rls.md`**
+- Gameplay rules and state machine → **`game-rules.md`**
+- HTTP and Realtime contracts → **`api-contracts.md`**
+- Day-to-day ops → **`runbook.md`**
+- Local dev setup → **`local-development.md`**
+- Capacity planning → **`free-tier-budget.md`**
+- Phased migration plan → **`roadmap.md`**
+- Granular task list → **`tasks.md`**
+
+This file is the entry point. Read it first; follow the links for depth.

--- a/docs/aws-teardown-checklist.md
+++ b/docs/aws-teardown-checklist.md
@@ -1,0 +1,188 @@
+# AWS Teardown Checklist (Phase 7)
+
+The exact, ordered list of AWS resources to destroy after the new Supabase/Render/Pages stack is live and stable. Follow top-to-bottom. Each item has a verification step — don't move on without confirming.
+
+**Pre-conditions** (must all be true before starting):
+- [ ] New `Sound-Clash` deployed at `https://soundclash.org` and `https://api.soundclash.org`
+- [ ] Smoke test passing: a real game session was played end-to-end on the new stack
+- [ ] At least 24 hours of green metrics on the new stack
+- [ ] All songs verified in Supabase (`SELECT count(*) FROM songs` matches legacy count)
+- [ ] DNS already cut over (apex `soundclash.org` points at Cloudflare Pages, not CloudFront)
+
+**Estimated total time**: 60–90 minutes (CloudFront disable alone is ~15 min).
+
+**Estimated cost saved**: ~$1–2/month at idle, ~$15/month if the legacy on-demand stack was being run; up to $105/month if always-on was reactivated.
+
+---
+
+## Step 0 — Snapshot before destroying
+
+- [ ] Export legacy songs CSV one last time as a belt-and-suspenders backup:
+  ```bash
+  aws s3 cp s3://soundclash-songs-data/songs.csv ./backups/songs-$(date +%Y%m%d).csv
+  ```
+  Store this file outside AWS (e.g., in a private GitHub gist or the planning directory). After teardown, the S3 bucket is gone — this is your last copy from AWS.
+- [ ] Note current AWS bill ($/month) for comparison: AWS Console → Billing → "Bills".
+
+## Step 1 — Destroy Fargate + ALB stacks (legacy on-demand)
+
+These are cheap to recreate but have ongoing cost while up. Tear down first.
+
+- [ ] In `Sound-Clash-legacy/scripts/ondemand/`:
+  ```bash
+  ./destroy-all.sh
+  ```
+  This invokes `cdk destroy` on the on-demand ALB and Fargate stacks. Takes ~8–10 min.
+- [ ] **Verify**: AWS Console → ECS → Clusters — the `ondemand` cluster either gone or shows no running tasks.
+- [ ] **Verify**: AWS Console → EC2 → Load Balancers — no on-demand ALB present.
+
+## Step 2 — Destroy any remaining always-on stacks
+
+If the always-on `infrastructure/` stack was ever deployed (it may not have been used recently), destroy it now.
+
+- [ ] In `Sound-Clash-legacy/infrastructure/`:
+  ```bash
+  cdk list                 # see what's deployed
+  cdk destroy --all        # destroy what's there; will prompt
+  ```
+- [ ] **Verify**: `cdk list` after destroy shows no deployed stacks.
+- [ ] **Verify**: AWS Console → CloudFormation → Stacks — no `Sound-Clash-*` stacks remaining.
+
+## Step 3 — Empty + delete S3 buckets
+
+CDK won't delete S3 buckets that contain objects. Empty them first.
+
+- [ ] List buckets to confirm targets:
+  ```bash
+  aws s3 ls | grep -E '(ondemand-frontend|soundclash-songs-data|soundclash-)'
+  ```
+- [ ] Empty + delete the on-demand frontend bucket:
+  ```bash
+  aws s3 rm s3://ondemand-frontend-381492257993-us-east-1 --recursive
+  aws s3 rb s3://ondemand-frontend-381492257993-us-east-1
+  ```
+- [ ] Empty + delete the songs CSV bucket (you already saved a local copy in Step 0):
+  ```bash
+  aws s3 rm s3://soundclash-songs-data --recursive
+  aws s3 rb s3://soundclash-songs-data
+  ```
+- [ ] Check for any other `soundclash-*` buckets (deploy logs, CloudFront access logs, CDK staging buckets):
+  ```bash
+  aws s3 ls | grep -i soundclash
+  ```
+  Empty + delete any that come up.
+- [ ] **Verify**: `aws s3 ls | grep -i soundclash` returns nothing.
+
+## Step 4 — Disable + delete CloudFront distribution
+
+This is the slow one. CloudFront takes ~15 min to fully disable before it can be deleted.
+
+- [ ] Identify the distribution:
+  ```bash
+  aws cloudfront list-distributions --query 'DistributionList.Items[?contains(Aliases.Items[0], `soundclash`)].{Id:Id,Status:Status,Aliases:Aliases.Items[0]}'
+  ```
+  Expected ID: `E2NIDUY011R5N4` (verify before destroying).
+- [ ] Disable it (Console is easier than CLI here):
+  AWS Console → CloudFront → select the distribution → "Disable" → confirm.
+- [ ] Wait ~15 minutes. The status moves from `InProgress` to `Deployed` (still disabled).
+- [ ] Delete it: AWS Console → CloudFront → select distribution → "Delete".
+- [ ] **Verify**: `aws cloudfront list-distributions` no longer shows a distribution for `soundclash.org`.
+
+## Step 5 — Delete ECR repositories
+
+Container image registry — small but not zero cost when you have many images.
+
+- [ ] List the legacy repos:
+  ```bash
+  aws ecr describe-repositories --query 'repositories[?contains(repositoryName, `ondemand`) || contains(repositoryName, `soundclash`)].repositoryName'
+  ```
+- [ ] Delete each (the `--force` flag deletes the repo even with images present):
+  ```bash
+  aws ecr delete-repository --repository-name ondemand/game-management   --force
+  aws ecr delete-repository --repository-name ondemand/song-management   --force
+  aws ecr delete-repository --repository-name ondemand/websocket-service --force
+  ```
+- [ ] **Verify**: `aws ecr describe-repositories` shows no `ondemand/*` or `soundclash*` repos.
+
+## Step 6 — Delete ACM certificates
+
+- [ ] List wildcard cert(s) for the domain:
+  ```bash
+  aws acm list-certificates --region us-east-1 \
+    --query 'CertificateSummaryList[?contains(DomainName, `soundclash.org`)].{Arn:CertificateArn,Domain:DomainName}'
+  ```
+  Note: ACM certs used by CloudFront must be in `us-east-1`.
+- [ ] Delete each ARN. Note: ACM will refuse to delete a cert still attached to a CloudFront distribution; if you skipped Step 4, do that first.
+  ```bash
+  aws acm delete-certificate --certificate-arn <arn> --region us-east-1
+  ```
+- [ ] **Verify**: list command above returns empty.
+
+## Step 7 — Delete CloudWatch log groups
+
+Free at idle but they accumulate over time and can incur cost.
+
+- [ ] List relevant log groups:
+  ```bash
+  aws logs describe-log-groups \
+    --query 'logGroups[?contains(logGroupName, `ondemand`) || contains(logGroupName, `soundclash`) || contains(logGroupName, `game-management`) || contains(logGroupName, `song-management`) || contains(logGroupName, `websocket-service`)].logGroupName'
+  ```
+- [ ] Delete each:
+  ```bash
+  aws logs delete-log-group --log-group-name <name>
+  ```
+- [ ] **Verify**: list command returns empty.
+
+## Step 8 — Check for stragglers
+
+These may or may not exist depending on what was ever deployed. Check each:
+
+- [ ] **RDS**: `aws rds describe-db-instances --query 'DBInstances[?contains(DBInstanceIdentifier, `soundclash`) || contains(DBInstanceIdentifier, `sound-clash`)].DBInstanceIdentifier'` — if any, take a final snapshot then delete.
+- [ ] **DynamoDB**: `aws dynamodb list-tables --query 'TableNames[?contains(@, `soundclash`) || contains(@, `sound-clash`)]'` — delete each.
+- [ ] **ElastiCache**: `aws elasticache describe-cache-clusters --query 'CacheClusters[?contains(CacheClusterId, `soundclash`)].CacheClusterId'` — delete each.
+- [ ] **Route 53**: any hosted zones for `soundclash.org`? Domain DNS lives at Cloudflare now, so any Route 53 zone is unused. AWS Console → Route 53 → Hosted zones.
+- [ ] **Secrets Manager / SSM Parameter Store**: any `/soundclash/*` entries? Console → Systems Manager → Parameter Store; Console → Secrets Manager.
+- [ ] **VPC**: a custom VPC for the legacy stack? If everything used the default VPC, skip. Otherwise: Console → VPC → confirm any custom VPC has no remaining ENIs/instances/load balancers, then delete.
+- [ ] **EIPs**: `aws ec2 describe-addresses` — any unattached Elastic IPs charge $0.005/hour. Release.
+- [ ] **NAT Gateways**: `aws ec2 describe-nat-gateways --filter Name=state,Values=available` — these are $32/mo each. Should be none, but verify.
+
+## Step 9 — Verify $0
+
+- [ ] Wait at least one hour after Step 8 for the AWS bill to update.
+- [ ] AWS Console → Billing → "Cost Explorer" → set range to "next month" forecast.
+- [ ] **Forecast should be $0** (or within a few cents for trailing line items like cross-region data transfer).
+- [ ] If forecast is non-zero, drill into the report to find what's still running. Common culprits: an EIP not released, a Route 53 hosted zone, a CloudWatch alarm with a Lambda destination.
+
+## Step 10 — Final cleanup
+
+- [ ] Update `Sound-Clash-legacy/README.md` with a teardown notice: "AWS resources for this codebase were torn down on YYYY-MM-DD. The deploy scripts no longer function."
+- [ ] Add `LEGACY.md` (template at `Sound-Clash-Plan/templates/LEGACY.md`) to the legacy repo's root.
+- [ ] In the new `Sound-Clash` repo, mark all `DEPLOY-09` checkboxes complete in the project tracker.
+- [ ] Take a screenshot of the AWS Cost Explorer "$0 forecast" and save it in the new repo at `docs/teardown-evidence-YYYY-MM-DD.png`. Closes the loop.
+
+---
+
+## What CAN'T be deleted (and that's fine)
+
+- **AWS account itself** — keep it; it's free at $0 spend. May be useful for future projects.
+- **CloudTrail logs older than 90 days** — auto-prune unless you've configured a long retention. No cost concern.
+- **IAM users/roles created during legacy** — review and remove unused ones for security hygiene, but they don't cost anything.
+
+## Rollback (don't actually do this without strong reason)
+
+If you're in the middle of teardown and decide you need the legacy stack back:
+
+1. Stop teardown immediately.
+2. From `Sound-Clash-legacy/scripts/ondemand/`: `./deploy-all.sh` re-creates the on-demand stack. ~15–20 min.
+3. DNS revert: Cloudflare → `soundclash.org` apex → CNAME back to the new CloudFront distribution that was just recreated.
+
+This works **only** if you stop before Step 4 (CloudFront delete). After Step 4, the original distribution ID is gone; you'd get a new one and need to update other references. After Step 5 (ECR), the deploy scripts also fail because the image registry is gone — you'd need to rebuild + push images first.
+
+In short: Steps 1–3 are reversible in ~30 min. Steps 4+ are not practically reversible.
+
+## Sign-off
+
+- Started: __________ (date, time, operator)
+- Completed: __________ (date, time)
+- AWS Cost Explorer forecast: __________ ($X.XX/mo)
+- Anomalies: __________ (any line items that took investigation)

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,236 @@
+# Sound Clash — Data Model
+
+The schema for Postgres on Supabase. Six tables, two halves: durable catalog and ephemeral game state.
+
+For PL/pgSQL function bodies that mutate this schema, see **`rpc-functions.md`**.
+For RLS policies and access matrix, see **`security-rls.md`**.
+
+## 1. ER Diagram
+
+```
+genres ──┬── song_genres ──┬── songs
+         │                 │
+         │ (composite PK)  │
+         │                 │
+         └─────────────────┘
+                                 (FK with ON DELETE SET NULL)
+                                              │
+active_games (PK: game_code) ◄────────────────┤
+   │                                          │
+   ├── game_teams (FK: game_code) — N teams   │
+   │                                          │
+   └── game_rounds (FK: game_code) ───────────┘
+```
+
+**Durable** (never auto-deleted): `songs`, `genres`, `song_genres`.
+**Ephemeral** (deleted 4h after `started_at`): `active_games`, `game_teams`, `game_rounds`. Pruned by pg_cron.
+
+The only FK crossing the durable ↔ ephemeral boundary is `game_rounds.song_id → songs.id`, with `ON DELETE SET NULL` so deleting a song doesn't break in-progress rounds.
+
+## 2. DDL
+
+```sql
+-- Required extensions
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;  -- for gen_random_uuid()
+
+-- ====== Durable: song catalog ======
+CREATE TABLE songs (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title         text NOT NULL,
+  artist        text NOT NULL,
+  youtube_id    char(11) NOT NULL,
+  start_time    integer NOT NULL DEFAULT 0,    -- seconds
+  is_soundtrack boolean NOT NULL DEFAULT false, -- true = movie/TV soundtrack
+  source        text,                           -- name of movie/TV show; nullable
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE genres (
+  id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  slug text NOT NULL UNIQUE
+);
+
+CREATE TABLE song_genres (
+  song_id  uuid REFERENCES songs(id)  ON DELETE CASCADE,
+  genre_id uuid REFERENCES genres(id) ON DELETE CASCADE,
+  PRIMARY KEY (song_id, genre_id)
+);
+
+-- ====== Ephemeral: live game state ======
+CREATE TABLE active_games (
+  game_code         char(6) PRIMARY KEY,
+  status            text NOT NULL DEFAULT 'waiting'
+                     CHECK (status IN ('waiting','playing','ended')),
+  total_rounds      integer NOT NULL,
+  selected_genres   uuid[] NOT NULL DEFAULT '{}',
+  round_number      integer NOT NULL DEFAULT 0,
+  current_song_id   uuid REFERENCES songs(id) ON DELETE SET NULL,
+  current_round_id  uuid,                              -- FK added below
+  buzzed_team_id    uuid,                              -- nullable; the lock
+  locked_at         timestamptz,                       -- server-authoritative buzz time
+  started_at        timestamptz NOT NULL DEFAULT now(),
+  ended_at          timestamptz,
+  expires_at        timestamptz NOT NULL DEFAULT (now() + interval '4 hours')
+);
+
+CREATE TABLE game_teams (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  game_code  char(6) NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
+  name       text NOT NULL,
+  score      integer NOT NULL DEFAULT 0,
+  joined_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (game_code, name)
+);
+
+CREATE TABLE game_rounds (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  game_code       char(6) NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
+  round_number    integer NOT NULL,
+  song_id         uuid REFERENCES songs(id) ON DELETE SET NULL,
+  started_at      timestamptz NOT NULL DEFAULT now(),
+  buzzed_team_id  uuid REFERENCES game_teams(id) ON DELETE SET NULL,
+  title_points    integer NOT NULL DEFAULT 0,
+  artist_points   integer NOT NULL DEFAULT 0,
+  source_points   integer NOT NULL DEFAULT 0,
+  timeout_penalty integer NOT NULL DEFAULT 0,
+  ended_at        timestamptz,
+  UNIQUE (game_code, round_number)
+);
+
+-- Deferred FKs (must be added after game_rounds and game_teams exist)
+ALTER TABLE active_games
+  ADD CONSTRAINT active_games_current_round_fkey
+  FOREIGN KEY (current_round_id) REFERENCES game_rounds(id) ON DELETE SET NULL;
+
+ALTER TABLE active_games
+  ADD CONSTRAINT active_games_buzzed_team_fkey
+  FOREIGN KEY (buzzed_team_id) REFERENCES game_teams(id) ON DELETE SET NULL;
+```
+
+## 3. Indexes
+
+```sql
+CREATE INDEX active_games_expires_at_idx  ON active_games (expires_at);  -- cron sweep
+CREATE INDEX game_teams_game_code_idx     ON game_teams  (game_code);
+CREATE INDEX game_rounds_game_code_idx    ON game_rounds (game_code);
+CREATE INDEX songs_is_soundtrack_idx      ON songs (is_soundtrack) WHERE is_soundtrack = true;
+CREATE INDEX song_genres_genre_idx        ON song_genres (genre_id);
+```
+
+The `active_games_expires_at_idx` is the most important: it backs the hourly pg_cron sweep, which scans for rows past their TTL.
+
+## 4. Field Notes
+
+### `active_games.game_code`
+
+- 6 chars, alphabet `ABCDEFGHJKMNPQRSTUVWXYZ23456789` (no 0/O, 1/I/L, no lowercase).
+- Generated by FastAPI on `POST /games` with collision retry up to 5 times, then 500.
+- ~32^6 ≈ 1 billion combinations. Birthday-paradox collision becomes likely around ~30k concurrent games — well above any expected scale.
+
+### `active_games.status`
+
+State machine enforced by CHECK constraint and by RPC functions (see `rpc-functions.md` and `game-rules.md`).
+
+```
+waiting → playing → ended
+```
+
+Backwards transitions are NOT enforced at the database level; RPC functions reject them.
+
+### `active_games.selected_genres`
+
+Postgres `uuid[]` array. Used by FastAPI when picking a random song:
+```sql
+SELECT s.* FROM songs s
+JOIN song_genres sg ON sg.song_id = s.id
+WHERE sg.genre_id = ANY($1)
+  AND s.id NOT IN (
+    SELECT song_id FROM game_rounds WHERE game_code = $2 AND song_id IS NOT NULL
+  )
+ORDER BY random() LIMIT 1;
+```
+
+### `active_games.expires_at`
+
+Default `started_at + 4 hours`. Read-only after game creation. The pg_cron sweep (`cleanup_expired_games()` in `rpc-functions.md`) deletes any row past this point.
+
+### `active_games.buzzed_team_id` and `locked_at`
+
+These two columns implement the buzzer lock. Both are NULL when no team holds the buzz. Set together by the `buzz_in` RPC. Cleared together by `start_round` and `award_points`.
+
+### `game_teams.score`
+
+Integer (can go negative, though MVP scoring rules don't deduct). Updated only by `award_points` RPC, never directly.
+
+### `game_rounds` denormalization
+
+Each round records `title_points`, `artist_points`, `source_points`, `timeout_penalty` separately so the round detail can be reconstructed for display. Total awarded = `title + artist + source - timeout`. The `game_teams.score` field is the running cumulative — both sources of truth for different views.
+
+## 5. Row-Level Security (summary)
+
+Two principals: `anon` (browser) and `service_role` (FastAPI). All tables have RLS enabled; `anon` gets SELECT-only on all tables; mutations are exclusively via service_role or via the `buzz_in` RPC (the only function `anon` is granted EXECUTE on).
+
+Full policy DDL and threat model: see **`security-rls.md`**.
+
+## 6. RPC Functions (summary)
+
+Five PL/pgSQL functions encode all state transitions:
+
+| Function | Purpose | Caller |
+|---|---|---|
+| `buzz_in(p_game_code, p_team_id)` | Atomic buzzer lock | Browser via PostgREST |
+| `start_round(p_game_code, p_song_id)` | Begin a new round | FastAPI |
+| `award_points(p_game_code, p_round_id, p_title, p_artist, p_source, p_timeout)` | Evaluate and score | FastAPI |
+| `end_game(p_game_code)` | Mark game ended | FastAPI |
+| `cleanup_expired_games()` | TTL sweep | pg_cron |
+
+Full bodies, race-correctness arguments, and tests: see **`rpc-functions.md`**.
+
+## 7. Migration Ordering
+
+Apply SQL files in this order:
+
+```
+db/migrations/
+├── 001_extensions.sql        -- pg_cron, pgcrypto
+├── 002_durable_tables.sql    -- songs, genres, song_genres
+├── 003_ephemeral_tables.sql  -- active_games, game_teams, game_rounds, deferred FKs
+├── 004_indexes.sql
+├── 005_rpc_functions.sql     -- the 5 PL/pgSQL functions (see rpc-functions.md)
+├── 006_rls_policies.sql      -- enable RLS + policies + grants (see security-rls.md)
+├── 007_cron_jobs.sql         -- cron.schedule() calls
+└── 008_seed_genres.sql       -- initial genre rows
+```
+
+All migrations are written to be idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. Re-running them is safe.
+
+Songs are imported separately by Phase 2 of the roadmap (`scripts/import-songs.py`), not by these migrations. Genres are seeded statically in `008_seed_genres.sql`.
+
+## 8. Capacity
+
+At expected scale (100–1000 games/mo):
+
+- `songs` table: ~1,000–10,000 rows × ~200 bytes = ~2 MB. Static.
+- `genres`: ~20 rows. Tiny.
+- `song_genres`: ~30,000 rows × ~50 bytes = ~1.5 MB. Static.
+- `active_games`: never more than ~30 rows at any moment (TTL prunes); ~1 KB each.
+- `game_teams`: max ~30 × 8 = ~240 rows; ~200 bytes each.
+- `game_rounds`: max ~30 × 30 = ~900 rows; ~300 bytes each.
+
+**Total live size**: ~5 MB. Free tier is 500 MB. Headroom is enormous.
+
+## 9. Dropped from Old Schema
+
+The legacy Sound Clash codebase had tables and columns that **will not** be carried over. Listed here so future contributors don't reintroduce them:
+
+- `songs.play_count`, `songs.last_played` — heatmap analytics; out of scope (game data is ephemeral by design).
+- `songs.is_active` — soft-delete flag; replaced by hard delete.
+- AI song-selection cache table — feature dropped.
+- DynamoDB-style ephemeral state with TTL — replaced by Postgres `expires_at` + pg_cron.
+- ElastiCache Redis sessions — Realtime handles fan-out; no server sessions to cache.
+- Per-game audit log — out of scope (ephemeral).
+
+If any of these are wanted later, add a separate migration; do not retrofit into the base schema.

--- a/docs/free-tier-budget.md
+++ b/docs/free-tier-budget.md
@@ -1,0 +1,227 @@
+# Sound Clash — Free-Tier Budget
+
+This is the early-warning system. It quantifies how many games you can run per month before hitting any free-tier ceiling, and which numbers to watch.
+
+The design target is **comfortably free for 50–100 games per month**. Beyond that, this doc tells you what to upgrade and when.
+
+## 1. Per-Game Resource Estimate
+
+A typical Sound Clash game has these characteristics (used as the unit of capacity throughout this doc):
+
+| Property | Estimate |
+|---|---|
+| Duration | 30 minutes |
+| Teams | 4 |
+| Spectator displays | 1 |
+| Manager | 1 |
+| Total concurrent clients | 6 |
+| Rounds | 10 |
+| Buzz events | ~10 (one per round) |
+| Round-state UPDATEs | ~30 (start, buzz lock, award, ...) |
+| Team list UPDATEs | ~5 (joins) |
+| Realtime messages per game | ~250 |
+| FastAPI requests per game | ~30 (create, joins, song picks, awards, end) |
+
+These numbers are pessimistic — real-world will be lower. Round up for safety.
+
+## 2. Service-by-Service Quota Analysis
+
+### 2.1 Supabase (free tier)
+
+| Resource | Limit | Per-game use | Capacity (games/mo) | Notes |
+|---|---|---|---|---|
+| Postgres storage | 500 MB | ~5 KB (rounds + teams + game row) | n/a (cleared in 4h) | songs catalog ~5–20 MB indefinitely |
+| Database egress | 2 GB / mo | ~50 KB per game (queries + RPC) | **40,000 games** | Far above any practical use |
+| Realtime concurrent peers | 200 | 6 | **33 games in parallel** | Hard cap; affects max simultaneous games |
+| Realtime messages | 2,000,000 / mo | 250 | **8,000 games/mo** | Comfortable |
+| Auth users | 50,000 | 0 | n/a | Not used in MVP |
+| Storage | 1 GB | 0 | n/a | Not used (YouTube only) |
+| Bandwidth | 5 GB | minimal | n/a | |
+| Edge function invocations | 500k / mo | 0 | n/a | Not used in MVP |
+
+**Binding constraint**: 200 concurrent peers = max **33 simultaneous games**. Anything beyond that needs Supabase Pro ($25/mo, 500 peers).
+
+**Soft constraint**: 2M messages/mo = ~8,000 games. Realistically you'll hit the 200-peer ceiling first.
+
+**Project pause policy**: Supabase pauses free projects after 7 days of inactivity. Mitigation: a tiny GitHub Action that hits a SELECT once a week (not strictly necessary if you actually run games).
+
+### 2.2 Render (free web service)
+
+| Resource | Limit | Notes |
+|---|---|---|
+| Service hours | 750 / mo | Single service uses ~720 (24/7) — below cap |
+| RAM | 512 MB | FastAPI + supabase-py easily fits |
+| Build minutes | included | |
+| Bandwidth | 100 GB / mo | ~30 KB per game request × 30 reqs × 8000 games ≈ 7 GB; safe |
+| Idle sleep | 15 min idle → sleep | Acceptable: FastAPI is off the buzzer hot path |
+| Cold start | ~30 s wake | Felt only on game creation after long idle |
+
+**Binding constraint**: cold-start UX. The first game-creation request after a >15min idle period stalls ~30s. Mitigation: cron-job.org pings `/health` every 14 minutes (free tier: 50 cron jobs).
+
+### 2.3 Cloudflare Pages
+
+| Resource | Limit | Notes |
+|---|---|---|
+| Bandwidth | unlimited | Best-in-class for static sites |
+| Builds | 500 / mo | A merge to `main` consumes 1; we'll be far under |
+| Concurrent builds | 1 | Builds queue but don't fail |
+| Custom domains | 100 | We use 1 |
+| File count per deployment | 20,000 | Vite builds well under this |
+
+**No binding constraint** at any realistic usage.
+
+### 2.4 Cloudflare DNS
+
+Free, no quotas relevant to this project.
+
+### 2.5 GitHub Actions
+
+| Resource | Limit (public repo) | Limit (private) | Notes |
+|---|---|---|---|
+| Minutes | unlimited | 2,000 / mo | Public repo recommended for unlimited CI |
+| Storage (artifacts/cache) | 500 MB | 500 MB | Tests don't store much |
+| Concurrent jobs | 20 | 20 | |
+
+**Recommendation**: keep the new `Sound-Clash` repo public. Saves CI worry.
+
+### 2.6 Sentry (free tier — error tracking)
+
+| Resource | Limit | Notes |
+|---|---|---|
+| Errors | 5,000 / mo | At 1% error rate per game request × 30 reqs × 8000 games = 2400/mo; safe at expected volume |
+| Performance events | 10,000 / mo | Sample buzzer transactions at 100% during MVP; throttle later |
+| Replays | 50 / mo | Use sparingly for debugging |
+| Team members | 1 | Solo maintainer |
+
+### 2.7 cron-job.org (Render keepalive)
+
+| Resource | Limit | Notes |
+|---|---|---|
+| Cron jobs | 50 | Use 1 |
+| Min interval | 1 minute | We use 14 min |
+
+### 2.8 Domain (paid; not free)
+
+`soundclash.org` registration ~$10–15 / yr. The only non-free cost.
+
+## 3. Monthly Budget Summary
+
+If you run **100 games per month**:
+
+| Service | Usage | % of Quota | Status |
+|---|---|---|---|
+| Supabase Realtime peers | 6 concurrent | 3% | comfortable |
+| Supabase Realtime msgs | 25,000 | 1.25% | comfortable |
+| Supabase egress | 5 MB | 0.25% | comfortable |
+| Render hours | 720 | 96% | by design (always-on) |
+| Render bandwidth | 90 MB | 0.09% | comfortable |
+| Cloudflare Pages | <1 build/day | <5% | comfortable |
+| GitHub Actions (public) | unlimited | n/a | n/a |
+| Sentry errors | <30 | <1% | comfortable |
+
+**Total monthly cost: $0** (excluding the domain).
+
+If you run **1,000 games per month**:
+
+| Service | Usage | % of Quota | Status |
+|---|---|---|---|
+| Supabase Realtime peers | 6 concurrent (worst-case if many sequential) | up to 200 if parallel | watch |
+| Supabase Realtime msgs | 250,000 | 12.5% | comfortable |
+| Supabase egress | 50 MB | 2.5% | comfortable |
+| Render hours | 720 | 96% | unchanged |
+| Render bandwidth | 900 MB | 0.9% | comfortable |
+| Sentry errors | ~300 | 6% | comfortable |
+
+Still $0/month. The constraint kicks in only with **simultaneous games** (concurrent peers), not total volume.
+
+## 4. Alert Thresholds
+
+Configure these alerts:
+
+### Supabase (dashboard email alerts)
+- Realtime peers > 150 (75% of cap) → warn
+- Realtime peers > 180 (90%) → critical
+- Realtime messages > 1.5M / mo (75%) → warn
+- DB egress > 1.5 GB / mo (75%) → warn
+- DB size > 400 MB (80%) → warn
+
+### Render (dashboard alerts)
+- Service unhealthy (5xx rate > 5% over 5min) → critical
+- Memory > 450 MB (88%) → warn
+- Build failures → critical
+
+### Sentry
+- New issue (any error) → email
+- Error rate > 1% of `buzz_in` calls → critical
+- Performance: `buzz_in` p95 > 250ms over 1 hour → warn
+
+### Cloudflare Pages
+- Build failure → email
+
+## 5. Scale-Out Triggers
+
+Upgrade only when you actually hit a ceiling. Order of likely upgrade:
+
+| Trigger | Upgrade | Cost / mo | What it gives |
+|---|---|---|---|
+| Realtime peers approach 200 cap | **Supabase Pro** | $25 | 500 concurrent peers, 5M msgs, daily backups, point-in-time recovery, 8GB DB |
+| Cold-start UX hurts game-day flow | **Render Starter** | $7 | No idle sleep; 512MB → 1GB optional |
+| Sentry errors > 5k/mo | **Sentry Team** | $26 | 50k errors |
+| Want multi-region | **Migrate FastAPI to Fly.io** | $0–$5 | Multi-region machines |
+| Want multi-tenant managers | **Supabase Auth + Pro** | $25 | OAuth providers + Pro storage limits |
+
+If you ever ship publicly and run 1000+ concurrent games, the bottleneck is Supabase peers; Pro is the answer. Until then, free is genuinely free.
+
+## 6. What Costs Money If You're Not Careful
+
+Listed for awareness — none of these are in the current design, but they're easy mistakes to make later:
+
+- **Sending audio via Realtime.** Don't. Audio is YouTube-embedded; messages are JSON state changes only. A single audio packet would blow the message budget.
+- **Subscribing to entire tables instead of filtered rows.** Always include `filter: 'game_code=eq.XXXXXX'` on `postgres_changes` subscriptions, otherwise every client receives every game's events → quota exhaustion.
+- **Polling instead of subscribing.** A team page polling `/games/{code}/state` every second = 86,400 requests / day per team. Don't do it.
+- **Logging Realtime payloads at INFO level on the server.** Log volumes climb fast. Use DEBUG, sample, or skip.
+- **Running database migrations from CI on every push.** Run them on manual dispatch only.
+- **AWS resources still up after migration.** Verify AWS Cost Explorer = $0 forecast post-cutover. CloudFront is the most likely lingering cost.
+- **NAT Gateway anywhere.** $32/month minimum on AWS. The new design has no AWS — but if you ever go back, never put a service behind a NAT.
+
+## 7. Cost Comparison vs. Current Architecture
+
+| Architecture | Idle/mo | 100 games/mo | 1000 games/mo |
+|---|---|---|---|
+| Current AWS always-on | ~$105 | ~$105 | ~$110 |
+| Current AWS on-demand (deploy/destroy) | ~$0.02 | ~$1.50 | ~$15 |
+| **New free-tier (this design)** | **$0** | **$0** | **$0** |
+| New + Supabase Pro (when needed) | $25 | $25 | $25 |
+
+The design saves $1,200+/year vs. always-on AWS, with significantly better UX (no deploy ritual, no 15min wait between sessions).
+
+## 8. Annual Total Cost of Ownership (TCO)
+
+Year 1 estimate at expected usage:
+
+| Item | Cost |
+|---|---|
+| `soundclash.org` domain renewal | $12 |
+| Supabase free tier | $0 |
+| Render free tier | $0 |
+| Cloudflare Pages | $0 |
+| GitHub | $0 |
+| Sentry | $0 |
+| cron-job.org | $0 |
+| **Total** | **$12 / year** |
+
+If volume forces upgrades, year 2+ would be ~$300/year (Supabase Pro). Compare with current AWS always-on at ~$1,260/year.
+
+## 9. Capacity Planning Worksheet
+
+Use this when planning a launch (e.g., a tournament with many parallel games):
+
+```
+1. Number of simultaneous games: ___
+2. Multiply by 6 (typical clients per game): ___ concurrent peers
+3. Compare to 200 (free tier limit): ____% utilization
+
+If > 80%, schedule games sequentially OR upgrade to Pro.
+```
+
+For example, 30 simultaneous games = 180 concurrent peers = 90% utilization → cutting it close; upgrade.

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -1,0 +1,186 @@
+# Sound Clash — Game Rules
+
+This is the canonical specification of how the game is played. Other docs reference this one for behaviour. If a rule conflicts with another document, this doc wins.
+
+## 1. Roles
+
+| Role | What they do | Per game |
+|---|---|---|
+| **Manager (host)** | Creates the game, picks genres, advances rounds, judges answers | exactly 1 |
+| **Team** | Joins by game code, presses buzzer, gives verbal answer | 1 to N (N typically 2–8) |
+| **Display** | Public scoreboard / "TV screen" | 0 to many (read-only) |
+
+The manager and display are typically separate physical screens (laptop + TV). Teams are typically phones in players' hands.
+
+## 2. Game Lifecycle (state machine)
+
+```
+        ┌──────────┐  manager creates    ┌──────────┐
+        │  (none)  │ ─────────────────▶  │ waiting  │
+        └──────────┘                     └────┬─────┘
+                                              │ manager presses "Start game"
+                                              │ (≥ 1 team must have joined)
+                                              ▼
+                          ┌────────────┐  manager: next round
+                  ┌─────▶ │  playing   │ ─────────────┐
+                  │       └─────┬──────┘              │
+                  │             │ all rounds done OR  │ (loops per round)
+                  │             │ manager: end game   │
+                  │             ▼                     │
+                  │       ┌────────────┐              │
+                  └───────┤   ended    │◀─────────────┘
+                          └────────────┘
+                                │
+                                │ pg_cron sweep (≥4h after started_at)
+                                ▼
+                            (deleted)
+```
+
+### State transitions (authoritative)
+
+| From | Event | To | Performed by |
+|---|---|---|---|
+| (none) | `POST /games` | `waiting` | Manager (admin auth) |
+| `waiting` | manager starts game | `playing` (round 1 active) | Manager (admin auth) |
+| `playing` | round complete + rounds remaining | `playing` (next round) | Manager (admin auth) |
+| `playing` | round complete + last round | `ended` | Manager (admin auth) |
+| `playing` | manager presses "End game" | `ended` | Manager (admin auth) |
+| any | `expires_at < now()` | (deleted) | `pg_cron` |
+
+Invalid transitions (e.g., `ended` → `playing`) MUST be rejected by the RPC layer.
+
+## 3. Round Lifecycle
+
+Each round is one song. The round's micro-state is encoded in `active_games` (`buzzed_team_id`, `locked_at`, `current_round_id`) plus the matching `game_rounds` row.
+
+```
+   round_started ──▶ song playing ──▶ team buzzes ──▶ buzzer_locked
+                                                            │
+                                                            ▼
+                                                    manager evaluates
+                                                            │
+                       ┌───── timeout (no buzz) ──┐         │
+                       │                          ▼         ▼
+                       │                  next_round  or  award_points
+                       │                                    │
+                       └────────────────────────────────────┘
+```
+
+### Round events (server-authoritative)
+
+1. **Round starts** — manager picks (or system random-picks) a song; `start_round` RPC clears prior buzz state and assigns `current_song_id`.
+2. **Song plays** — manager controls YouTube IFrame Player.
+3. **Buzz** — first team to call `buzz_in` RPC wins; `locked_at` is the server timestamp.
+4. **Evaluation** — manager judges the buzzing team's verbal answer and awards points per component (or a timeout penalty).
+5. **Round ends** — `award_points` RPC writes the result and clears buzz state for the next round.
+
+## 4. Scoring
+
+Per-round point components (locked at MVP, configurable later):
+
+| Component | Points | When awarded |
+|---|---|---|
+| Song title correct | **+10** | Manager judges title correct |
+| Artist correct | **+5** | Manager judges artist correct |
+| Source (movie/TV show) correct | **+5** | Only for soundtrack songs (`is_soundtrack = true`) |
+| Timeout penalty | **−2** | Round ended with no buzz |
+
+Maximum per round: **20** (title + artist + source for a soundtrack song). For non-soundtrack songs, the max is **15** and the source component is N/A.
+
+Scores are integers; ties are allowed. The team with the highest score at game end is the winner; tied teams share the win (no tiebreaker round in MVP — see §11).
+
+### Scoring rules
+
+- Points are added to `game_teams.score` only when a team buzzed AND the manager awards them.
+- The timeout penalty is applied to no team — it's just a `game_rounds.timeout_penalty` value for the round record. (Past versions deducted from a buzzing team; the new version does not.)
+- Negative team scores are allowed (if a future rule penalizes a wrong buzz).
+- The manager cannot retroactively change a previous round's score in MVP. (Future: an "edit last round" undo flow.)
+
+## 5. Song Selection
+
+- Songs come from the `songs` catalog. Manager picks `selected_genres` at game-creation time.
+- For each round, the manager either:
+  - **(a)** clicks "Random song" → backend `POST /games/{code}/select-song` returns a random song from `songs` filtered by `selected_genres`, **excluding songs already played in this game**, OR
+  - **(b)** picks manually from a search/browse UI (out of MVP scope; reserved).
+- "No repeats per game" is enforced at the API layer by joining against `game_rounds` for the current `game_code`.
+- If all matching songs are exhausted: backend returns 409 with a clear error; manager must add more genres or end the game.
+
+## 6. Buzzer Rules
+
+- Only one team can hold the lock at a time. The atomic guarantee is in the `buzz_in` PL/pgSQL function (see `rpc-functions.md`).
+- The buzz button is enabled only while `active_games.status = 'playing'` AND `buzzed_team_id IS NULL`.
+- After lock, the button is disabled for ALL teams until the manager either awards points or restarts the song.
+- The `locked_at` timestamp is server-authoritative. Clients display "X locked it" with no client-side ordering logic.
+- Rejected buzz attempts (lock already held) get a quiet UI signal — no error toast, just disabled state.
+
+## 7. Reconnection (teams)
+
+The current Sound Clash has a 15-second grace window for team disconnect. The new design simplifies this:
+
+- A team's identity is `{ game_team_id (uuid), game_code }`. Both are stored in `localStorage` on join.
+- On page reload or temporary disconnect, the page reads `localStorage`, re-subscribes to the Realtime channel, and resumes — no server-side state restoration needed.
+- If the team's row was deleted (e.g., game expired or the manager kicked them), the page redirects to the join screen with a message.
+- No "reconnect grace period" is enforced. If a team disconnects, the game continues. They can rejoin while the game is `waiting` or `playing`.
+
+## 8. Reconnection (manager)
+
+- Manager identity is "whoever has the admin password and the game code." Manager state is recoverable from the `active_games` row.
+- If the manager closes the tab mid-game, the game stays in its current state (`playing`, `buzzed_team_id` still set if mid-buzz). The manager can reload `/manager/game/{code}` and resume.
+- **Two manager tabs problem**: the design accepts that two tabs both work as manager. Both can issue `start_round` / `award_points` RPCs. Practical impact is low (typical use is one host on one device). Mitigation deferred — see §11.
+
+## 9. Timeouts
+
+### Buzz window timeout
+
+- After `start_round`, if no team buzzes within **20 seconds** (configurable), the manager UI shows a "no one buzzed" prompt and the manager presses "Skip / Timeout" → `award_points` RPC is called with `p_timeout = 2`, and the round ends with a `-2` penalty recorded.
+- The 20-second window is enforced client-side in the manager UI (timer). The server does not auto-timeout.
+
+### Answer-evaluation window
+
+- After buzz lock, the manager has unbounded time to listen and evaluate. No server timeout.
+- (Future: optional 10-second answer countdown for tournament mode — out of MVP.)
+
+## 10. Game Expiration & TTL
+
+- `active_games.expires_at = started_at + interval '4 hours'` (fixed at game creation).
+- `pg_cron` runs `cleanup_expired_games()` hourly: `DELETE FROM active_games WHERE expires_at < now()`.
+- `game_teams` and `game_rounds` cascade-delete via FK.
+- **Mid-game truncation**: a marathon session running >4 hours from start will be deleted while still in `playing` state. The frontend handles this by detecting the row vanishing (Realtime DELETE event) and redirecting all clients to a "game expired" page. This is an accepted limitation; documented for users.
+
+## 11. Edge Cases & Open Questions
+
+| Scenario | Behaviour | Status |
+|---|---|---|
+| All teams disconnect mid-round | Game stays in `playing`. Manager can wait or end the game. No auto-pause. | Defined |
+| Manager disconnects | Game stays in current state. Recoverable via reload. | Defined |
+| Manager presses "End game" mid-round | `end_game` RPC runs; current round is left without `ended_at`; scoreboard shows current scores. | Defined |
+| Tied final scores | Multiple teams shown as "winner"; no tiebreaker round. | Defined for MVP |
+| Same team name joined twice | Rejected by `UNIQUE (game_code, name)`. UI shows clear error. | Defined |
+| Empty team name / 100-char team name | Rejected at API layer; min 1 char, max 30 chars. | Defined |
+| Game created with no genres | Rejected at API layer; min 1 genre required. | Defined |
+| Manager restarts the same song | "Restart song" button calls `start_round` RPC again with the same `song_id`. Buzz state cleared. Old round row remains as a no-points-awarded artifact. | Defined |
+| Two manager tabs open | Both work. Last write wins. | Accepted limitation; future presence-based detection |
+| Network partition splits some teams from Supabase | Affected teams freeze. They reconnect and re-subscribe. Game state is server-authoritative; UI reconciles on reconnect. | Defined |
+| User opens browser DevTools and calls `buzz_in` directly | Allowed by RLS. Functionally equivalent to pressing the button. Not a security issue. | Accepted |
+| User tries to call `award_points` from the browser | Blocked: only `service_role` can execute it. The browser only has the anon key. | Enforced via RLS |
+| Tiebreaker round | Out of MVP. Manager declares tied result manually. | Future |
+| Song play_count / popularity | Out of MVP. Game data is ephemeral; cannot accumulate stats without a separate durable counter. | Future |
+| Bonus rounds, lightning round, double-or-nothing | Out of MVP. | Future |
+
+## 12. UX Constraints (informational, for frontend work)
+
+- Buzz button must respond in **<100ms** of tap (UI feedback) — the actual lock confirmation comes via Realtime in <200ms. Optimistic UI: button shows "buzzing…" immediately, then "locked!" or "too slow" once the Realtime row update arrives.
+- Display screen must be readable at 3+ meters (large fonts; high contrast).
+- Team page should work on iOS Safari and Chrome Android. iPhone SE viewport is the smallest supported size.
+- No notifications, no permissions prompts.
+
+## 13. What is NOT a Game Rule
+
+For clarity — these are out of scope and explicitly NOT enforced by the system:
+
+- Players' real identities (no accounts, no profiles)
+- Team chat
+- Voice/video communication between teams
+- Streaming the manager's screen for remote teams (use Zoom)
+- Anti-cheating (Shazam detection, audio fingerprinting on team device)
+- Practice mode / single player

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,338 @@
+# Sound Clash — Local Development
+
+How to run the system on your laptop. Read this before opening a code editor.
+
+The local stack is intentionally minimal: a local Supabase instance, a Python venv, and `npm run dev`. No Docker required for routine work (Docker is only for the production-build verification step).
+
+## 1. Prerequisites
+
+| Tool | Min version | Install |
+|---|---|---|
+| Python | 3.11 | https://www.python.org/downloads/ |
+| Node.js | 20 | https://nodejs.org/ |
+| Supabase CLI | latest | https://supabase.com/docs/guides/cli/getting-started |
+| Docker Desktop | latest | https://www.docker.com/products/docker-desktop |
+| Git | any recent | https://git-scm.com/ |
+| (optional) `gh` CLI | any | https://cli.github.com/ |
+| (optional) `direnv` | any | for auto-loading `.env` |
+
+Docker is only required because Supabase CLI uses it to spin up local Postgres + Realtime + PostgREST containers. You don't write Dockerfiles for daily dev.
+
+### Windows note
+
+The user runs Windows 11. Supabase CLI works on Windows but Docker Desktop must be running. Use **PowerShell 7+** (not Windows PowerShell 5) for the better terminal UX. WSL2 also works if you prefer.
+
+## 2. Clone & Initial Setup
+
+```bash
+git clone https://github.com/BenArtzi4/Sound-Clash.git
+cd Sound-Clash
+```
+
+(After Phase 1 of the roadmap is done. Until then, the repo is empty.)
+
+```
+Sound-Clash/
+├── backend/               # FastAPI app
+├── frontend/              # React + Vite SPA
+├── db/
+│   ├── migrations/        # SQL files, ordered by prefix
+│   └── seed/              # genre seed data
+├── tests/
+│   ├── db/                # pytest + testcontainers
+│   ├── backend/           # pytest + httpx
+│   └── e2e/               # Playwright
+├── scripts/               # one-off scripts (data import, etc.)
+└── .github/workflows/     # CI
+```
+
+### Environment variables
+
+Copy the templates:
+
+```bash
+cp .env.example .env
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+Fill them in (see §4 for what each value should be in dev).
+
+## 3. Start Local Supabase
+
+From the repo root:
+
+```bash
+supabase init       # one-time; creates supabase/ config
+supabase start      # spins up Docker containers
+```
+
+This launches:
+- **Postgres** at `localhost:54322`
+- **PostgREST API** at `http://localhost:54321`
+- **Realtime** (WebSocket) at the same `localhost:54321`
+- **Studio UI** at `http://localhost:54323`
+- **Mailcatcher** for auth emails (unused in MVP) at `http://localhost:54324`
+
+`supabase start` prints the local anon key, service-role key, and JWT secret. Copy these into your `.env` files.
+
+To stop: `supabase stop`. To reset (wipe all data): `supabase db reset`.
+
+### Apply migrations
+
+Each migration file in `db/migrations/` runs automatically when you `supabase db reset`. Or apply them to a running instance:
+
+```bash
+./db/migrate.sh local    # uses local Supabase URL + service-role key
+```
+
+### Seed data
+
+```bash
+psql postgres://postgres:postgres@localhost:54322/postgres -f db/seed/genres.sql
+python scripts/import-songs.py --target local --source data/songs.csv
+```
+
+(Once `data/songs.csv` is exported from the legacy AWS RDS — see Phase 2 of the roadmap.)
+
+## 4. Environment Variable Templates
+
+### Root `.env.example`
+```
+# Used by docker-compose, scripts
+SUPABASE_URL=http://localhost:54321
+SUPABASE_ANON_KEY=<from `supabase start` output>
+SUPABASE_SERVICE_ROLE_KEY=<from `supabase start` output>
+DATABASE_URL=postgres://postgres:postgres@localhost:54322/postgres
+```
+
+### `backend/.env.example`
+```
+SUPABASE_URL=http://localhost:54321
+SUPABASE_SERVICE_ROLE_KEY=<from `supabase start` output>
+ADMIN_PASSWORD=devpass123
+PORT=8000
+CORS_ORIGINS=http://localhost:5173
+LOG_LEVEL=DEBUG
+```
+
+### `frontend/.env.example`
+```
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=<from `supabase start` output>
+VITE_API_URL=http://localhost:8000
+VITE_ADMIN_PASSWORD=devpass123
+```
+
+(`VITE_ADMIN_PASSWORD` is dev-only convenience. In production the user types it.)
+
+## 5. Run the Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate         # PowerShell: .venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+uvicorn app.main:app --reload --port 8000
+```
+
+Hits `http://localhost:8000`. Auto-generated Swagger UI at `http://localhost:8000/docs`.
+
+Verify:
+```bash
+curl http://localhost:8000/health
+# {"status":"ok",...}
+```
+
+## 6. Run the Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Hits `http://localhost:5173`. Vite hot-reloads on save.
+
+## 7. End-to-End Local Test
+
+With local Supabase + backend + frontend all running:
+
+1. Open http://localhost:5173 → home screen.
+2. Click "I'm a host" → enter `devpass123` → "Create game" → fill in genres → submit.
+3. Note the 6-character game code.
+4. Open a second browser tab → http://localhost:5173 → "I'm a team" → enter the code, team name → join.
+5. Open a third tab → "I'm a display" → enter the code → join.
+6. Back in tab 1 (host) → "Start game" → "Next song" → song info appears.
+7. In tab 2 (team) → press "Buzz!".
+8. All three tabs should show the lock state within ~100ms (local Supabase has near-zero latency).
+
+If any step fails, check:
+- Browser console for errors
+- Backend uvicorn logs
+- Supabase Studio (http://localhost:54323) → Logs
+
+## 8. Run Tests
+
+### Backend (pytest)
+
+```bash
+cd backend
+pytest                              # all backend tests
+pytest tests/backend -k "test_games"   # subset
+pytest -x --pdb                     # stop on first fail, drop into debugger
+```
+
+The DB layer tests (`tests/db/`) use **testcontainers** — they spin up an ephemeral Postgres container per test session. Requires Docker running.
+
+### Frontend (vitest)
+
+```bash
+cd frontend
+npm test                            # watch mode
+npm test -- --run                   # single run, exit
+npm test -- --coverage              # coverage report
+```
+
+### E2E (Playwright)
+
+```bash
+cd tests/e2e
+npm install                         # one-time
+npx playwright install              # one-time, installs browsers
+npm test                            # runs against the local stack
+npm test -- --ui                    # interactive mode
+npm test buzzer_race                # specific spec
+```
+
+E2E expects local backend + frontend + Supabase running.
+
+## 9. Common Workflows
+
+### Add a new song manually
+```bash
+psql $DATABASE_URL -c "
+  INSERT INTO songs (title, artist, youtube_id, start_time)
+  VALUES ('My Song', 'Artist', 'abc12345678', 0);
+"
+```
+
+Or via the admin UI: http://localhost:5173/admin/songs (login with `devpass123`).
+
+### Add a new migration
+1. Create `db/migrations/00X_my_change.sql`.
+2. Apply to local: `./db/migrate.sh local`.
+3. Verify in Supabase Studio.
+4. Commit. CI will refuse if it's a syntax error.
+
+### Generate a fresh game code
+Game codes are server-generated by `POST /games`. To create one for testing:
+```bash
+curl -X POST http://localhost:8000/games \
+  -H "X-Admin-Password: devpass123" \
+  -H "Content-Type: application/json" \
+  -d '{"total_rounds": 3, "selected_genres": []}'
+```
+
+(Empty `selected_genres` will be rejected by validation; use a real genre uuid from `SELECT id FROM genres LIMIT 1`.)
+
+### Inspect Realtime traffic
+Open the browser DevTools → Network → WS tab. Filter by "realtime". Click on the WebSocket connection → Messages. You'll see the `postgres_changes` events flowing through.
+
+### Reset everything
+```bash
+supabase db reset                   # wipes Postgres data, re-runs migrations + seed
+rm -rf backend/__pycache__ backend/.pytest_cache
+rm -rf frontend/node_modules/.vite
+```
+
+## 10. Code Style & Linting
+
+### Backend (ruff + mypy)
+
+```bash
+cd backend
+ruff check .                        # lint
+ruff format .                       # format (replaces black)
+mypy app/                           # type check
+```
+
+Pre-commit hook: `pre-commit install` once, then formatting + linting runs on `git commit`.
+
+### Frontend (eslint + prettier)
+
+```bash
+cd frontend
+npm run lint                        # eslint
+npm run format                      # prettier
+npm run type-check                  # tsc --noEmit
+```
+
+CI rejects PRs with lint errors. Fix locally before pushing.
+
+## 11. Troubleshooting
+
+### `supabase start` fails
+
+- Check Docker Desktop is running.
+- `supabase stop` then `supabase start` again.
+- If ports are in use: `supabase status` shows the ports; kill any conflicting process.
+- On Windows: ensure WSL2 backend is enabled in Docker Desktop.
+
+### Backend can't connect to local Supabase
+
+- Verify `SUPABASE_URL=http://localhost:54321` (not `https://`, not the cloud URL).
+- Verify the service-role key matches what `supabase status` reports.
+- Test: `curl http://localhost:54321/rest/v1/genres -H "apikey: $SUPABASE_ANON_KEY"`.
+
+### Frontend can't connect to backend
+
+- Verify CORS: backend `CORS_ORIGINS` must include `http://localhost:5173`.
+- Verify `VITE_API_URL=http://localhost:8000` in frontend `.env`.
+- Hard refresh the browser (changes to `.env` require a Vite restart, not just HMR).
+
+### `buzz_in` RPC returns 401
+
+- The frontend must use the anon key, not the service-role key.
+- Verify the `apikey` header is sent: DevTools → Network → request headers.
+
+### Realtime events not arriving
+
+- Check Supabase Studio → Database → Replication → ensure the table is in the `supabase_realtime` publication.
+- Verify the channel filter matches the row's `game_code`.
+- Check the WebSocket is open in DevTools.
+
+### "Address already in use" on port 8000 / 5173 / 54321
+
+```bash
+# Find the process
+lsof -i :8000        # or :5173, :54321
+# Kill it
+kill -9 <pid>
+```
+
+PowerShell:
+```powershell
+Get-NetTCPConnection -LocalPort 8000 | Select-Object OwningProcess
+Stop-Process -Id <pid>
+```
+
+## 12. Optional: Use a Cloud Preview Supabase
+
+If you don't want to run Docker, you can point local dev at a dedicated cloud Supabase project (`Sound-Clash-Preview`):
+
+- Pros: no Docker; same environment as CI.
+- Cons: data is shared across collaborators; Realtime quotas tick down; slower than local.
+
+To use it: change `.env` files to point to the preview project's URL and keys. The rest of the workflow is identical.
+
+Don't point local dev at the production Supabase project under any circumstances.
+
+## 13. What This Doc Doesn't Cover
+
+- IDE setup (VS Code recommended; install Python + ESLint extensions; that's about it)
+- Debugger configuration (use uvicorn `--reload` + browser DevTools; stretch goal: launch.json for VS Code)
+- Hot-reload of Python (uvicorn `--reload` is good enough; no need for fancier)
+- Mocking the Supabase client in unit tests (see existing tests for patterns)
+
+For anything not covered, ask in a GitHub discussion or read the upstream docs.

--- a/docs/realtime-design.md
+++ b/docs/realtime-design.md
@@ -1,0 +1,288 @@
+# Sound Clash — Realtime Design
+
+This is the central design document of the rewrite. It describes how the system achieves <200ms buzzer latency on a free-tier infrastructure that has no always-on Python WebSocket server. Every other doc references this one for the details below.
+
+## 1. The Problem in One Paragraph
+
+A buzzer game is hard to build on free hosting because the buzzer needs:
+1. **Atomic single-winner ordering** — when two teams tap within milliseconds, exactly one wins.
+2. **Server-authoritative timestamps** — clients can't be trusted to order themselves.
+3. **Low fan-out latency** — all clients see the lock within ~200ms of the press.
+4. **Always-available endpoint** — no cold starts in the press path.
+
+Free-tier Python (Render free / Cloud Run scale-to-zero) violates #4 with multi-second cold starts. Free-tier WebSocket platforms either limit connections (Pusher: 100) or burn through quotas. The current architecture (FastAPI WebSocket service in-process broadcast) cannot cost-effectively run 24/7 for free.
+
+## 2. The Resolution: Take Python Out of the Hot Path
+
+| Concern | Old (FastAPI WS) | New (Supabase Realtime + Postgres RPC) |
+|---|---|---|
+| Atomic lock | Python in-memory `if buzzed_team is None` check | Postgres conditional UPDATE: `WHERE buzzed_team_id IS NULL` |
+| Timestamp authority | Python `datetime.utcnow()` | Postgres `now()` |
+| Fan-out | `asyncio.gather(send_to_each_client)` | Postgres replication → Supabase Realtime |
+| Endpoint availability | Always-on Python WS server | Supabase PostgREST (always on, no cold start) |
+| Hot-path latency | ~50–200ms (with warm process) | ~80–180ms (RTT-bound) |
+| Idle cost | $$ per month | $0 |
+
+The browser calls Postgres directly via PostgREST; Python is never in the buzz path.
+
+## 3. The Hot Path, Step by Step
+
+```
+┌────────────┐  1. supabase.rpc('buzz_in', { p_game_code, p_team_id })
+│ Browser    │ ─────────────────────────────────────────────────────────┐
+│ (team tab) │                                                          │
+└────────────┘                                                          ▼
+                                                          ┌──────────────────────┐
+                                                          │  Supabase PostgREST  │
+                                                          │  /rest/v1/rpc/buzz_in│
+                                                          └──────────┬───────────┘
+                                                                     │
+                                                                     ▼
+                                                  ┌────────────────────────────────────┐
+                                                  │  Postgres: buzz_in() PL/pgSQL       │
+                                                  │  UPDATE active_games               │
+                                                  │     SET buzzed_team_id = p_team_id, │
+                                                  │         locked_at = now()          │
+                                                  │   WHERE game_code = p_game_code    │
+                                                  │     AND status = 'playing'         │
+                                                  │     AND buzzed_team_id IS NULL     │
+                                                  │  RETURNING ...                     │
+                                                  └────────────────┬───────────────────┘
+                                                                   │  (row replicated)
+                                                                   ▼
+                                              ┌──────────────────────────────────────┐
+                                              │  Supabase Realtime broadcast         │
+                                              │  postgres_changes event              │
+                                              └────┬──────────────┬──────────────┬───┘
+                                                   │              │              │
+                                                   ▼              ▼              ▼
+                                             ┌─────────┐    ┌─────────┐    ┌─────────┐
+                                             │ Manager │    │ Display │    │ Other   │
+                                             │ tab     │    │ tab     │    │ teams   │
+                                             └─────────┘    └─────────┘    └─────────┘
+```
+
+### Latency budget (typical, EU user → eu-central-1 Supabase)
+
+| Hop | Time | Notes |
+|---|---|---|
+| Browser → Supabase TLS handshake (reused) | 0–10 ms | Connection kept alive |
+| Browser → Supabase API RTT | 30–60 ms | Geographic |
+| PostgREST dispatch + UPDATE | 5–15 ms | In-memory MVCC, single row |
+| Replication slot pickup | 10–30 ms | Realtime worker polls slot |
+| Realtime → other subscribers | 30–80 ms | WebSocket fan-out |
+| **Caller round-trip** | **45–85 ms** | Buzzer team sees confirmation |
+| **Other clients see lock** | **75–195 ms** | Fan-out total |
+
+**Worst-case acceptable**: ~250ms in adverse network conditions. **Hard fail threshold**: >500ms — investigate.
+
+## 4. Race Correctness
+
+### Why the conditional UPDATE is atomic
+
+Postgres MVCC + row-level locking guarantees:
+
+1. Two concurrent calls to `buzz_in(p_game_code='ABCDEF', ...)` both attempt to UPDATE the same row.
+2. Postgres acquires a row lock. The first transaction proceeds; the second blocks.
+3. The first sees `buzzed_team_id IS NULL`, sets it to its team, commits. Lock released.
+4. The second now reads the post-commit snapshot: `buzzed_team_id` is non-null. The `WHERE buzzed_team_id IS NULL` predicate matches zero rows. UPDATE returns "0 rows affected."
+5. The PL/pgSQL function detects this via `IF NOT FOUND` and returns `locked: false` with the current holder.
+
+This is well-trodden Postgres territory. No advisory locks, no `SELECT FOR UPDATE`, no application-level coordination needed.
+
+### Stress test (Phase 3 exit criterion)
+
+```python
+# tests/db/test_buzz_in_race.py
+async def test_concurrent_buzz_one_winner():
+    game_code = await create_test_game()
+    team_ids = [await create_test_team(game_code) for _ in range(10)]
+    results = await asyncio.gather(*[
+        rpc_buzz_in(game_code, team_id) for team_id in team_ids
+    ])
+    winners = [r for r in results if r["locked"]]
+    assert len(winners) == 1
+```
+
+This test is required to pass 100 consecutive runs before merging Phase 3.
+
+### Why the rest of the system trusts MVCC
+
+`start_round`, `award_points`, `end_game` all use single-row UPDATEs on `active_games`. They serialize on the same row lock as `buzz_in`. The consequence: if a manager calls `start_round` at the same nanosecond a team calls `buzz_in`, one wins and the other sees the post-commit state. Either ordering is valid because both operations are intent-level commands the manager would resolve manually.
+
+## 5. Subscribing to Game State
+
+Each browser opens **one Realtime channel per game** and subscribes to three table change streams (filtered by `game_code`):
+
+- `active_games` — the live game row (status, current round, buzz state)
+- `game_teams` — team list and scores
+- `game_rounds` — round history (used for "song already played" enforcement and the round info card)
+
+The frontend reduces these change streams into a derived state object:
+
+```ts
+interface GameState {
+  game: ActiveGame;            // active_games row
+  teams: Map<string, Team>;    // keyed by team id
+  rounds: GameRound[];         // sorted by round_number
+  currentRound: GameRound | null;  // resolved from game.current_round_id
+}
+```
+
+State updates are applied in the order Realtime delivers events. Postgres replication is ordered per row, but cross-table ordering is not guaranteed. The frontend's reducer is idempotent: applying the same event twice is a no-op.
+
+## 6. Initial State and Reconciliation
+
+When a client subscribes, it does NOT automatically receive a snapshot of current state — Realtime only forwards future changes. Therefore:
+
+```ts
+// 1. Subscribe (sets up the channel; will start receiving events)
+const channel = supabase.channel(`game:${gameCode}`).on(...).on(...).on(...);
+
+// 2. Wait for SUBSCRIBED status
+channel.subscribe(async (status) => {
+  if (status !== 'SUBSCRIBED') return;
+
+  // 3. Now fetch the current state. Any events that happened between
+  //    SUBSCRIBED and this fetch will be applied via the reducer when
+  //    they arrive (idempotent), so no race window.
+  const game = await supabase.from('active_games')
+    .select('*, game_teams(*), game_rounds(*)')
+    .eq('game_code', gameCode)
+    .single();
+  initState(game.data);
+});
+```
+
+The order matters: subscribe first, then fetch. If we fetched first then subscribed, events between fetch and subscribe would be lost.
+
+## 7. Reconnection
+
+`supabase-js` reconnects automatically with exponential backoff (1s, 2s, 4s, ..., capped). On reconnect, it re-establishes the WebSocket and resubscribes existing channels. Missed events during disconnect are NOT replayed — Realtime is not durable.
+
+The recovery strategy:
+
+1. On WebSocket reconnect, the frontend re-fetches the full game state (same query as initial fetch).
+2. The reducer overwrites local state with the fresh fetch.
+3. Future events apply on top.
+
+**Disconnect signaling**: while disconnected, the team UI shows a non-blocking banner ("reconnecting…"). The buzz button is disabled (because the lock state is stale). Once reconnected, normal operation resumes.
+
+### Team identity persistence
+
+A team's identity = `{ game_team_id (uuid), game_code, name }`. Stored in `localStorage`:
+
+```js
+localStorage.setItem(`game:${gameCode}:team`, JSON.stringify({ id, name }));
+```
+
+On page reload, the team page reads `localStorage`, validates that the team still exists in `game_teams` (via SELECT), and resumes. If the team row was deleted (kicked or game expired), the page redirects to the join screen.
+
+## 8. Time Synchronization
+
+Server-authoritative `locked_at` is the source of truth. But for client-side timer countdowns (e.g., the 20-second buzz window), the client needs a way to convert "server time" into "wall-clock progress on this device."
+
+Strategy: **measure the offset once per session, then trust it.**
+
+```ts
+// On first connection or first event with a server timestamp:
+const serverNow = new Date(realtimeEvent.commit_timestamp);
+const clientNow = new Date();
+const offset = serverNow.getTime() - clientNow.getTime();  // ms
+
+// Anywhere we need "now in server time":
+function serverTimeNow(): Date {
+  return new Date(Date.now() + offset);
+}
+```
+
+For the buzz window timer:
+```ts
+const elapsedMs = serverTimeNow().getTime() - new Date(round.started_at).getTime();
+const remainingMs = Math.max(0, 20_000 - elapsedMs);
+```
+
+Offset accuracy is within ~50ms (one half-RTT to Supabase). Good enough for a 20-second timer.
+
+## 9. YouTube IFrame Player Race
+
+The YouTube IFrame Player loads asynchronously. If a `start_round` event arrives before the player is ready, the song doesn't play.
+
+Mitigation: gate the round-active UI behind a `playerReady` boolean.
+
+```ts
+const [playerReady, setPlayerReady] = useState(false);
+const [pendingSongLoad, setPendingSongLoad] = useState<{youtube_id: string, start_time: number} | null>(null);
+
+// On player ready:
+function onPlayerReady() {
+  setPlayerReady(true);
+  if (pendingSongLoad) {
+    player.loadVideoById(pendingSongLoad.youtube_id, pendingSongLoad.start_time);
+    setPendingSongLoad(null);
+  }
+}
+
+// On round started (Realtime event):
+function onRoundStarted(round) {
+  if (playerReady) {
+    player.loadVideoById(round.song.youtube_id, round.song.start_time);
+  } else {
+    setPendingSongLoad(round.song);  // play when ready
+  }
+}
+```
+
+The manager UI also disables the "Start round" button until the player reports ready.
+
+## 10. Failure Modes & Mitigations
+
+| Failure | Detection | Mitigation |
+|---|---|---|
+| Realtime disconnects | `channel.subscribe` callback gets `CLOSED`/`CHANNEL_ERROR` | Show "reconnecting…" banner; disable buzzer; `supabase-js` auto-reconnects |
+| `buzz_in` RPC times out | Promise rejects after 10s timeout | Show "buzz failed, try again"; do NOT retry automatically (could double-press) |
+| `buzz_in` returns network error | Same | Same |
+| Postgres slow query (rare) | RPC RTT > 500ms | Logged client-side via Sentry; investigate; not user-recoverable |
+| Realtime quota exhausted | Channel subscribe fails with quota error | Fail-loud at game-creation time (not mid-game); manager sees "service at capacity" |
+| Render is cold | First request to FastAPI takes ~30s | UI shows "creating game…" spinner; only happens on game creation, not during play |
+| FastAPI is down | API call returns 5xx | Game creation impossible; existing games keep working (Realtime + RPC are independent of FastAPI) |
+| Supabase project is down | Everything fails | Game-day DR: nothing; this is the single point of failure. Free tier accepts this. |
+
+## 11. Single-Manager Invariant
+
+Two browser tabs both authenticated as manager → both can issue admin actions → race conditions at the application level (e.g., two simultaneous `start_round` calls advance round_number twice).
+
+The MVP accepts this and documents it. Mitigation when revisited:
+
+- Use Realtime **presence** to detect multiple manager tabs on the same game.
+- The first to subscribe (oldest presence) is the "active manager." Subsequent tabs see a banner "another manager is active; click here to take over." Taking over revokes the old tab's controls (via a Realtime broadcast).
+
+This is non-trivial UX and is explicitly out of MVP. Today the invariant is "the host runs one tab."
+
+## 12. Why Not Approach X?
+
+| Alternative | Why rejected |
+|---|---|
+| Pusher Channels | 100-connection limit too tight for parallel games; Python still needed for atomic claim → still need warm Python |
+| Cloudflare Durable Objects | Requires a JavaScript runtime; user requested Python primary |
+| Run Python on Fly.io | Free tier requires CC and is being phased out; long-term free not guaranteed |
+| Run Python on Oracle Always Free | Genuine free always-on VM; viable but adds ops burden (own VM, own monitoring, own SSL) — Supabase + Render is lower ops cost |
+| AWS AppSync | Not free tier above small caps; AWS lock-in is what we're moving away from |
+| Roll our own WebSocket on Cloudflare Workers | Reinvents Realtime; Durable Objects already exist; not Python |
+
+The chosen design optimizes for: free, low-ops, Python-friendly, <200ms buzzer. Supabase Realtime + PL/pgSQL satisfies all four.
+
+## 13. Performance Monitoring
+
+Production observability for the hot path:
+
+- **Client-side** (Sentry browser SDK): record `buzz_in` RPC duration as a custom transaction; sample 100% during MVP.
+- **Server-side** (Postgres): log slow queries (`log_min_duration_statement = 100`); review `pg_stat_statements` for `buzz_in` p95.
+- **Realtime metrics** (Supabase dashboard): connection count, message rate, message lag.
+
+Alert thresholds:
+- `buzz_in` RTT p95 > 250ms for 5 minutes → investigate.
+- Realtime message lag > 500ms → investigate.
+- Sentry rate of `buzz_failed` errors > 1% → investigate.
+
+These are tracked in `runbook.md` and `free-tier-budget.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,262 @@
+# Sound Clash — Migration Roadmap
+
+Eight phases (Phase 0 + seven core) from naming/account setup to production cutover. Each phase has a goal, deliverables, exit criteria, dependencies, estimated time, and known risks.
+
+The estimates assume one developer working part-time. They are loose.
+
+The new code lives in **`Sound-Clash`** (GitHub). The current AWS-based code is renamed to **`Sound-Clash-legacy`** (kept read-only for reference).
+
+---
+
+## Phase 0 — Naming & Repo Hygiene
+
+**Goal**: Free up the name `Sound-Clash` for the new codebase by renaming the existing repo to `Sound-Clash-legacy`.
+
+**Deliverables**
+- GitHub: rename `BenArtzi4/Sound-Clash` → `BenArtzi4/Sound-Clash-legacy` (Settings → General → Repository name).
+- Update local clone's remote URL: `git remote set-url origin https://github.com/BenArtzi4/Sound-Clash-legacy.git`
+- Add a `LEGACY.md` to the renamed repo's root: "this is the AWS-based version of Sound Clash. Active development continues at https://github.com/BenArtzi4/Sound-Clash."
+
+**Exit criteria**
+- Old URL `github.com/BenArtzi4/Sound-Clash` redirects to `Sound-Clash-legacy` (GitHub does this automatically).
+- Local `git pull` works on the renamed remote.
+
+**Dependencies**: none
+
+**Estimated time**: 15 minutes
+
+**Risks**: Anyone with a hardcoded old-URL clone needs to update their remote. Low blast radius for a solo project.
+
+---
+
+## Phase 1 — Infrastructure Setup
+
+**Goal**: Provision the free-tier accounts and skeleton the new repo. No code yet.
+
+**Deliverables**
+- New GitHub repo: **`Sound-Clash`** (public to get unlimited Actions minutes)
+- Skeleton repo layout:
+  - `backend/` — FastAPI app placeholder
+  - `frontend/` — React + Vite placeholder
+  - `db/migrations/` — empty
+  - `tests/` — empty
+  - `.github/workflows/` — empty
+  - `docs/` — copies of relevant planning docs from `Sound-Clash-Plan/`
+  - `README.md`, `.gitignore`, `.env.example`
+- Supabase project `Sound-Clash` created (region: matching primary user geography — see `tech-stack.md` §3)
+- Render web service created with `Dockerfile` autodetect
+- Cloudflare Pages project created, linked to GitHub repo
+- DNS records (Cloudflare): `soundclash.org` → Pages; `api.soundclash.org` CNAME → Render
+- GitHub repo secrets configured (full list in `local-development.md` §4 and `runbook.md` §3)
+- cron-job.org keepalive pinging `https://api.soundclash.org/health` every 14 min (see `tech-stack.md` §8)
+
+**Exit criteria**
+- Pushing an empty commit to `main` triggers a green CI run (workflow shell only)
+- `https://soundclash.org` resolves and serves a Pages placeholder page
+- `https://api.soundclash.org/health` returns 200 from Render
+
+**Dependencies**: Phase 0
+
+**Estimated time**: 1 day
+
+**Risks**: DNS propagation delay; Render service link to GitHub may need a manual redeploy after secret changes
+
+---
+
+## Phase 2 — Data Migration
+
+**Goal**: Move the song catalog from the existing AWS RDS / S3 CSV (in `Sound-Clash-legacy`) into Supabase Postgres.
+
+**Deliverables**
+- `scripts/export-songs.py` — re-uses the existing export logic from `Sound-Clash-legacy/scripts/`; outputs `songs.json` and `genres.json`
+- `scripts/import-songs.py` — reads the JSON, inserts into Supabase via `supabase-py` using the service-role key
+- `db/seed/genres.sql` — manual seed of canonical genres (rock, pop, hiphop, classical, soundtrack, ...)
+- `docs/data-migration.md` describing how to re-run the import
+
+**Exit criteria**
+- All songs from the legacy system exist in Supabase `songs` table with correct `youtube_id`, `start_time`, and genre links
+- `SELECT count(*) FROM songs` matches the source-of-truth count
+- Spot-check: 5 random songs play correctly via `https://www.youtube.com/watch?v=<youtube_id>&t=<start_time>`
+
+**Dependencies**: Phase 1 (Supabase project must exist)
+
+**Estimated time**: 1 day
+
+**Risks**: schema mismatch (the legacy system stores `is_soundtrack` differently per service — reconcile during export); duplicate songs in source data
+
+---
+
+## Phase 3 — Postgres Logic
+
+**Goal**: Land the schema, RPC functions, RLS, and pg_cron job. **The buzzer race correctness is proven here, before any frontend.**
+
+**Deliverables**
+- `db/migrations/001_extensions.sql` … `008_seed_genres.sql` — see **`data-model.md`** §7 for the full ordering, **`rpc-functions.md`** for the function bodies, **`security-rls.md`** for the RLS policies
+- `tests/db/test_buzz_in_race.py` — pytest using `testcontainers-postgres` that fires 10 concurrent `buzz_in` calls; asserts exactly one returns `locked=true`
+- `tests/db/test_rls_policies.py` — connects as `anon` role; verifies allowed/denied operations
+- `tests/db/test_cron_cleanup.py` — manually invokes `cleanup_expired_games()`; asserts deletion + cascade
+- `db/migrate.sh` — applies migrations in order via `psql` (used by GitHub Actions and locally)
+
+**Exit criteria**
+- Buzz race test passes 100 times consecutively
+- RLS test confirms anon can SELECT but cannot mutate
+- pg_cron job is registered and visible in `cron.job` table
+
+**Dependencies**: Phase 1 (Supabase) — does not need Phase 2
+
+**Estimated time**: 2 days
+
+**Risks**: pg_cron behavior on Supabase free tier (verify it actually fires); RLS gotchas with `SECURITY DEFINER` functions
+
+---
+
+## Phase 4 — Backend Port
+
+**Goal**: Single FastAPI app on Render replaces the three-service legacy backend. **WebSocket service is deleted entirely** — Supabase Realtime is the replacement.
+
+**Deliverables**
+- `backend/app/main.py` — FastAPI app entry, mounts routers, configures CORS for `soundclash.org`
+- `backend/app/middleware/admin_auth.py` — header check `X-Admin-Password` vs env var, constant-time comparison
+- `backend/app/routers/games.py` — see **`api-contracts.md`** §2 for the endpoint contract
+- `backend/app/routers/admin_songs.py` — admin-gated CRUD + bulk CSV import
+- `backend/app/routers/genres.py` — public GET endpoints
+- `backend/app/db/supabase_client.py` — thin wrapper around `supabase-py`, holds service-role key
+- `backend/Dockerfile` — multi-stage, non-root user, `uvicorn` entrypoint
+- `backend/pyproject.toml` — `fastapi`, `uvicorn`, `supabase`, `pytest`, `httpx`, `ruff`, `mypy`
+- `.github/workflows/backend.yml` — runs ruff, mypy, pytest; on main triggers Render deploy hook
+
+**Exit criteria**
+- `pytest` passes against testcontainers Postgres
+- `curl POST https://api.soundclash.org/games` (with admin header) returns a new game code
+- Admin-gated endpoints return 401 without the password header
+- WebSocket-related code is **not** present (`grep -r websocket backend/` empty)
+
+**Dependencies**: Phase 3
+
+**Estimated time**: 3 days
+
+**Risks**: Render Docker build time + free-tier resource limits; `supabase-py` quirks with service-role auth
+
+---
+
+## Phase 5 — Realtime Wiring & Frontend Port
+
+**Goal**: React frontend works against Supabase Realtime + the new FastAPI backend. The buzzer makes a direct PostgREST RPC call from the browser.
+
+**Deliverables**
+- `frontend/src/lib/supabase.ts` — `createClient(SUPABASE_URL, SUPABASE_ANON_KEY)`, exported singleton
+- `frontend/src/hooks/useGameChannel.ts` — subscribes to `active_games`, `game_teams`, `game_rounds` for a `game_code`; reducer pattern (see **`realtime-design.md`** §5)
+- `frontend/src/hooks/useBuzzer.ts` — calls `supabase.rpc('buzz_in', ...)`; exposes `{ buzz, isLocking, lockedTeam, lockedAt }`
+- Refactored pages: `TeamGameplay.tsx`, `ManagerConsole.tsx`, `DisplayScreen.tsx` — all use the new hooks
+- **Deleted**: `frontend/src/services/websocket/` from legacy code
+- `frontend/src/context/AuthContext.tsx` — kept (admin-password gate UX preserved)
+- `frontend/src/components/YouTubePlayer.tsx` — kept; gated by `playerReady` (see **`realtime-design.md`** §9)
+- `frontend/.env.example` — `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_URL`
+- `frontend/vitest.config.ts` + component tests with mocked Supabase client
+- `_headers` file with CSP (see **`security-rls.md`** §7)
+- `.github/workflows/frontend.yml` — `npm ci`, `vitest run`, `npm run build`, `wrangler pages deploy` on main
+
+**Exit criteria**
+- Local dev: 3 browser tabs (manager + 2 teams + display) play a full game end-to-end
+- Buzzer race in browser: both teams click within ~50ms; exactly one wins; UI agrees across all 4 contexts
+- Admin login works with env-var password
+
+**Dependencies**: Phase 4
+
+**Estimated time**: 5 days
+
+**Risks**: Realtime subscription lifecycle bugs; React strict-mode double-effect; YouTube IFrame Player race with Realtime "round start" events
+
+---
+
+## Phase 6 — End-to-End Testing
+
+**Goal**: Automated proof that the full system works under realistic concurrency, on a real Supabase project, with measured latency.
+
+**Deliverables**
+- `tests/e2e/playwright.config.ts` — multi-context test runner
+- `tests/e2e/buzzer_race.spec.ts` — 4 browser contexts (manager, team1, team2, display); race the buzz; assertions per **`realtime-design.md`** §3
+- `tests/e2e/full_game.spec.ts` — happy-path 3-round game end-to-end
+- `tests/e2e/admin_flows.spec.ts` — admin login + song CRUD via UI
+- `.github/workflows/e2e.yml` — runs Playwright against a dedicated `Sound-Clash-Preview` Supabase project; gates merges to main
+- A separate `Sound-Clash-Preview` Supabase project for E2E isolation
+
+**Exit criteria**
+- Buzzer race test: 100 consecutive runs, 0 failures, p95 latency < 200ms when run from a region close to the Supabase project
+- Full-game test passes
+- All workflows green on main
+
+**Dependencies**: Phase 5
+
+**Estimated time**: 3 days
+
+**Risks**: Playwright timing flakiness; CI runners far from Supabase region inflate measured latency
+
+---
+
+## Phase 7 — Deploy & Cutover
+
+**Goal**: `soundclash.org` traffic moves from the AWS stack (in `Sound-Clash-legacy`) to the new system; AWS resources are torn down; bill goes to $0.
+
+**Deliverables**
+- `docs/runbook.md` — copied from `Sound-Clash-Plan/runbook.md`; ops procedures
+- `docs/aws-teardown-checklist.md` — explicit steps:
+  - `cdk destroy` on `infrastructure-ondemand/` (in `Sound-Clash-legacy`)
+  - `cdk destroy` on `infrastructure/` if anything still up
+  - empty + delete S3 buckets: `ondemand-frontend-…`, `soundclash-songs-data` (only after Supabase has the songs)
+  - delete ECR repos: `ondemand/game-management`, `ondemand/song-management`, `ondemand/websocket-service`
+  - disable + delete CloudFront distribution `E2NIDUY011R5N4` (~15 min)
+  - delete ACM cert
+  - delete CloudWatch log groups
+- DNS cutover: change apex `soundclash.org` from CloudFront to Cloudflare Pages
+- Smoke test: `tests/smoke/post_deploy.sh` — curl health endpoints, confirm a synthetic game can be created and a round can run
+
+**Exit criteria — Definition of Done**
+- [ ] `https://soundclash.org` serves the new frontend
+- [ ] `https://api.soundclash.org/health` returns 200
+- [ ] A real end-to-end game playable from a clean browser session
+- [ ] Smoke-test script passes
+- [ ] AWS Cost Explorer shows $0 forecasted for next month
+- [ ] All AWS resources from the teardown checklist are confirmed deleted
+- [ ] `Sound-Clash-legacy` README updated with `LEGACY.md` pointing at `Sound-Clash`
+- [ ] `Sound-Clash` README has setup, dev, deploy, runbook links
+- [ ] Monitoring active: Render health alerts + Supabase email alerts + Sentry
+- [ ] Rollback plan documented (DNS revert to CloudFront within 24h)
+
+**Dependencies**: Phase 6
+
+**Estimated time**: 1–2 days (plus 24h post-cutover watch period)
+
+**Risks**: DNS propagation; undocumented dependency on the legacy AWS stack; CloudFront teardown takes ~15min
+
+---
+
+## Total
+
+~17–19 working days end to end, parallelizable: Phase 2 can overlap with Phase 3; Phase 5 frontend work can start once Phase 4 API contracts are stable.
+
+## Companion Documents
+
+| Doc | Used in phase(s) |
+|---|---|
+| `architecture.md` | All — read first |
+| `realtime-design.md` | 3, 5, 6 — central design reference |
+| `tech-stack.md` | 1 — provisioning checklist |
+| `data-model.md` | 2, 3 — schema source of truth |
+| `rpc-functions.md` | 3 — function spec |
+| `security-rls.md` | 3, 4, 5 — RLS + auth |
+| `api-contracts.md` | 4, 5 — frontend/backend pact |
+| `game-rules.md` | 4, 5 — gameplay flow |
+| `local-development.md` | All — dev setup |
+| `free-tier-budget.md` | 1, 6, 7 — capacity + alerts |
+| `runbook.md` | 7 onward — ops |
+| `tasks.md` | All — granular tasks |
+
+## Out of Scope (NOT in roadmap)
+
+- Multi-tenant (per-host accounts) — future work; data model leaves room
+- Game history / leaderboards — ephemeral by user choice
+- Direct audio uploads — YouTube-only by design
+- Mobile app — web-only
+- Internationalization — single language for now
+- Frontend state-machine library / Redux — local React state is enough at this scope

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -1,0 +1,439 @@
+# Sound Clash — Postgres RPC Functions
+
+The five PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
+
+This is the spec Phase 3 of the roadmap implements. Functions live in `db/migrations/005_rpc_functions.sql` in the new repo.
+
+## 0. Conventions
+
+- All functions use `SECURITY DEFINER` so they run with the table-owner's privileges (allowing them to bypass RLS for their own writes). Anon callers can only invoke functions that have been explicitly `GRANT EXECUTE ... TO anon`'d.
+- Functions are idempotent where the data model allows (see per-function notes).
+- Error returns use Postgres exception codes: `P0001` for application errors, `P0002` for "no_data_found".
+- Functions are named with `snake_case`. Parameter names prefixed with `p_`.
+- Return types are explicit `TABLE(...)` for multi-column results; void for fire-and-forget ops.
+
+## 1. `buzz_in` — atomic buzzer claim
+
+The hot path. Called by browsers via PostgREST. <100ms RTT.
+
+```sql
+CREATE OR REPLACE FUNCTION buzz_in(
+  p_game_code char(6),
+  p_team_id   uuid
+)
+RETURNS TABLE(locked boolean, locked_team_id uuid, locked_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Atomic conditional UPDATE
+  RETURN QUERY
+  UPDATE active_games ag
+     SET buzzed_team_id = p_team_id,
+         locked_at      = now()
+   WHERE ag.game_code = p_game_code
+     AND ag.status = 'playing'
+     AND ag.buzzed_team_id IS NULL
+  RETURNING true, ag.buzzed_team_id, ag.locked_at;
+
+  -- If the UPDATE didn't match (lock already held or game not playing),
+  -- return the current state so the caller can reconcile its UI.
+  IF NOT FOUND THEN
+    RETURN QUERY
+    SELECT false, ag.buzzed_team_id, ag.locked_at
+      FROM active_games ag
+     WHERE ag.game_code = p_game_code;
+  END IF;
+END $$;
+
+REVOKE ALL ON FUNCTION buzz_in(char, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION buzz_in(char, uuid) TO anon;
+```
+
+### Race correctness
+
+Postgres MVCC + row-level locking guarantees only one concurrent caller can satisfy `buzzed_team_id IS NULL`. See `realtime-design.md` §4 for the full argument.
+
+### Error semantics
+
+| Caller's input | Function returns |
+|---|---|
+| Valid call, lock available | `(locked=true, locked_team_id=<their id>, locked_at=<now>)` |
+| Valid call, lock already held | `(locked=false, locked_team_id=<other team>, locked_at=<earlier>)` |
+| `p_team_id` doesn't exist in `game_teams` | UPDATE proceeds; orphan FK eventually breaks. **Caller is responsible** for sending a valid team id (frontend reads from its localStorage). |
+| `p_game_code` doesn't exist | UPDATE matches 0 rows; SELECT returns 0 rows; PostgREST returns `[]`. Frontend treats as no-op. |
+| Game in `waiting` or `ended` state | Same as "no match"; returns `(locked=false, ...)` if game exists. |
+
+The function does not raise exceptions. All outcomes are encoded in the return value. This keeps the hot path fast (no exception overhead) and the client logic simple.
+
+### Callers
+
+- Browser team page via `supabase.rpc('buzz_in', { p_game_code, p_team_id })`.
+- Phase 3 stress test: `tests/db/test_buzz_in_race.py`.
+
+### Testing
+
+```python
+# tests/db/test_buzz_in_race.py
+async def test_concurrent_buzz_one_winner(db):
+    game_code = await create_test_game(db, status='playing')
+    team_ids = [await create_test_team(db, game_code) for _ in range(10)]
+
+    results = await asyncio.gather(*[
+        db.rpc('buzz_in', {'p_game_code': game_code, 'p_team_id': tid})
+        for tid in team_ids
+    ])
+
+    winners = [r for r in results if r[0]['locked']]
+    assert len(winners) == 1, f"Expected 1 winner, got {len(winners)}"
+
+async def test_buzz_when_no_game(db):
+    result = await db.rpc('buzz_in', {'p_game_code': 'NOPE12', 'p_team_id': uuid4()})
+    assert result == []  # PostgREST empty array
+
+async def test_buzz_when_game_waiting(db):
+    game_code = await create_test_game(db, status='waiting')
+    team_id = await create_test_team(db, game_code)
+    result = await db.rpc('buzz_in', {'p_game_code': game_code, 'p_team_id': team_id})
+    assert result[0]['locked'] is False
+```
+
+Phase 3 exit criterion: the race test passes 100 consecutive runs without a single failure.
+
+## 2. `start_round` — manager advances to next song
+
+Called by FastAPI (`POST /games/{code}/select-song`). Not exposed to anon.
+
+```sql
+CREATE OR REPLACE FUNCTION start_round(
+  p_game_code char(6),
+  p_song_id   uuid
+)
+RETURNS uuid  -- new round id
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_round_id  uuid;
+  v_round_num integer;
+  v_status    text;
+BEGIN
+  -- Verify game state
+  SELECT status, round_number + 1 INTO v_status, v_round_num
+    FROM active_games WHERE game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_status = 'ended' THEN
+    RAISE EXCEPTION 'game_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Insert new round row
+  INSERT INTO game_rounds (game_code, round_number, song_id)
+  VALUES (p_game_code, v_round_num, p_song_id)
+  RETURNING id INTO v_round_id;
+
+  -- Update game state: clear buzz, advance round number, set current song/round
+  UPDATE active_games
+     SET status           = 'playing',
+         round_number     = v_round_num,
+         current_song_id  = p_song_id,
+         current_round_id = v_round_id,
+         buzzed_team_id   = NULL,
+         locked_at        = NULL
+   WHERE game_code = p_game_code;
+
+  RETURN v_round_id;
+END $$;
+
+REVOKE ALL ON FUNCTION start_round(char, uuid) FROM PUBLIC;
+-- No GRANT to anon; only service_role calls this.
+```
+
+### Error semantics
+
+| Failure | Exception |
+|---|---|
+| Game doesn't exist | `P0002 game_not_found` |
+| Game already ended | `P0001 game_already_ended` |
+| Song doesn't exist (orphan FK) | Postgres FK violation |
+
+The FastAPI router translates these into HTTP responses (404, 409).
+
+### Idempotency
+
+Not idempotent. Each call increments `round_number` and creates a new row. Callers must not retry blindly on network error.
+
+### Callers
+
+- FastAPI `POST /games/{code}/select-song` after picking a random song.
+
+## 3. `award_points` — manager evaluates the answer
+
+Called by FastAPI (`POST /games/{code}/award-points`). Not exposed to anon.
+
+```sql
+CREATE OR REPLACE FUNCTION award_points(
+  p_game_code char(6),
+  p_round_id  uuid,
+  p_title     integer DEFAULT 0,
+  p_artist    integer DEFAULT 0,
+  p_source    integer DEFAULT 0,
+  p_timeout   integer DEFAULT 0
+)
+RETURNS TABLE(team_id uuid, points_awarded integer, team_total_score integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id  uuid;
+  v_total    integer;
+  v_round_ended timestamptz;
+BEGIN
+  -- Idempotency check: if round already evaluated, return the prior result
+  SELECT buzzed_team_id, ended_at INTO v_team_id, v_round_ended
+    FROM game_rounds WHERE id = p_round_id AND game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'round_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_round_ended IS NOT NULL THEN
+    RAISE EXCEPTION 'round_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Compute total points (timeout is mutually exclusive with title/artist/source;
+  -- caller responsibility to enforce. Function trusts inputs.)
+  v_total := COALESCE(p_title, 0) + COALESCE(p_artist, 0) + COALESCE(p_source, 0)
+             - COALESCE(p_timeout, 0);
+
+  -- Write round result
+  UPDATE game_rounds
+     SET title_points    = p_title,
+         artist_points   = p_artist,
+         source_points   = p_source,
+         timeout_penalty = p_timeout,
+         ended_at        = now()
+   WHERE id = p_round_id;
+
+  -- Apply points to team's running total (only if a team buzzed)
+  IF v_team_id IS NOT NULL AND p_timeout = 0 THEN
+    UPDATE game_teams SET score = score + v_total WHERE id = v_team_id;
+  END IF;
+
+  -- Reset buzz state on the game so the manager can start the next round
+  UPDATE active_games
+     SET buzzed_team_id = NULL, locked_at = NULL
+   WHERE game_code = p_game_code;
+
+  -- Return summary
+  RETURN QUERY
+  SELECT v_team_id,
+         v_total,
+         COALESCE((SELECT score FROM game_teams WHERE id = v_team_id), 0);
+END $$;
+
+REVOKE ALL ON FUNCTION award_points(char, uuid, integer, integer, integer, integer) FROM PUBLIC;
+```
+
+### Error semantics
+
+| Failure | Exception |
+|---|---|
+| Round doesn't exist | `P0002 round_not_found` |
+| Round already evaluated | `P0001 round_already_ended` |
+| Source points awarded for non-soundtrack song | Not enforced here — FastAPI validates first |
+| Negative point input | Not enforced — caller responsibility (FastAPI validates) |
+
+### Idempotency
+
+Idempotent on `round_id` via the `ended_at IS NOT NULL` check — second call raises an exception that FastAPI maps to a 409 (Conflict). This protects against double-award on retry.
+
+### Edge cases
+
+- **Timeout with no buzz**: caller passes `p_timeout=2`, all others 0. `v_team_id` is NULL → score update skipped. The round row records the timeout penalty.
+- **Buzz with timeout=0 but all components 0**: legitimate "team buzzed, got everything wrong, 0 points." Allowed.
+- **Buzz with timeout > 0**: ambiguous; caller must not send this. Function uses timeout to suppress score update; intent unclear. FastAPI validation rejects.
+
+### Callers
+
+- FastAPI `POST /games/{code}/award-points`.
+
+## 4. `end_game` — manager ends the game
+
+Called by FastAPI (`POST /games/{code}/end`). Not exposed to anon.
+
+```sql
+CREATE OR REPLACE FUNCTION end_game(p_game_code char(6))
+RETURNS timestamptz  -- the ended_at timestamp
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_ended_at timestamptz;
+  v_status   text;
+BEGIN
+  SELECT status, ended_at INTO v_status, v_ended_at
+    FROM active_games WHERE game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_status = 'ended' THEN
+    RAISE EXCEPTION 'game_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE active_games
+     SET status   = 'ended',
+         ended_at = now()
+   WHERE game_code = p_game_code
+   RETURNING ended_at INTO v_ended_at;
+
+  RETURN v_ended_at;
+END $$;
+
+REVOKE ALL ON FUNCTION end_game(char) FROM PUBLIC;
+```
+
+### Error semantics
+
+| Failure | Exception |
+|---|---|
+| Game doesn't exist | `P0002 game_not_found` |
+| Game already ended | `P0001 game_already_ended` |
+
+### Idempotency
+
+Not idempotent on the game-state side (raises on repeat call). FastAPI returns 409 to surface this to the manager UI rather than silently no-oping (a no-op would mask a UI bug).
+
+### Side effects
+
+The pg_cron sweeper (§5) will eventually delete the game row. Setting `status = 'ended'` does not trigger immediate deletion — the game and its scoreboard remain queryable until `expires_at` is reached.
+
+### Callers
+
+- FastAPI `POST /games/{code}/end`.
+
+## 5. `cleanup_expired_games` — pg_cron sweeper
+
+Called by `pg_cron` hourly. Not exposed to anyone else.
+
+```sql
+CREATE OR REPLACE FUNCTION cleanup_expired_games()
+RETURNS integer  -- number of games deleted
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH deleted AS (
+    DELETE FROM active_games
+     WHERE expires_at < now()
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_count FROM deleted;
+
+  RETURN v_count;
+END $$;
+
+REVOKE ALL ON FUNCTION cleanup_expired_games() FROM PUBLIC;
+```
+
+### Behaviour
+
+Deletes every `active_games` row whose `expires_at` has passed. `game_teams` and `game_rounds` cascade-delete via FK (defined in `data-model.md`).
+
+### Schedule
+
+```sql
+SELECT cron.schedule(
+  'cleanup-expired-games',
+  '0 * * * *',                      -- top of every hour
+  $$ SELECT cleanup_expired_games(); $$
+);
+```
+
+### Observability
+
+Cron run history is in `cron.job_run_details`:
+
+```sql
+SELECT jobid, runid, job_pid, database, status, return_message, start_time, end_time
+  FROM cron.job_run_details
+ WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'cleanup-expired-games')
+ ORDER BY start_time DESC LIMIT 10;
+```
+
+The `return_message` shows the integer count of deleted games (success) or an error message.
+
+### Failure modes
+
+| Failure | Effect | Mitigation |
+|---|---|---|
+| pg_cron job paused/disabled | Games accumulate; storage grows | Monitor `cron.job_run_details`; manual `DELETE FROM active_games WHERE expires_at < now();` |
+| Cascade delete blocks (lock contention) | Sweep retries next hour | Acceptable; no urgent action |
+| pg_cron extension not installed | Sweeper never runs | Phase 3 verifies extension is enabled |
+
+### Testing
+
+```python
+# tests/db/test_cron_cleanup.py
+async def test_cleanup_deletes_expired(db):
+    game_code = await create_test_game(db)
+    await db.execute(
+        "UPDATE active_games SET expires_at = now() - interval '1 minute' "
+        "WHERE game_code = $1", game_code)
+    deleted = await db.rpc('cleanup_expired_games')
+    assert deleted >= 1
+    row = await db.fetchrow(
+        "SELECT 1 FROM active_games WHERE game_code = $1", game_code)
+    assert row is None
+```
+
+## 6. Function ↔ Caller Reference Matrix
+
+| Function | Anon callable? | Service role callable? | Called by |
+|---|---|---|---|
+| `buzz_in` | ✅ | ✅ | Browser (team page) |
+| `start_round` | ❌ | ✅ | FastAPI POST /games/.../select-song |
+| `award_points` | ❌ | ✅ | FastAPI POST /games/.../award-points |
+| `end_game` | ❌ | ✅ | FastAPI POST /games/.../end |
+| `cleanup_expired_games` | ❌ | ✅ | pg_cron (hourly), manual ops |
+
+## 7. Why Functions, Not Just Direct UPDATEs?
+
+You could implement these in FastAPI as raw SQL UPDATEs. We don't, because:
+
+1. **Atomicity for `buzz_in`** — must be a single statement, server-side. A function is the cleanest way to express "atomic UPDATE + return current state."
+2. **Race-free RPC for the browser** — the browser must call `buzz_in` directly to bypass Python cold starts. PostgREST exposes only functions and tables; complex logic needs a function.
+3. **Encapsulation** — the function is the contract. Future implementations (e.g., adding tournament mode) can change internals without touching callers.
+4. **Single-place enforcement of state-machine rules** — the `IF v_status = 'ended'` checks live in one place, not scattered across HTTP routes.
+5. **Server-authoritative timestamps** — `now()` runs in the database, not the application. No clock-skew bugs.
+
+The cost is some PL/pgSQL learning curve for the team. Worth it for the hot-path correctness alone.
+
+## 8. What These Functions Don't Do
+
+- **No authentication checks**. Auth lives at the layer above — RLS for anon, FastAPI's admin middleware for service-role calls.
+- **No business-rule validation that depends on external state** (e.g., "is this song already played in this game?"). FastAPI does that before calling the RPC.
+- **No transactional bundling beyond their own scope**. Each function is one transaction; cross-function bundling is the caller's job (rare; the boundaries are well-aligned).
+- **No long-running work**. All functions complete in single-digit milliseconds.
+
+## 9. Migration Notes
+
+These functions are added in `db/migrations/005_rpc_functions.sql`. To modify a function in production:
+
+1. Write a new migration file (e.g., `006_revise_buzz_in.sql`) with `CREATE OR REPLACE FUNCTION ...`.
+2. Apply via `db-migrate` GitHub Actions workflow.
+3. Deploy any caller code changes (FastAPI, frontend) to use the new contract.
+
+`CREATE OR REPLACE` is safe for callers — it doesn't break existing transactions. But changing the **return type or parameter list** is a breaking change; coordinate with caller deploys.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,281 @@
+# Sound Clash — Runbook
+
+How to operate the live system. This is for the on-call human (probably you) — what to do, in what order, when something breaks or needs to change.
+
+For *building* the system, see `roadmap.md` and `tasks.md`. For *quotas*, see `free-tier-budget.md`. This doc is for *day 2+ operations*.
+
+## 0. Where Things Live (single source of truth)
+
+| What | Where | URL / Path |
+|---|---|---|
+| User-facing app | Cloudflare Pages | https://soundclash.org |
+| API | Render | https://api.soundclash.org |
+| Database | Supabase | https://app.supabase.com → project `Sound-Clash` |
+| DNS | Cloudflare | https://dash.cloudflare.com → `soundclash.org` |
+| Source code | GitHub | https://github.com/BenArtzi4/Sound-Clash |
+| Legacy AWS code (read-only reference) | GitHub | https://github.com/BenArtzi4/Sound-Clash-legacy |
+| Error tracking | Sentry | https://sentry.io → project `sound-clash` |
+| Keepalive | cron-job.org | https://console.cron-job.org |
+
+Bookmark these as a folder.
+
+## 1. Deploy a New Version
+
+### 1.1 Backend (FastAPI on Render)
+
+The pipeline:
+```
+git push origin main
+   ↓
+GitHub Actions (.github/workflows/backend.yml)
+   ↓ (on green)
+Render deploy hook fires
+   ↓
+Render builds Docker image, deploys, health-checks
+   ↓
+New version live at api.soundclash.org
+```
+
+Manually trigger from Render dashboard if needed: Service → "Manual Deploy" → "Deploy latest commit."
+
+### 1.2 Frontend (Cloudflare Pages)
+
+Pages auto-deploys on `main` push. The workflow runs `vitest`, builds, and uploads via `wrangler pages deploy`.
+
+Preview deploys: every PR gets a unique URL (`<branch>.sound-clash.pages.dev`). Test there before merging.
+
+### 1.3 Database migrations
+
+Migrations are NOT auto-applied. They run on manual dispatch:
+
+```
+GitHub Actions → "db-migrate" workflow → Run workflow → choose env (preview / prod) → Run
+```
+
+The workflow runs `db/migrate.sh` against the chosen Supabase project URL. Migrations are idempotent — running twice is safe.
+
+**Order of operations for a deploy that includes a migration**:
+1. Open PR with backend code + new migration file.
+2. Merge PR (do NOT deploy backend yet — Render is paused or manual).
+3. Run `db-migrate` workflow against prod.
+4. Verify migration succeeded (check `cron.job_run_details` if it touched cron).
+5. Trigger Render deploy.
+
+This avoids the race where new backend code expects schema that isn't there yet.
+
+## 2. Rollback
+
+### 2.1 Backend rollback
+
+Render dashboard → Service → "Deploys" tab → previous green deploy → "Rollback to this deploy". Effect is immediate (~30 seconds).
+
+If you can't reach Render, you can `git revert` the bad commit and push — the next deploy will roll forward to the reverted state.
+
+### 2.2 Frontend rollback
+
+Cloudflare Pages dashboard → project → "Deployments" → previous deployment → "Rollback to this deployment". Or `git revert` and push.
+
+### 2.3 Database rollback
+
+Postgres migrations are forward-only by design. To revert:
+
+- **Soft revert** (most common): write a new migration that reverses the change. Apply it.
+- **Hard revert** (data corruption only): restore from Supabase backup. Free tier has 1 day of backups; Pro has more.
+
+Supabase free tier does NOT have point-in-time recovery. For prod-impacting incidents, accept that the last full backup is your floor.
+
+### 2.4 DNS rollback (cutover undo)
+
+If the migration cutover fails and you need to send traffic back to the legacy AWS stack:
+1. Cloudflare DNS → `soundclash.org` apex → change CNAME from Pages back to CloudFront distribution `E2NIDUY011R5N4`.
+2. Propagation: ~1 minute on Cloudflare.
+3. Spin AWS back up if it was destroyed (`scripts/ondemand/deploy-all.sh` in the legacy repo).
+
+This rollback path is only available if the AWS stack is still alive. Once you tear it down (Phase 7), the rollback option is gone.
+
+## 3. Secret Rotation
+
+Secrets are stored in three places. Rotating means updating all three (if shared) or just the relevant one.
+
+### 3.1 `ADMIN_PASSWORD`
+
+1. Generate new password (>=16 chars, random).
+2. Update GitHub repo secret `ADMIN_PASSWORD`.
+3. Update Render env var `ADMIN_PASSWORD` (Service → Environment → Edit). Triggers a redeploy.
+4. Tell the host(s) the new password (out-of-band, e.g., in person).
+
+The frontend does NOT have this secret; users enter it via the admin login form.
+
+### 3.2 `SUPABASE_SERVICE_ROLE_KEY`
+
+This one is sensitive — it bypasses RLS. Rotate if leaked.
+
+1. Supabase dashboard → Settings → API → "Reset service role key". (This invalidates all sessions using the old key.)
+2. Update GitHub repo secret `SUPABASE_SERVICE_ROLE_KEY`.
+3. Update Render env var `SUPABASE_SERVICE_ROLE_KEY`. Triggers redeploy.
+4. Verify by hitting an admin endpoint.
+
+### 3.3 `SUPABASE_ANON_KEY` and `SUPABASE_URL`
+
+The anon key is shipped to the browser — it's not really a secret, but rotating it invalidates open browser sessions.
+
+1. Supabase dashboard → Settings → API → "Reset anon key".
+2. Update GitHub repo secrets and Render env vars.
+3. Update Cloudflare Pages env vars (`VITE_SUPABASE_ANON_KEY`, `VITE_SUPABASE_URL`).
+4. Trigger frontend redeploy. Active games will need to refresh.
+
+### 3.4 `RENDER_DEPLOY_HOOK`
+
+1. Render dashboard → Service → Settings → "Deploy Hook" → "Regenerate".
+2. Update GitHub repo secret `RENDER_DEPLOY_HOOK`.
+
+### 3.5 Cloudflare API token
+
+1. Cloudflare dashboard → "My Profile" → API Tokens → revoke + create new.
+2. Update GitHub repo secret `CF_API_TOKEN`.
+
+## 4. Common Issues
+
+### 4.1 "Buzzer is slow"
+
+Symptoms: lock event takes >500ms; users complain.
+
+Triage:
+1. Check Sentry: are `buzz_in` performance entries spiking? Is it client-side (RTT) or server-side (Postgres)?
+2. Check Supabase dashboard → Database → Query Performance: is `buzz_in` slow?
+3. Check Realtime tab: any peer count or message lag warnings?
+4. Try the buzzer yourself from a known-fast network. Compare.
+
+Common causes:
+- Supabase region far from users (deal: pick region matching geography at project creation; not movable without migration).
+- Network congestion (transient; wait it out).
+- Postgres CPU saturation (free tier). Restart project if available; consider Pro upgrade.
+
+### 4.2 "Game won't start" (cold-start)
+
+Symptoms: manager presses "Create game", waits 30+ seconds, then it works.
+
+Cause: Render free tier sleeping after 15min idle. First request wakes it.
+
+Mitigation already in place: cron-job.org pings `/health` every 14 min.
+
+If this is happening, check:
+1. cron-job.org dashboard → is the keepalive job running? Last execution time?
+2. Render dashboard → service status → is it asleep?
+
+If keepalive is broken, fix it. If keepalive is running but service still sleeps, Render may have changed free-tier policy — investigate.
+
+### 4.3 "Realtime updates aren't arriving"
+
+Symptoms: a team buzzes; the manager doesn't see it.
+
+Triage:
+1. Check Supabase dashboard → Realtime tab → connection count and message rate. If 0, Realtime is broken.
+2. Check the affected client's browser DevTools → Network → WS tab. Is the WebSocket open?
+3. Check console for `supabase-js` errors.
+4. Refresh the page — does it work after?
+
+Common causes:
+- WebSocket blocked by firewall (corporate networks, schools). Mitigation: educate user, offer mobile hotspot.
+- Subscription filter mismatch. Verify `filter: 'game_code=eq.XXXXXX'` is correct.
+- Quota exhausted (peers > 200). Check Supabase Realtime tab — if at limit, peers are being rejected. Upgrade to Pro.
+
+### 4.4 "I can't log in as admin"
+
+Symptoms: admin password rejected.
+
+Triage:
+1. Verify Render env var `ADMIN_PASSWORD` (Service → Environment).
+2. Check that the frontend is sending the `X-Admin-Password` header (DevTools → Network → request headers).
+3. Verify it matches what Render expects (typo? leading/trailing whitespace?).
+
+Mitigation: rotate password (§3.1).
+
+### 4.5 "Game expired mid-session"
+
+Symptoms: marathon session crosses 4-hour mark; game vanishes.
+
+Cause: by design (`expires_at` is fixed-from-start; pg_cron sweeps).
+
+Mitigation: end the game before 4 hours, or accept the limitation. Future: make `expires_at` sliding (refresh on activity) — see open items in `realtime-design.md`.
+
+### 4.6 "Songs catalog data lost"
+
+Symptoms: `SELECT count(*) FROM songs` is 0 or much smaller than expected.
+
+Triage:
+1. Check Supabase backup tab. Restore from latest snapshot.
+2. If no usable backup, re-run data migration from legacy AWS RDS (`scripts/import-songs.py`).
+3. Investigate: did someone accidentally drop the table? Check `pg_audit` if enabled.
+
+Songs are durable — they should never be deleted en masse. Loss is an incident.
+
+## 5. Incident Response
+
+### Severity classes
+
+| Class | Definition | Response time |
+|---|---|---|
+| **SEV1** | App unreachable for all users; data loss; security breach | Immediate; drop other work |
+| **SEV2** | Major feature broken (buzzer not working); some users affected | Within 1 hour |
+| **SEV3** | Minor degradation; workaround exists | Same day |
+| **SEV4** | Nuisance; cosmetic | Backlog |
+
+### Response playbook
+
+1. **Acknowledge** — receive the alert; confirm you're investigating (e.g., reply to the email).
+2. **Assess** — check the dashboards in §0. Identify which service is impacted.
+3. **Contain** — if user-impacting, take the bandage step:
+   - Frontend issue? Roll back (§2.2).
+   - Backend issue? Roll back (§2.1).
+   - Supabase issue? You can't roll back a managed service; check Supabase status page (https://status.supabase.com) and post a status to users.
+4. **Diagnose** — find the root cause via logs.
+5. **Fix** — write a fix, test, deploy.
+6. **Postmortem** — for SEV1/SEV2, write a 1-page postmortem in `docs/postmortems/YYYY-MM-DD-<title>.md`. Sections: timeline, impact, root cause, what fixed it, what we'll do to prevent it.
+
+## 6. Backups & Disaster Recovery
+
+### What's backed up
+
+| Data | Backup mechanism | Retention |
+|---|---|---|
+| Songs catalog (`songs`, `genres`, `song_genres`) | Supabase daily backup (free tier) | 1 day |
+| Active game data | Not backed up (ephemeral) | n/a |
+| Source code | GitHub | indefinite |
+| Configuration (env vars, secrets) | Manually documented in 1Password / Bitwarden / wherever | indefinite |
+
+### Recovery scenarios
+
+| Scenario | Recovery |
+|---|---|
+| Bad migration drops a column | Restore from Supabase backup (lose <1 day of data). |
+| Bad code deletes all songs | Same. |
+| Render service deleted | Re-create from Dockerfile + env vars. ~10 min. |
+| Cloudflare Pages project deleted | Re-create, link to GitHub repo. Auto-deploys latest main. ~10 min. |
+| Supabase project deleted | Re-create. Apply all migrations from `db/migrations/`. Re-import songs. ~1 hour. |
+| Domain expires | Re-register; update DNS. |
+
+The system is designed to be **rebuildable from source** — if everything except the GitHub repo is gone, you can reconstruct in under an hour. The songs catalog is the only critical persistent state, and it's regenerable from the legacy CSV (`s3://soundclash-songs-data/songs.csv`) if you keep that file as belt-and-suspenders.
+
+## 7. Routine Maintenance
+
+| Cadence | Task |
+|---|---|
+| Weekly | Glance at Sentry dashboard for new error trends |
+| Weekly | Glance at Supabase Realtime peers/msgs charts |
+| Monthly | Review free-tier utilization (`free-tier-budget.md` thresholds) |
+| Monthly | Review Render bandwidth + service hours |
+| Monthly | Update dependencies (Dependabot PRs) — merge if green |
+| Quarterly | Test rollback procedure (§2) on staging — actually do it |
+| Quarterly | Test backup restore (§6) on a preview project |
+| Annually | Rotate `ADMIN_PASSWORD` (§3.1) |
+| Annually | Rotate Supabase service-role key (§3.2) |
+
+## 8. Emergency Contacts
+
+- **You**: benartzi4@gmail.com
+- **Supabase support** (free tier): community Discord + GitHub issues; no SLA
+- **Render support**: support@render.com (no free-tier SLA)
+- **Cloudflare**: dashboard support tab
+
+For critical production issues on free tiers, expect community-grade support response (hours to days). Plan for self-service recovery.

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -1,0 +1,231 @@
+# Sound Clash — Security & RLS
+
+How the system protects itself. Read this if you're auditing the design or adding new tables/endpoints.
+
+The threat model is small (no PII, no payments, ephemeral game data) but not zero — service-role key leakage, game-code enumeration, and DoS on free-tier infrastructure are all things to address.
+
+## 1. Two-Principal Model
+
+Every interaction with Postgres happens as one of two principals:
+
+| Principal | What they hold | What they can do | Where they execute |
+|---|---|---|---|
+| **anon** | Supabase anon key (public) | Whatever RLS allows | Browser |
+| **service_role** | Supabase service-role key (secret) | Bypass RLS; everything | FastAPI on Render |
+
+There are no other roles in MVP. No `authenticated`, no per-user scoping, no JWTs from Supabase Auth. This is by design (matches today's behavior: admin password + anonymous teams).
+
+The anon key ships in the frontend bundle — it's not a secret. RLS policies prevent it from being abused.
+
+The service-role key is server-only. **It must never reach the browser.** The build pipeline for the frontend has zero environment variables prefixed `SUPABASE_SERVICE_ROLE_*` available; only `VITE_SUPABASE_ANON_KEY` and `VITE_SUPABASE_URL`. Verified in CI.
+
+## 2. RLS Policy Matrix
+
+| Table | anon SELECT | anon INSERT | anon UPDATE | anon DELETE |
+|---|---|---|---|---|
+| `songs`         | ✅ (all rows) | ❌ | ❌ | ❌ |
+| `genres`        | ✅ (all rows) | ❌ | ❌ | ❌ |
+| `song_genres`   | ✅ (all rows) | ❌ | ❌ | ❌ |
+| `active_games`  | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
+| `game_teams`    | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
+| `game_rounds`   | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
+
+`service_role` bypasses all RLS.
+
+| RPC function | anon EXECUTE | service_role EXECUTE |
+|---|---|---|
+| `buzz_in`               | ✅ | ✅ |
+| `start_round`           | ❌ | ✅ |
+| `award_points`          | ❌ | ✅ |
+| `end_game`              | ❌ | ✅ |
+| `cleanup_expired_games` | ❌ | ✅ |
+
+### Why anon can SELECT any game
+
+Game codes are 6 chars from a 32-character alphabet → ~1 billion combinations. Knowing a code IS the auth. This matches today's behaviour (anyone with the code can join). RLS doesn't try to prevent enumeration — it would require per-game JWTs, which are not in MVP.
+
+### Policies (DDL)
+
+```sql
+ALTER TABLE songs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE genres       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE song_genres  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE active_games ENABLE ROW LEVEL SECURITY;
+ALTER TABLE game_teams   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE game_rounds  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "anon_read_songs"        ON songs        FOR SELECT TO anon USING (true);
+CREATE POLICY "anon_read_genres"       ON genres       FOR SELECT TO anon USING (true);
+CREATE POLICY "anon_read_song_genres"  ON song_genres  FOR SELECT TO anon USING (true);
+CREATE POLICY "anon_read_active_games" ON active_games FOR SELECT TO anon USING (true);
+CREATE POLICY "anon_read_game_teams"   ON game_teams   FOR SELECT TO anon USING (true);
+CREATE POLICY "anon_read_game_rounds"  ON game_rounds  FOR SELECT TO anon USING (true);
+```
+
+No `INSERT`, `UPDATE`, or `DELETE` policies are created for `anon` → all writes are denied by default.
+
+### Function grants
+
+```sql
+REVOKE ALL ON FUNCTION buzz_in(char, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION buzz_in(char, uuid) TO anon;
+
+-- All other functions: no GRANT to anon. Only service_role can call.
+```
+
+## 3. Realtime Subscriptions
+
+Supabase Realtime respects RLS for `postgres_changes` events. An anon subscriber receives an event only if their RLS policies would have allowed them to SELECT the row.
+
+For Sound Clash, `anon` can SELECT any game row → anon receives every game's events globally. **This is fine** because:
+- Filters at subscription time (`filter: 'game_code=eq.XXXXXX'`) ensure clients only get events for their game.
+- Events contain no sensitive data (just team names and scores).
+
+If we ever add per-user scoping, RLS policies become more restrictive and Realtime auto-respects them.
+
+## 4. Threat Model
+
+| Threat | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **Service-role key leak** (e.g., committed to git) | Medium | Critical (full DB access) | Pre-commit hook scanning for `eyJ` JWTs; GitHub secret scanning; Sentry leak detection |
+| **Anon key abuse** | Low | Low | Anon can only SELECT + buzz; no privileged operations |
+| **Game-code enumeration** | Medium | Low (just join a stranger's game) | Accepted; can mitigate by lengthening code to 8 chars (~10^12 combos) |
+| **DoS via game-creation spam** | Medium | Medium (storage growth, FastAPI exhausted) | Rate limit `POST /games` to 10/min/IP at FastAPI; Cloudflare DDoS protection upstream |
+| **DoS via team-join spam** | Medium | Low (UNIQUE constraint catches dupes) | Rate limit `POST /games/.../teams` to 30/min/IP |
+| **DoS via buzz spam** | Low | Low (Postgres handles concurrency) | Postgres MVCC; no app-level rate limit needed |
+| **Cross-site request forgery (CSRF)** | Low | Low | No cookies; admin auth is a header (not auto-sent by browser); SameSite N/A |
+| **XSS via team name** | Low | Medium (admin views injected names) | React auto-escapes; never use `dangerouslySetInnerHTML` for user-supplied content; CSP header |
+| **Realtime quota exhaustion** | Medium | Medium (game-day outage) | Alert at 75% utilization; document max-concurrent-games limit |
+| **Admin password brute force** | Low | High (full admin access) | 16+ char strong password; rate limit admin endpoints to 100/min/IP |
+| **YouTube ID injection** (admin endpoint) | Low | Low | Validate as 11-char alphanumeric+`-_`; reject others |
+| **SQL injection** | Low | Critical | Use parameterized queries everywhere (`supabase-py` does this); functions use prepared parameters |
+
+## 5. Secret Inventory
+
+What secrets exist, where they live, who sees them:
+
+| Secret | Storage | Visible to |
+|---|---|---|
+| `SUPABASE_ANON_KEY`, `SUPABASE_URL` | Frontend bundle, GitHub secrets, Render env, Cloudflare Pages env | Everyone (intentional) |
+| `SUPABASE_SERVICE_ROLE_KEY` | GitHub secrets, Render env | Server-only |
+| `ADMIN_PASSWORD` | GitHub secrets, Render env | Server + manager humans |
+| `RENDER_DEPLOY_HOOK` | GitHub secrets | CI only |
+| `CF_API_TOKEN` | GitHub secrets | CI only |
+| Postgres direct connection string | Supabase dashboard, **never** in repo | Operator only (rare use) |
+| Sentry DSN (frontend) | Public; rate-limit by Sentry side | Everyone |
+| Sentry DSN (backend) | Render env | Server only |
+
+Rotation procedures: see `runbook.md` §3.
+
+## 6. Rate Limiting
+
+FastAPI uses `slowapi` (in-memory, per-instance — fine for single Render instance):
+
+```python
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)
+
+@router.post("/games")
+@limiter.limit("10/minute")
+async def create_game(...):
+    ...
+```
+
+| Endpoint | Limit | Reason |
+|---|---|---|
+| `POST /games` | 10/min/IP | Prevent game-code spam |
+| `POST /games/*/teams` | 30/min/IP | Prevent team-spam DoS |
+| `POST /admin/songs/bulk-import` | 5/min/IP | Heavy CSV processing |
+| All `/admin/*` | 100/min/IP | Conservative cap on admin endpoints |
+| `GET /health` | unlimited | Used by keepalive |
+| `GET /genres` | unlimited | Cached, cheap |
+
+`buzz_in` (PostgREST RPC) is NOT rate-limited — Postgres handles concurrency safely. If abuse is observed, add Postgres-level rate limit via `pg_throttle` extension.
+
+## 7. CSP and HTTP Headers
+
+Frontend served by Cloudflare Pages. Configure via `_headers` file:
+
+```
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io
+```
+
+Notes:
+- `'unsafe-inline'` for scripts is needed by Vite's runtime + YouTube IFrame Player. Tighten in a future hardening pass with hashes.
+- `frame-src https://www.youtube.com` is required for the IFrame Player.
+- `connect-src` allows Supabase (REST + Realtime), backend API, and Sentry ingest only.
+
+Backend (FastAPI) sets:
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (Render terminates TLS; HSTS still useful)
+- `X-Content-Type-Options: nosniff`
+
+## 8. Input Validation
+
+All API inputs validated with Pydantic (FastAPI auto-validates request bodies):
+
+```python
+class CreateGameRequest(BaseModel):
+    total_rounds: conint(ge=1, le=50) = 10
+    selected_genres: conlist(UUID, min_length=1)
+
+class JoinTeamRequest(BaseModel):
+    name: constr(strip_whitespace=True, min_length=1, max_length=30)
+```
+
+YouTube ID validation: `re.match(r'^[A-Za-z0-9_-]{11}$', youtube_id)`.
+
+Game code validation: `re.match(r'^[A-Z2-9]{6}$', game_code)` (excludes ambiguous chars).
+
+Reject anything that doesn't fit. Don't try to "fix" invalid input.
+
+## 9. Logging & Sensitive Data
+
+- **Never log secrets**. Add a logging filter that scrubs `SUPABASE_SERVICE_ROLE_KEY`, `ADMIN_PASSWORD` from log messages.
+- **Never log admin passwords from request headers**. The middleware reads the header, validates, then drops it from the request context.
+- **Game codes ARE logged** (low sensitivity; expires in 4h anyway).
+- **Team names ARE logged** (entered by users; non-PII assumption).
+- Sentry `beforeSend` hook scrubs known sensitive fields.
+
+## 10. Auth Failure Modes
+
+| Scenario | Behaviour |
+|---|---|
+| `X-Admin-Password` header missing | 401 Unauthorized, generic message ("admin authentication required") |
+| `X-Admin-Password` wrong | 401 Unauthorized, generic message (do NOT distinguish "wrong password" from "missing" — info leak) |
+| Anon key omitted on Supabase RPC | PostgREST 401 |
+| Service-role key omitted on FastAPI internal call | Should never happen — code path bug; alert via Sentry |
+
+The auth middleware uses constant-time comparison (`secrets.compare_digest`) to prevent timing attacks on the admin password.
+
+## 11. Dependency Security
+
+- Dependabot enabled on the repo for `pip` and `npm`.
+- Auto-merge low-severity patch updates.
+- Manual review for major version bumps.
+- Quarterly: review `pip-audit` and `npm audit` reports.
+
+## 12. What This Doc Doesn't Cover
+
+- **GDPR / privacy regulations**: there is no PII collected (team names are user-chosen pseudonyms), no cookies (sessionStorage only), no third-party tracking. A privacy notice on the site explains this. Not covered here.
+- **Terms of Service**: out of scope.
+- **Penetration testing**: not budgeted; rely on the small attack surface and dependency hygiene.
+- **Audit logging**: not implemented; game data is ephemeral so post-hoc audit is futile. Sentry provides incidental error trail.
+- **Bug bounty**: not in scope at MVP.
+
+## 13. Future Hardening
+
+Listed for awareness, not in MVP:
+
+- Replace admin password with Supabase Auth (manager accounts)
+- Issue per-game JWT to teams on join → tighten RLS to per-game scope
+- Tighten CSP (remove `'unsafe-inline'`, use script hashes)
+- Add `pg_throttle` for RPC-level rate limiting
+- Add CAPTCHA on team-join if bot abuse appears
+- Lengthen game code to 8 chars if enumeration becomes a real concern

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,199 @@
+# Sound Clash — Task List
+
+Granular, checkboxed tasks grouped by area. Tasks within an area are roughly ordered, but cross-area parallelism is fine where dependencies allow. Each task should be small enough to ship as one PR.
+
+The new repo is **`Sound-Clash`** (GitHub). The legacy AWS-based repo is **`Sound-Clash-legacy`**.
+
+## Phase 0 — Naming
+
+- [ ] **NAME-01** Rename GitHub repo `BenArtzi4/Sound-Clash` → `BenArtzi4/Sound-Clash-legacy` (Settings → General → Repository name). GitHub auto-redirects the old URL.
+- [ ] **NAME-02** Update local clone's remote: `git remote set-url origin https://github.com/BenArtzi4/Sound-Clash-legacy.git`
+- [ ] **NAME-03** Add `LEGACY.md` at the root of the renamed repo: "AWS-based Sound Clash. Active development at https://github.com/BenArtzi4/Sound-Clash."
+
+## Infrastructure
+
+- [ ] **INFRA-01** Create new GitHub repo **`Sound-Clash`** (public, MIT license)
+- [ ] **INFRA-02** Add baseline files: `.gitignore`, `.env.example`, `README.md`, `LICENSE`, `CODEOWNERS`
+- [ ] **INFRA-03** Skeleton directory layout: `backend/`, `frontend/`, `db/migrations/`, `db/seed/`, `tests/`, `scripts/`, `docs/`, `.github/workflows/`
+- [ ] **INFRA-04** Copy planning docs from `Sound-Clash-Plan/` into new repo's `docs/` (architecture, realtime-design, data-model, rpc-functions, security-rls, api-contracts, game-rules, tech-stack, runbook, free-tier-budget, local-development)
+- [ ] **INFRA-05** Create Supabase project `Sound-Clash` (region: closest to primary users — see `tech-stack.md` §3); record project URL + anon key + service-role key
+- [ ] **INFRA-06** Enable Postgres extensions in Supabase: `pg_cron`, `pgcrypto`
+- [ ] **INFRA-07** Create dedicated `Sound-Clash-Preview` Supabase project for E2E (see `local-development.md` §12)
+- [ ] **INFRA-08** Create Render web service, link to GitHub repo, autodetect Dockerfile in `backend/`
+- [ ] **INFRA-09** Create Cloudflare Pages project, link to GitHub repo; build command `npm run build`, output `frontend/dist`
+- [ ] **INFRA-10** Add DNS records in Cloudflare: apex `soundclash.org` → Pages; `api.soundclash.org` CNAME → Render
+- [ ] **INFRA-11** Add GitHub repo secrets: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_PREVIEW_URL`, `SUPABASE_PREVIEW_SERVICE_ROLE_KEY`, `ADMIN_PASSWORD`, `RENDER_DEPLOY_HOOK`, `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `SENTRY_DSN_FRONTEND`, `SENTRY_DSN_BACKEND`
+- [ ] **INFRA-12** Add Render env vars: same secrets minus CF_*; plus `LOG_LEVEL`, `CORS_ORIGINS`
+- [ ] **INFRA-13** Add Cloudflare Pages env vars: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_URL`, `VITE_SENTRY_DSN`
+- [ ] **INFRA-14** cron-job.org: register, add a job pinging `https://api.soundclash.org/health` every 14 min
+- [ ] **INFRA-15** Sentry: create project `sound-clash`; record DSNs (frontend + backend separately)
+- [ ] **INFRA-16** Configure Supabase email alerts: free-tier dashboards → set thresholds per `free-tier-budget.md` §4
+
+## Auth & Security
+
+- [ ] **AUTH-01** Implement `backend/app/middleware/admin_auth.py`: header check `X-Admin-Password` vs env var, **constant-time comparison** (`secrets.compare_digest`)
+- [ ] **AUTH-02** Apply admin middleware to `/admin/*` and `POST /games`, `POST /games/*/select-song`, `POST /games/*/award-points`, `POST /games/*/end`, `DELETE /games/*/teams/*`
+- [ ] **AUTH-03** Frontend: keep existing `AuthContext.tsx` pattern; on admin pages, send `X-Admin-Password` header on every API call via `frontend/src/lib/api.ts` interceptor
+- [ ] **AUTH-04** RLS policies SQL — see `security-rls.md` §2
+- [ ] **AUTH-05** Function grants: `GRANT EXECUTE ON FUNCTION buzz_in TO anon`; revoke all others from PUBLIC
+- [ ] **AUTH-06** CSP `_headers` file in frontend — see `security-rls.md` §7
+- [ ] **AUTH-07** Backend security headers (HSTS, X-Content-Type-Options) via FastAPI middleware
+- [ ] **AUTH-08** Verify in CI: no `SUPABASE_SERVICE_ROLE_*` env vars are exposed to the frontend bundle. Add a check that fails the frontend build if found.
+- [ ] **AUTH-09** Pre-commit hook scanning for committed JWT-shaped strings (catches accidental key leaks)
+- [ ] **AUTH-10** Rate limit config in FastAPI via `slowapi` — see `security-rls.md` §6 for limits
+- [ ] **AUTH-11** Document secret rotation procedure (covered in `runbook.md` §3)
+
+## Database — Postgres
+
+- [ ] **DB-01** `db/migrations/001_extensions.sql` — `CREATE EXTENSION IF NOT EXISTS pg_cron, pgcrypto`
+- [ ] **DB-02** `db/migrations/002_durable_tables.sql` — `songs`, `genres`, `song_genres` (per `data-model.md` §2)
+- [ ] **DB-03** `db/migrations/003_ephemeral_tables.sql` — `active_games`, `game_teams`, `game_rounds`, deferred FKs
+- [ ] **DB-04** `db/migrations/004_indexes.sql` — per `data-model.md` §3
+- [ ] **DB-05** `db/migrations/005_rpc_functions.sql` — `buzz_in`, `start_round`, `award_points`, `end_game`, `cleanup_expired_games` (full bodies in `rpc-functions.md`)
+- [ ] **DB-06** `db/migrations/006_rls_policies.sql` — enable RLS, anon SELECT policies, function grants
+- [ ] **DB-07** `db/migrations/007_cron_jobs.sql` — `cron.schedule('cleanup-expired-games', '0 * * * *', ...)`
+- [ ] **DB-08** `db/seed/genres.sql` — initial genre list (rock, pop, hiphop, classical, soundtrack, jazz, electronic, ...)
+- [ ] **DB-09** `db/migrate.sh` — applies migrations in order via `psql`; supports `local`/`preview`/`prod` targets
+- [ ] **DB-10** `.github/workflows/db-migrate.yml` — manual-dispatch workflow that applies migrations to chosen environment
+
+## Backend — Python (FastAPI)
+
+- [ ] **PY-01** `backend/pyproject.toml` with deps: `fastapi`, `uvicorn[standard]`, `supabase`, `pydantic`, `python-multipart` (for CSV upload), `slowapi`, `sentry-sdk[fastapi]`; dev: `pytest`, `pytest-asyncio`, `httpx`, `testcontainers[postgres]`, `ruff`, `mypy`
+- [ ] **PY-02** `backend/Dockerfile` — multi-stage, non-root user, uvicorn entry on `$PORT`
+- [ ] **PY-03** `backend/app/main.py` — FastAPI app, CORS for `soundclash.org`, mounts routers, `/health` endpoint, Sentry init, slowapi init
+- [ ] **PY-04** `backend/app/db/supabase_client.py` — singleton client using service-role key
+- [ ] **PY-05** `backend/app/routers/games.py` per `api-contracts.md` §2:
+  - `POST /games` (admin-gated)
+  - `POST /games/{code}/teams`
+  - `POST /games/{code}/select-song` (admin-gated; calls `start_round` RPC)
+  - `POST /games/{code}/award-points` (admin-gated; calls `award_points` RPC)
+  - `POST /games/{code}/end` (admin-gated; calls `end_game` RPC)
+  - `DELETE /games/{code}/teams/{team_id}` (admin-gated)
+- [ ] **PY-06** `backend/app/routers/admin_songs.py` — admin-gated GET/POST/PUT/DELETE; bulk CSV import endpoint with idempotency on `youtube_id`
+- [ ] **PY-07** `backend/app/routers/genres.py` — public GET `/genres`
+- [ ] **PY-08** `backend/app/services/game_code.py` — generator: 6 chars from `ABCDEFGHJKMNPQRSTUVWXYZ23456789`; collision retry
+- [ ] **PY-09** `backend/app/services/song_picker.py` — random song with `selected_genres` filter and "no repeats per game" enforcement
+- [ ] **PY-10** Pydantic request/response models matching `api-contracts.md`
+- [ ] **PY-11** Validation: YouTube ID regex `^[A-Za-z0-9_-]{11}$`; team name 1–30 chars
+- [ ] **PY-12** Error handler middleware mapping Postgres P0001/P0002 → HTTP 4xx codes
+- [ ] **PY-13** Confirm zero WebSocket code: `grep -ri 'websocket\|socket.io' backend/` returns nothing
+
+## Realtime / Frontend
+
+- [ ] **FE-01** `frontend/package.json` — React 18, TypeScript 5, Vite 5, `@supabase/supabase-js`, `react-router-dom`, `vitest`, `@testing-library/react`, `@sentry/react`
+- [ ] **FE-02** `frontend/.env.example` — `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_URL`, `VITE_SENTRY_DSN`
+- [ ] **FE-03** `frontend/src/lib/supabase.ts` — exported singleton client
+- [ ] **FE-04** `frontend/src/lib/api.ts` — typed REST client for FastAPI; sends `X-Admin-Password` from session for admin calls
+- [ ] **FE-05** `frontend/src/hooks/useGameChannel.ts` — Realtime subscription with reducer pattern (per `realtime-design.md` §5–6); subscribes then fetches initial state
+- [ ] **FE-06** `frontend/src/hooks/useBuzzer.ts` — `supabase.rpc('buzz_in', ...)`; exposes `{ buzz, isLocking, lockedTeam, lockedAt }`; Sentry transaction wrap
+- [ ] **FE-07** `frontend/src/hooks/useServerTime.ts` — measures server-client clock offset on first event; exposes `serverTimeNow()` (per `realtime-design.md` §8)
+- [ ] **FE-08** `frontend/src/hooks/usePlayerReady.ts` — gates round-active UI behind YouTube IFrame player readiness (per `realtime-design.md` §9)
+- [ ] **FE-09** Refactor `TeamGameplay.tsx`: use `useGameChannel` + `useBuzzer`; persist team identity in `localStorage` (per `game-rules.md` §7)
+- [ ] **FE-10** Refactor `ManagerConsole.tsx`: live state from `useGameChannel`; control actions call FastAPI; YouTube IFrame Player retained; player-ready gate
+- [ ] **FE-11** Refactor `DisplayScreen.tsx`: live state from `useGameChannel`; YouTube IFrame Player retained; large-screen styling
+- [ ] **FE-12** Decision + impl: team page omits YouTube embed (recommended; per `game-rules.md` §12)
+- [ ] **FE-13** Delete legacy WebSocket code: `frontend/src/services/websocket/` and any `socket.io` references
+- [ ] **FE-14** Reconnection banner: while `channel` not subscribed, show "reconnecting…" non-blocking banner; disable buzz button
+- [ ] **FE-15** Game-expired handler: detect Realtime DELETE on `active_games`; redirect to "game expired" screen
+- [ ] **FE-16** Kicked-team handler: detect Realtime DELETE on own `game_teams` row; redirect to join screen
+- [ ] **FE-17** Keep `AuthContext.tsx` admin password gate; verify `ProtectedRoute` still works
+- [ ] **FE-18** Routes: `/`, `/manager/create`, `/manager/lobby/:code`, `/manager/game/:code`, `/team/join`, `/team/:code`, `/display/join`, `/display/:code`, `/admin/songs`
+- [ ] **FE-19** `_headers` file with CSP (per `security-rls.md` §7)
+- [ ] **FE-20** Sentry init in `main.tsx` with `beforeSend` scrubbing team names
+- [ ] **FE-21** Confirm zero legacy WebSocket client code: `grep -ri 'WebSocket\|socket.io' frontend/src/` returns nothing app-level
+
+## Testing
+
+- [ ] **TEST-01** `tests/db/test_buzz_in_race.py` — testcontainers Postgres + 10 concurrent `buzz_in` calls; exactly one wins; **must pass 100 consecutive runs** (Phase 3 exit criterion)
+- [ ] **TEST-02** `tests/db/test_buzz_in_edge_cases.py` — buzz when game waiting; buzz when game ended; buzz with bad UUID; lock-already-held returns false
+- [ ] **TEST-03** `tests/db/test_rls_policies.py` — connects as `anon`; asserts allowed SELECTs and denied mutations
+- [ ] **TEST-04** `tests/db/test_cron_cleanup.py` — insert game with past `expires_at`; manually invoke `cleanup_expired_games()`; assert deletion + cascade
+- [ ] **TEST-05** `tests/db/test_award_points_idempotency.py` — call `award_points` twice on same round; second call raises `round_already_ended`
+- [ ] **TEST-06** `tests/backend/test_games_router.py` — full happy path: create → join × 2 → start round × 3 → award × 3 → end
+- [ ] **TEST-07** `tests/backend/test_admin_auth.py` — 401 without header; 200 with correct; 401 with wrong; constant-time comparison
+- [ ] **TEST-08** `tests/backend/test_rate_limits.py` — exceed `POST /games` rate limit; assert 429
+- [ ] **TEST-09** `tests/backend/test_admin_songs.py` — full CRUD + bulk import idempotency
+- [ ] **TEST-10** `tests/backend/test_validation.py` — bad YouTube IDs, oversized team names, empty genres list
+- [ ] **TEST-11** `frontend/src/hooks/useBuzzer.test.ts` — vitest with mocked Supabase client
+- [ ] **TEST-12** `frontend/src/hooks/useGameChannel.test.ts` — vitest; subscribe → event applied → state updated
+- [ ] **TEST-13** `frontend/src/components/*.test.tsx` — at least 5 component tests covering critical UI states
+- [ ] **TEST-14** `tests/e2e/playwright.config.ts` — multi-context base, runs against preview Supabase
+- [ ] **TEST-15** `tests/e2e/buzzer_race.spec.ts` — 4 contexts (manager, team1, team2, display); race the buzz; deterministic outcome and < 200ms p95 latency
+- [ ] **TEST-16** `tests/e2e/full_game.spec.ts` — 3-round happy path
+- [ ] **TEST-17** `tests/e2e/reconnection.spec.ts` — team disconnects mid-game; rejoin; state correct
+- [ ] **TEST-18** `tests/e2e/admin_flows.spec.ts` — admin login + song CRUD via UI
+- [ ] **TEST-19** `tests/e2e/expiration.spec.ts` — game with `expires_at` set to 1 sec in past; trigger cron manually; verify all clients redirect
+- [ ] **TEST-20** Coverage: `pytest --cov=app` (backend), `vitest --coverage` (frontend); upload to Codecov free tier
+
+## CI/CD
+
+- [ ] **CI-01** `.github/workflows/backend.yml` — on PR + main: `ruff check`, `ruff format --check`, `mypy`, `pytest`; on main only: trigger `RENDER_DEPLOY_HOOK`
+- [ ] **CI-02** `.github/workflows/frontend.yml` — on PR + main: `npm ci`, `tsc --noEmit`, `eslint`, `vitest run`, `npm run build`; on main only: `wrangler pages deploy`
+- [ ] **CI-03** `.github/workflows/e2e.yml` — on PR (label `run-e2e`) + main: Playwright against `Sound-Clash-Preview` Supabase project
+- [ ] **CI-04** `.github/workflows/db-migrate.yml` — manual dispatch; runs migrations against chosen environment (preview / prod)
+- [ ] **CI-05** Branch protection on `main`: require backend + frontend workflows green; require 1 review (or admin override for solo work)
+- [ ] **CI-06** Dependabot config for `pip` and `npm` (weekly; auto-merge low-severity patch updates)
+- [ ] **CI-07** Add Codecov badges to README
+- [ ] **CI-08** Pre-commit hook: ruff + prettier (frontend); on each commit
+- [ ] **CI-09** Verification step in `frontend.yml`: build artifact must not contain `service_role` (catches accidental leak)
+
+## Deployment / Cutover
+
+- [ ] **DEPLOY-01** First production deploy of backend to Render; verify `/health` 200
+- [ ] **DEPLOY-02** First production deploy of frontend to Cloudflare Pages; verify static load
+- [ ] **DEPLOY-03** Run `db-migrate` workflow against prod Supabase; verify schema and seed
+- [ ] **DEPLOY-04** Run data import (Phase 2 scripts) against prod; verify song count
+- [ ] **DEPLOY-05** Manual smoke test: create game → 2 teams join → 3 rounds → end → verify scoreboard → wait for cron sweep → verify game row deleted
+- [ ] **DEPLOY-06** `tests/smoke/post_deploy.sh` — automated smoke test for use after every deploy
+- [ ] **DEPLOY-07** DNS cutover: switch apex `soundclash.org` from CloudFront to Cloudflare Pages
+- [ ] **DEPLOY-08** Monitor 24h: error rates on Render, Supabase logs, Sentry, browser console reports from real game sessions
+- [ ] **DEPLOY-09** AWS teardown — execute `docs/aws-teardown-checklist.md`:
+  - [ ] `cdk destroy` on `infrastructure-ondemand/` in `Sound-Clash-legacy`
+  - [ ] `cdk destroy` on `infrastructure/` if anything still up
+  - [ ] empty + delete S3 buckets `ondemand-frontend-*`, `soundclash-songs-data`
+  - [ ] delete ECR repos `ondemand/game-management`, `ondemand/song-management`, `ondemand/websocket-service`
+  - [ ] disable + delete CloudFront distribution `E2NIDUY011R5N4`
+  - [ ] delete ACM cert
+  - [ ] delete CloudWatch log groups
+  - [ ] confirm in AWS Cost Explorer: $0 forecast for next month
+- [ ] **DEPLOY-10** `Sound-Clash-legacy`: confirm `LEGACY.md` is in place
+- [ ] **DEPLOY-11** Add monitoring: Render health alert email; Supabase email alerts; Sentry alerts (per `runbook.md` §4 thresholds)
+- [ ] **DEPLOY-12** Run capacity-planning worksheet (`free-tier-budget.md` §9) for the first scheduled tournament
+
+## Documentation
+
+- [ ] **DOC-01** `README.md` — what the project is, quick start, links to runbook + architecture
+- [ ] **DOC-02** `docs/architecture.md` — copy from `Sound-Clash-Plan/architecture.md`
+- [ ] **DOC-03** `docs/realtime-design.md` — copy from plan
+- [ ] **DOC-04** `docs/data-model.md`, `docs/rpc-functions.md`, `docs/security-rls.md`, `docs/api-contracts.md`, `docs/game-rules.md`, `docs/tech-stack.md`, `docs/free-tier-budget.md`, `docs/local-development.md`, `docs/runbook.md` — copy from plan
+- [ ] **DOC-05** `docs/aws-teardown-checklist.md` — explicit, dated checklist for the cutover
+- [ ] **DOC-06** Architecture diagram as PNG/SVG in `docs/diagrams/` (Excalidraw or Mermaid)
+- [ ] **DOC-07** `CONTRIBUTING.md` — coding style, PR template, test requirements
+- [ ] **DOC-08** PR template `.github/pull_request_template.md` — sections: what changed, why, test plan, doc updates
+
+---
+
+## Quick Reference: Files Created vs Deleted (vs `Sound-Clash-legacy`)
+
+**Deleted entirely** (no analog in new repo):
+- `backend/websocket-service/`
+- `frontend/src/services/websocket/`
+- `infrastructure/`, `infrastructure-ondemand/`
+- `scripts/ondemand/`
+
+**Carried over (with adaptation)**:
+- Game-management REST endpoints → `backend/app/routers/games.py`
+- Song-management REST endpoints → `backend/app/routers/admin_songs.py` + `genres.py`
+- React pages (`TeamGameplay`, `ManagerConsole`, `DisplayScreen`) — refactored for Supabase Realtime
+- `AuthContext.tsx` admin password pattern
+- YouTube IFrame Player component
+- Song data (migrated via Phase 2 scripts)
+
+**New** (no analog in legacy):
+- `db/migrations/` — Postgres-as-code (RPC functions are the new heart of the system)
+- `db/seed/` — static seed data
+- `tests/db/`, `tests/e2e/`, `tests/smoke/` — comprehensive test suite (none in legacy)
+- `.github/workflows/` — actual CI/CD (none in legacy)
+- `_headers` (CSP) on frontend
+- `slowapi` rate limits on FastAPI
+- Sentry instrumentation

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,0 +1,248 @@
+# Sound Clash — Tech Stack
+
+The concrete services that constitute the system, why each was chosen over alternatives, and the free-tier limits relevant to operations.
+
+For quota analysis (capacity in games/month), see `free-tier-budget.md`. For why this combination beats every-Python-on-one-host, see `realtime-design.md`.
+
+## 1. Stack Summary
+
+| Concern | Service | Free-tier scope |
+|---|---|---|
+| Backend runtime | Render (web service) | 750 hr/mo, 512 MB RAM, sleeps after 15min idle |
+| Database + Realtime + RPC | Supabase | 500 MB Postgres, 200 concurrent peers, 2M Realtime msgs/mo |
+| Frontend hosting | Cloudflare Pages | Unlimited bandwidth, 500 builds/mo |
+| DNS | Cloudflare | Free; existing |
+| CI/CD | GitHub Actions | Unlimited for public repos |
+| Error tracking | Sentry | 5,000 errors/mo, 10k performance events |
+| Render keepalive | cron-job.org | 50 cron jobs |
+| Domain | Namecheap (existing) | $12/yr (only paid item) |
+
+## 2. Backend Runtime — Render
+
+**FastAPI in a single Docker container deployed to Render's free web service tier.**
+
+### Why Render
+
+- **Free tier exists and is durable** (no credit-card requirement, no announced sunsetting).
+- **GitHub integration**: link the repo, push to `main`, deploy fires automatically.
+- **Single Dockerfile autodetect**: no platform-specific build config.
+- **Custom domains + auto-managed Let's Encrypt**: `api.soundclash.org` works out of the box.
+- **Health-check-aware deploys**: bad deploy doesn't take down a healthy service.
+- **Acceptable cold start** for our use: the only cold-affected operation is game creation, not gameplay (see `realtime-design.md`).
+
+### Why not Cloud Run
+
+- Scale-to-zero with 2–5s cold starts is worse UX than Render's "wake on first request after sleep."
+- GCP requires a credit card to enable the API even for free-tier usage.
+- More complex IaC (Terraform / `gcloud`) for solo maintainer.
+
+### Why not Fly.io
+
+- Free tier requires credit card; the historical "free always-on machines" benefit has shrunk.
+- Long-term free status is not guaranteed (Fly has tightened free-tier policy multiple times in 2024–2025).
+- Fallback path if Render becomes unsuitable: Fly is well-suited for FastAPI; migrating is a Dockerfile move.
+
+### Why not Oracle Always Free
+
+- Genuinely free, always-on, generous resources.
+- But: own VM, own SSL, own monitoring, own deployment pipeline. Significant ops burden for a solo maintainer.
+- Reserved as the escape hatch if all managed-PaaS free tiers disappear.
+
+### Configuration
+
+- Environment variables set via Render dashboard (see `runbook.md` §3 for the full list).
+- Auto-deploy from `main` branch on push.
+- Health check path: `/health`, expects 200.
+- Build command: autodetected from Dockerfile.
+- Start command: autodetected (`uvicorn app.main:app --host 0.0.0.0 --port $PORT`).
+
+## 3. Database, Realtime, RPC — Supabase
+
+**Supabase is the entire backend data layer.** Postgres for storage, PostgREST for direct-from-browser RPC, Realtime for fan-out, pg_cron for the 4-hour TTL sweep.
+
+### Why Supabase
+
+- **Postgres** is the right database for a small, structured, transactional workload.
+- **Realtime built-in**: row-level change events without standing up a separate broker. The single most-load-bearing decision in the architecture.
+- **PostgREST**: lets the browser call Postgres RPCs directly. This is what makes <200ms buzzer possible without warm Python.
+- **pg_cron available**: scheduled cleanup without an external cron service.
+- **Free tier is genuine**: 500MB DB + 200 concurrent peers is comfortable for the expected scale.
+- **Ops cost is zero**: managed backups, managed TLS, managed monitoring dashboards.
+
+### Why not Neon (Postgres only)
+
+- Neon is excellent for serverless Postgres, but **no Realtime**. We'd need to bolt on Pusher/Ably for fan-out, which costs money or has tighter quotas.
+
+### Why not Firebase / Firestore
+
+- Document database; bad fit for the relational game schema.
+- Vendor lock-in to Google.
+- No PL/pgSQL equivalent for the buzzer atomic claim.
+
+### Why not self-hosted Postgres on Render
+
+- Render free Postgres is 1GB but is **deleted after 90 days** unless upgraded. Disqualifying.
+
+### Constraints worth knowing
+
+- **Project pause**: free projects pause after 7 days of zero activity. A weekly cron (`SELECT 1`) prevents this. See `runbook.md`.
+- **Single region per project**: pick at creation, can't move.
+- **No PITR on free**: 1-day daily backup is the recovery floor.
+- **No connection pooler on free** (PgBouncer is Pro-tier in Supabase). FastAPI uses `supabase-py`'s built-in HTTP client, which doesn't need a pooler — calls go through PostgREST, not directly to Postgres. Safe.
+
+### Region choice
+
+Pick the region closest to the primary user geography. For an Israel-based maintainer with EU and Israeli users, `eu-central-1` (Frankfurt) is the closest free-tier region. For US users, `us-east-1`. Decided at project-creation time; immovable later.
+
+## 4. Frontend — Cloudflare Pages
+
+**Static React + Vite SPA hosted on Cloudflare Pages.**
+
+### Why Cloudflare Pages
+
+- **Unlimited bandwidth** on free tier (Vercel free is 100 GB and has commercial-use friction).
+- **500 builds/month** is generous; we'll use ~30.
+- **Built-in PR preview deploys**: every PR gets a unique URL. Clean QA workflow.
+- **Cloudflare DNS already controls the domain**: no extra DNS hops.
+- **Native Workers integration** if we ever need edge logic (we don't, in MVP).
+
+### Why not Vercel
+
+- Vercel is the obvious choice for React, but its free-tier bandwidth cap and commercial-use restrictions are tighter than we want for an audience-facing display screen. If a single tournament livestream takes off, we'd hit the cap.
+- Vercel locks us to Next.js patterns we don't need (we're a vanilla Vite SPA).
+
+### Why not Netlify
+
+- Comparable to Vercel; same caveats.
+
+### Why not GitHub Pages
+
+- Static-only; can't set custom headers (CSP, etc.).
+- Slower CDN globally vs. Cloudflare.
+
+### Configuration
+
+- Build command: `npm run build`.
+- Output directory: `frontend/dist`.
+- Environment variables (set in Cloudflare dashboard): `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_URL`.
+- Custom domain: `soundclash.org` (apex via Cloudflare DNS CNAME flattening).
+- `_headers` file in repo defines CSP and security headers (see `security-rls.md` §7).
+
+## 5. DNS — Cloudflare
+
+**`soundclash.org` already lives at Cloudflare.** No migration needed.
+
+Records:
+- Apex `soundclash.org` → CNAME-flattened to Cloudflare Pages
+- `www.soundclash.org` → CNAME to apex
+- `api.soundclash.org` → CNAME to Render (`<service>.onrender.com`)
+
+The legacy AWS records (CloudFront distribution, ALB hostname) are deleted as part of Phase 7 cutover.
+
+## 6. CI/CD — GitHub Actions
+
+**Three workflows + one manual-dispatch.**
+
+| Workflow | Trigger | Runs |
+|---|---|---|
+| `backend.yml` | PR + push to main | ruff, mypy, pytest; on main: Render deploy hook |
+| `frontend.yml` | PR + push to main | eslint, tsc, vitest, build; on main: `wrangler pages deploy` |
+| `e2e.yml` | PR (label-gated) + push to main | Playwright against preview Supabase project |
+| `db-migrate.yml` | manual dispatch only | Apply SQL migrations to chosen environment |
+
+### Why public repo
+
+GitHub Actions is **unlimited minutes for public repos**, 2,000/mo for private. The codebase has no proprietary IP — public is the right call. Saves CI worry forever.
+
+### Why not GitLab / CircleCI
+
+- GitHub Actions is bundled with the repo host; one less service to manage.
+- Integrations with Render, Cloudflare, Sentry are all first-class.
+
+## 7. Error Tracking — Sentry
+
+**Frontend and backend both report to a single Sentry project.**
+
+### Why Sentry
+
+- 5,000 errors/mo on free tier — enough at expected volume.
+- 10,000 performance events/mo — enough to instrument the buzzer hot path.
+- First-class integrations for FastAPI and React.
+- Source-map upload for readable browser stack traces.
+
+### What we instrument
+
+| Layer | What's tracked |
+|---|---|
+| Frontend (browser) | Unhandled errors, React error boundaries, `buzz_in` RPC duration as a custom transaction |
+| Backend (FastAPI) | Unhandled exceptions, slow RPC calls (>1s), 5xx responses |
+
+### What we DON'T send
+
+- Game codes (low sensitivity but they're spammy in the dashboard)
+- Team names (user-supplied; could be inappropriate; sanitized via `beforeSend` hook)
+- Admin passwords (scrubbed by header filters)
+- PII (none collected anyway)
+
+## 8. Render Keepalive — cron-job.org
+
+**External cron pings `https://api.soundclash.org/health` every 14 minutes** to defeat Render's 15-minute idle sleep.
+
+### Why this approach
+
+- Free, no signup friction.
+- Truly external (running this from GitHub Actions schedules would burn minutes and is the wrong tool).
+- 14-minute interval keeps Render warm; 15-minute interval risks a sleep window.
+
+### Failure mode
+
+If cron-job.org breaks, Render sleeps. The first game creation after sleep stalls 30s. Annoying but recoverable. Monitored: see `runbook.md` §4.2.
+
+### Alternative considered
+
+- Run the keepalive in a GitHub Actions cron schedule. Burns 5 minutes per ping × 96 pings/day = 480 min/day = 14,400 min/month. Way over the 2,000-min free tier. Disqualified.
+
+## 9. Local Development — Supabase CLI
+
+**`supabase start` spins up the entire data layer in Docker** for local dev.
+
+Includes:
+- Local Postgres (port 54322)
+- Local PostgREST (54321)
+- Local Realtime (54321)
+- Local Studio UI (54323)
+
+This is the same software as production, just local. Migrations applied identically. See `local-development.md` for the workflow.
+
+## 10. Decision Matrix Summary
+
+For each tier, the alternative considered and the reason for the choice:
+
+| Tier | Chosen | Runner-up | Decisive factor |
+|---|---|---|---|
+| Backend host | Render | Fly.io | Long-term free-tier durability |
+| Database | Supabase | Neon | Realtime built in |
+| Realtime | Supabase | Pusher | 200 peers > Pusher's 100; bundled |
+| Frontend host | Cloudflare Pages | Vercel | Unlimited bandwidth |
+| DNS | Cloudflare | Namecheap | Already the registrar+DNS |
+| CI/CD | GitHub Actions | GitLab CI | Bundled with repo host |
+| Errors | Sentry | LogRocket | Wider FastAPI/React support |
+| Keepalive | cron-job.org | GitHub Actions schedule | Doesn't burn CI minutes |
+
+## 11. Anti-Stack — Things We Explicitly Don't Use
+
+- **Redis / ElastiCache** — Realtime + Postgres do the work; nothing to cache.
+- **DynamoDB** — was used in legacy AWS for ephemeral state; replaced by Postgres rows + pg_cron.
+- **AWS S3 / Cloudflare R2 / any object storage** — songs are YouTube IDs; no audio files.
+- **Kafka / RabbitMQ / message broker** — fan-out is Realtime; no queueing.
+- **Kubernetes / ECS** — single FastAPI container on Render is enough.
+- **Terraform / Pulumi / CDK** — managed services; clicking a few dashboards once is faster than IaC for this scope. Reconsider if the stack grows.
+- **Prometheus / Grafana** — Render and Supabase dashboards cover what's needed; Sentry handles errors. No need for a separate metrics stack.
+- **NGINX / HAProxy** — Render and Cloudflare terminate TLS; no reverse-proxy layer needed.
+- **Background workers (Celery / RQ)** — no async work that doesn't fit a Postgres function or pg_cron.
+
+The smallest stack that solves the problem is the one we want. Each entry above is a service we'd **add** if a real need appears, not one we removed for fashion.
+
+## 12. Total Annual Cost
+
+See `free-tier-budget.md` for the breakdown. Bottom line: **$12/year** (domain) at expected usage, scaling to ~$300/year only if Realtime peers force a Supabase Pro upgrade.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,299 @@
+# Sound Clash — Testing Strategy
+
+The standard for this project: **CI is the gate; merging implies the tests passed.** No "I'll test it later", no flaky-test escape hatch, no skipped tests on `main`.
+
+## 1. What we're optimizing for
+
+Not 100% line coverage — that incentivizes testing trivialities.
+
+We're optimizing for **confidence in correctness under realistic conditions** for the high-stakes parts of the system:
+
+| Concern | Why it matters | Test medium |
+|---|---|---|
+| Buzzer race | A double-winner makes the game unplayable | DB race test (10 concurrent calls) + Playwright |
+| State-machine integrity | Invalid transitions corrupt scoreboards | DB tests on each RPC's error paths |
+| RLS | Anon must never escalate | DB tests connecting as anon |
+| Idempotency | Network retries must not double-award | DB tests calling each RPC twice |
+| Latency | The architectural promise is <200ms | E2E latency measurement |
+| TTL cleanup | Game data really must disappear at 4h | DB test with manually-set `expires_at` |
+| Auth gate | Admin endpoints must reject without password | Backend tests |
+| Reconnection | Realtime drop must not leave UI broken | Playwright + frontend hook tests |
+| Rate limiting | Abuse must return 429, not exhaust Render | Backend tests |
+| Schema migrations | Re-run must be idempotent | `db/migrate.sh` invoked twice in CI |
+
+## 2. Coverage Gates (CI-enforced)
+
+| Gate | Threshold | Tool | Where enforced |
+|---|---|---|---|
+| All tests pass | 100% (zero failures, zero un-skipped skips) | pytest, vitest, playwright | All workflows |
+| Backend line coverage | ≥ 90% | `pytest --cov=app --cov-fail-under=90` | `backend.yml` |
+| Backend branch coverage | ≥ 85% | `pytest --cov-branch --cov-fail-under=85` | `backend.yml` |
+| Frontend line coverage | ≥ 85% | `vitest run --coverage` with v8 + threshold | `frontend.yml` |
+| PL/pgSQL function coverage | 100% | manual: every function has a happy + every error case | reviewed in PR |
+| Buzz race test | passes 100 consecutive runs | dedicated CI job loops the test | `e2e.yml` (gated on label `run-stress`) |
+| Buzz E2E latency | p95 < 200ms (informational only — flaky in cloud CI) | Playwright trace + report | `e2e.yml` |
+| No `# pragma: no cover` | banned outside generated code | `ruff` rule + grep in CI | `backend.yml` |
+| No `it.skip` / `test.skip` | banned on main | grep in CI | `frontend.yml` |
+| No `xfail` without an open issue link | enforced via PR review | reviewer | code review |
+
+PRs that drop coverage below threshold fail. PRs that introduce skipped tests on `main` fail. PRs cannot merge with red CI.
+
+## 3. Test Pyramid (where each test type lives)
+
+```
+                       ╱─────────╲
+                      ╱  E2E      ╲          tests/e2e/         ~10 tests
+                     ╱  (slow)    ╲          Playwright multi-browser
+                    ╱──────────────╲
+                   ╱  Integration   ╲        tests/backend/    ~30 tests
+                  ╱   (medium)      ╲        pytest+httpx+testcontainers
+                 ╱──────────────────╲
+                ╱   DB (PL/pgSQL)    ╲       tests/db/         ~25 tests
+               ╱     (fast)          ╲       pytest+testcontainers
+              ╱───────────────────────╲
+             ╱  Unit (frontend hooks   ╲     frontend/**/*.test.ts ~50 tests
+            ╱   + backend services)    ╲     vitest, pytest
+           ╱─────────────────────────────╲
+```
+
+Numbers are targets at end of Phase 6. Don't game them; let the test count emerge from real coverage need.
+
+## 4. Test Categories — What and Where
+
+### 4.1 Database tests — `tests/db/`
+
+Spin up Postgres via `testcontainers-postgres`. Apply all migrations from `db/migrations/`. Run tests against the fresh DB.
+
+| File | What it tests | Phase 3 priority |
+|---|---|---|
+| `test_buzz_in_race.py` | 10 concurrent buzz_in calls → exactly 1 winner. **Loops 100×** in stress mode. | P0 |
+| `test_buzz_in_edge_cases.py` | buzz when game waiting/ended/missing; bad UUID; lock-already-held | P0 |
+| `test_start_round.py` | happy path; on ended game raises `game_already_ended`; advances round_number atomically | P0 |
+| `test_award_points.py` | happy path; idempotency (second call → `round_already_ended`); timeout case skips score update; team score accumulates | P0 |
+| `test_end_game.py` | happy path; on already-ended raises | P1 |
+| `test_cleanup_expired_games.py` | manually set `expires_at` to past; invoke `cleanup_expired_games()`; verify cascade to teams + rounds | P0 |
+| `test_rls_anon.py` | as `anon` role: SELECT works, INSERT/UPDATE/DELETE rejected on every table | P0 |
+| `test_rls_function_grants.py` | as `anon`: EXECUTE buzz_in works; EXECUTE start_round/award_points/end_game/cleanup rejected | P0 |
+| `test_migrations_idempotent.py` | run all migrations twice; second run is no-op | P1 |
+| `test_schema_constraints.py` | duplicate game_code rejected; duplicate (game_code,name) rejected; FK cascades | P1 |
+| `test_pg_cron_registered.py` | `SELECT * FROM cron.job WHERE jobname = 'cleanup-expired-games'` returns 1 row | P1 |
+
+P0 = blocks Phase 3 exit; P1 = ships in Phase 3 but lower priority.
+
+### 4.2 Backend tests — `tests/backend/`
+
+`pytest + httpx` against the FastAPI app, with a testcontainer Postgres + applied migrations as the DB.
+
+| File | What it tests |
+|---|---|
+| `test_health.py` | `/health` returns 200 with version |
+| `test_admin_auth.py` | 401 without header; 200 with correct; 401 with wrong; constant-time compare |
+| `test_games_create.py` | happy path; admin auth required; collision-retry on duplicate code; validation (genres required) |
+| `test_games_join.py` | happy path; rejected if name duplicate; rejected if game expired; rejected if game ended |
+| `test_games_select_song.py` | happy path; respects `selected_genres`; excludes already-played songs; 409 when exhausted |
+| `test_games_award_points.py` | happy path; auth required; idempotency surfaces 409 |
+| `test_games_end.py` | happy path; auth required; 409 if already ended |
+| `test_games_kick_team.py` | happy path; auth required |
+| `test_admin_songs_crud.py` | full CRUD; YouTube ID validation; 401 without auth |
+| `test_admin_songs_bulk_import.py` | new rows inserted; existing youtube_id updated; malformed CSV rejected with row numbers |
+| `test_genres.py` | public; returns all genres |
+| `test_rate_limits.py` | exceed `POST /games` rate → 429; per-IP isolation |
+| `test_validation.py` | invalid YouTube IDs; oversized team names; out-of-range total_rounds |
+| `test_error_mapping.py` | Postgres P0001/P0002 → HTTP 4xx with structured body |
+
+### 4.3 Frontend unit tests — co-located `*.test.ts(x)`
+
+`vitest + @testing-library/react`. Mock the Supabase client.
+
+| File | What it tests |
+|---|---|
+| `lib/supabase.test.ts` | client singleton; reads env vars |
+| `lib/api.test.ts` | sets X-Admin-Password header from session for admin routes |
+| `hooks/useBuzzer.test.ts` | calls `rpc('buzz_in', ...)`; pending → success/lost states; double-press blocked |
+| `hooks/useGameChannel.test.ts` | subscribes with filter; reducer applies INSERT/UPDATE/DELETE; unsubscribes on unmount |
+| `hooks/useServerTime.test.ts` | computes offset on first event; `serverTimeNow()` returns offset-corrected time |
+| `hooks/usePlayerReady.test.ts` | resolves when YT ready; queues song load before ready |
+| `pages/TeamGameplay.test.tsx` | renders pending/locked/won/lost; reads team identity from localStorage |
+| `pages/ManagerConsole.test.tsx` | renders game state; admin actions disabled until player ready |
+| `pages/DisplayScreen.test.tsx` | renders scoreboard; updates on team-score events |
+| `components/BuzzButton.test.tsx` | disabled while locked; disabled while disconnected; click fires buzz |
+| `components/Scoreboard.test.tsx` | sorts by score desc; ties shown together |
+| `context/AuthContext.test.tsx` | sessionStorage round-trip; logout clears |
+
+### 4.4 E2E tests — `tests/e2e/`
+
+Playwright with multi-browser-context. Runs against a dedicated `Sound-Clash-Preview` Supabase project.
+
+| File | What it tests |
+|---|---|
+| `buzzer_race.spec.ts` | manager + 2 teams + display; both teams click within 5ms; deterministic winner; all contexts agree |
+| `full_game.spec.ts` | 3-round happy path with score accumulation |
+| `reconnection.spec.ts` | team disconnects mid-game; reload; state restored; can buzz |
+| `expiration.spec.ts` | game with expires_at in past; cron runs; all clients redirect to "expired" page |
+| `admin_login.spec.ts` | wrong password rejected; correct password admits |
+| `admin_songs_crud.spec.ts` | create/edit/delete song via admin UI |
+| `kick_team.spec.ts` | manager kicks team; team's tab redirects |
+| `mobile_team.spec.ts` | iPhone viewport; buzzer reachable + tappable |
+
+Multi-browser matrix: chromium + firefox + webkit. Each spec must pass in all three.
+
+### 4.5 Smoke tests — `tests/smoke/`
+
+Run manually after each prod deploy.
+
+| File | What it does |
+|---|---|
+| `post_deploy.sh` | curl `/health`; create game with admin password; join 2 teams; start round; end game; cleanup |
+| `prod_realtime.spec.ts` | Playwright against prod URL; one buzzer race round end-to-end |
+
+## 5. Phase Schedule
+
+| Phase | Tests written | Coverage gates active? |
+|---|---|---|
+| Phase 1 (scaffolding) | dummy passing tests in each suite (so CI runs green) | Configured but at low thresholds (e.g., 0% — passes with empty code) |
+| Phase 2 (data migration) | smoke check on imported songs | n/a |
+| Phase 3 (Postgres logic) | All `tests/db/*` | DB tests: 100% functions tested + race test 100× |
+| Phase 4 (backend port) | All `tests/backend/*` | Backend coverage gate raised to 90% |
+| Phase 5 (frontend) | All `frontend/**/*.test.ts(x)` + integration | Frontend coverage gate raised to 85% |
+| Phase 6 (E2E) | All `tests/e2e/*` | E2E gate active; latency reported |
+| Phase 7 (cutover) | `tests/smoke/*` | Manual run after deploy |
+
+Coverage thresholds in CI start LOW in Phase 1 (so the empty repo doesn't block) and ratchet UP at the end of each phase. PRs to ratchet thresholds are mandatory at phase boundaries.
+
+## 6. Anti-Patterns We Reject
+
+| Anti-pattern | Why we reject |
+|---|---|
+| Catch-all `try/except: pass` in test | Hides real failures |
+| Assertions inside try-blocks | Pytest rewrites assert; the try eats useful info |
+| `time.sleep(N)` for race conditions | Flaky; use polling with timeout |
+| Mocking Postgres in DB tests | Defeats the point; use testcontainers |
+| Tests that depend on test order | Tests must be independent (`pytest -p no:randomly` should still pass) |
+| Tests that hit the real Supabase prod project | NEVER; preview only, or testcontainers |
+| `it.skip` to "fix later" | Tests are either green or deleted; no gray zone |
+| 100% line coverage by testing getters | Optimize for branch coverage on real logic |
+| Snapshot tests for everything | Snapshots without intent become regression-blockers without value |
+| Coverage reports that summarize but don't fail CI | Threshold-only — humans don't reliably check coverage trends |
+
+## 7. Tooling
+
+### Backend (Python)
+
+```toml
+# pyproject.toml [tool.pytest.ini_options]
+addopts = "-ra --strict-markers --tb=short -p no:randomly"
+
+# pyproject.toml [tool.coverage.run]
+branch = true
+source = ["app"]
+
+# pyproject.toml [tool.coverage.report]
+fail_under = 90  # raised per phase
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "raise NotImplementedError"]
+```
+
+### Frontend
+
+```ts
+// vitest.config.ts
+test: {
+  coverage: {
+    provider: 'v8',
+    reporter: ['text', 'lcov'],
+    thresholds: {
+      lines: 85,
+      branches: 80,
+      functions: 85,
+      statements: 85,
+    },
+    exclude: ['**/*.test.{ts,tsx}', 'src/main.tsx'],
+  },
+}
+```
+
+### Playwright
+
+```ts
+// playwright.config.ts
+{
+  retries: process.env.CI ? 1 : 0,    // single retry only — surface flake
+  workers: process.env.CI ? 2 : undefined,
+  projects: [
+    { name: 'chromium', use: devices['Desktop Chrome'] },
+    { name: 'firefox',  use: devices['Desktop Firefox'] },
+    { name: 'webkit',   use: devices['Desktop Safari'] },
+    { name: 'mobile',   use: devices['iPhone SE'] },
+  ],
+}
+```
+
+## 8. CI Workflow Outline
+
+`backend.yml`:
+```yaml
+on: [pull_request, push]
+jobs:
+  test:
+    services:
+      postgres: postgres:15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -e backend[dev]
+      - run: ruff check backend/
+      - run: ruff format --check backend/
+      - run: mypy backend/app
+      - run: cd backend && pytest --cov=app --cov-branch --cov-fail-under=90 --cov-report=xml
+      - run: '! grep -r "pragma: no cover" backend/app'
+      - uses: codecov/codecov-action@v4
+        with: { file: backend/coverage.xml, fail_ci_if_error: true }
+```
+
+`frontend.yml`:
+```yaml
+on: [pull_request, push]
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm run lint
+      - run: cd frontend && npm run typecheck
+      - run: cd frontend && npm run test -- --coverage --run
+      - run: '! grep -rE "(it|test)\.skip" frontend/src'
+      - uses: codecov/codecov-action@v4
+        with: { file: frontend/coverage/lcov.info }
+```
+
+`e2e.yml`: runs Playwright against the preview Supabase project, label-gated for full matrix.
+
+`db-migrate.yml`: manual dispatch; applies migrations to a chosen environment.
+
+## 9. Local Discipline
+
+Tests run before commit (pre-commit hook):
+```yaml
+# .pre-commit-config.yaml
+- id: ruff-check
+- id: ruff-format
+- id: pytest-quick   # fast subset, e.g., pytest -m "not slow"
+- id: vitest-affected
+```
+
+Full suite expected to be runnable in <2 min locally (excluding E2E and DB stress).
+
+## 10. Open Questions / Future Work
+
+- **Mutation testing** (e.g., `mutmut`) on the PL/pgSQL functions: would catch tests that pass without actually validating the logic. Worth considering once the test suite stabilizes.
+- **Property-based testing** (e.g., `hypothesis` for game-code generator collision rate, score arithmetic): nice-to-have.
+- **Performance regression tests** (track `buzz_in` p95 over time): not in MVP.
+- **Visual regression tests** for the manager/display UI: not in MVP — game is functional, not pixel-perfect.
+
+## 11. What This Doc Doesn't Cover
+
+- How to write specific tests (read the existing tests for the pattern)
+- Mocking strategies (covered case-by-case in test files)
+- Tests for legacy code (out of scope; legacy is reference-only)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Sound Clash frontend — copy to frontend/.env.local for local dev.
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=
+VITE_API_URL=http://localhost:8000
+VITE_SENTRY_DSN=

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,47 @@
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+
+export default [
+  { ignores: ["dist", "node_modules", "coverage"] },
+  js.configs.recommended,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        console: "readonly",
+        localStorage: "readonly",
+        sessionStorage: "readonly",
+        fetch: "readonly",
+        WebSocket: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sound Clash</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "sound-clash-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Sound Clash — React + Vite SPA",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json}\"",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "cd ../tests/e2e && npx playwright test"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.46.0",
+    "@sentry/react": "^8.40.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "^2.1.5",
+    "eslint": "^9.15.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.14",
+    "jsdom": "^25.0.1",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.5"
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+// Phase 1 placeholder. Real router + providers in Phase 5 per docs/api-contracts.md.
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+function App() {
+  return <h1>Sound Clash — Phase 1 scaffold</h1>;
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/src/smoke.test.ts
+++ b/frontend/src/smoke.test.ts
@@ -1,0 +1,8 @@
+// Phase 1 smoke test. Real tests arrive in Phase 5 per docs/testing-strategy.md §4.3.
+import { describe, expect, it } from "vitest";
+
+describe("smoke", () => {
+  it("arithmetic still works", () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "useDefineForClassFields": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,13 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+  },
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,32 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
+    css: false,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      exclude: [
+        "**/*.test.{ts,tsx}",
+        "**/*.config.{ts,js}",
+        "src/main.tsx",
+        "src/test-setup.ts",
+        "**/dist/**",
+        "**/node_modules/**",
+      ],
+      // Phase 1 starts low; ratchet up at end of each phase per
+      // ../docs/testing-strategy.md §5
+      thresholds: {
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },
+    },
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,53 @@
+# Tests
+
+Five test categories live here. The split is intentional — see [`docs/testing-strategy.md`](../docs/testing-strategy.md) for the complete strategy.
+
+| Directory | What goes here | Tool | Phase |
+|---|---|---|---|
+| [`db/`](db/) | PL/pgSQL function tests, RLS policy tests, migration idempotency, pg_cron | pytest + testcontainers-postgres | 3 |
+| [`backend/`](backend/) | FastAPI endpoint tests against an in-process app with testcontainer DB | pytest + httpx + testcontainers | 4 |
+| [`frontend/`](frontend/) | (Empty) — frontend unit tests are co-located with components in `frontend/src/**/*.test.ts(x)`. This dir exists only for cross-component integration tests if needed. | vitest | 5 |
+| [`e2e/`](e2e/) | Playwright multi-browser, multi-context end-to-end | Playwright | 6 |
+| [`smoke/`](smoke/) | Post-deploy synthetic checks against prod or preview | bash + Playwright | 7 |
+
+## Hard rules
+
+These are enforced by CI. Violating any of them blocks merge:
+
+1. **No skipped tests on `main`**. `it.skip`, `test.skip`, `@pytest.mark.skip`, `xfail` all banned outside of generated code or with a documented issue link.
+2. **No `pragma: no cover` in `backend/app/`**. We don't game coverage.
+3. **No tests against the prod Supabase project**. Use testcontainers (DB tests) or the `Sound-Clash-Preview` project (E2E).
+4. **No `time.sleep(N)` to wait for race conditions**. Poll with timeout or use proper synchronization.
+5. **Tests must be independent**. Order randomization is enabled (`pytest -p no:randomly` is on); a passing-only-in-order test is a failing test.
+
+## Running tests locally
+
+```bash
+# Backend (from repo root)
+cd backend
+pytest                              # all backend + db tests
+pytest tests/backend                # subset
+pytest -m "not slow and not stress" # quick subset
+pytest --cov=app --cov-report=html  # coverage report
+
+# Frontend (from repo root)
+cd frontend
+npm test                            # watch mode
+npm run test:run                    # single run
+npm run test:coverage               # with coverage
+
+# E2E (requires local stack running OR preview env vars)
+cd tests/e2e
+npx playwright test                 # all
+npx playwright test --ui            # interactive
+```
+
+See [`docs/local-development.md`](../docs/local-development.md) for full local setup.
+
+## Test inventory
+
+[`docs/testing-strategy.md`](../docs/testing-strategy.md) §4 lists every planned test file with its purpose and phase. Don't add a new test file without a corresponding entry there (or update the strategy doc in the same PR).
+
+## Phase 1 status
+
+This dir is mostly empty in Phase 1. Each subdirectory contains a placeholder smoke test that proves CI runs end-to-end. Real tests arrive in their respective phases.

--- a/tests/backend/README.md
+++ b/tests/backend/README.md
@@ -1,0 +1,26 @@
+# Backend (FastAPI) tests
+
+Tests for FastAPI routes — admin auth, game lifecycle, song CRUD, rate limits, validation.
+
+Each test runs against an in-process FastAPI app, with a testcontainer Postgres + applied migrations as the DB. `httpx.AsyncClient` is used to call routes.
+
+**Phase 4 deliverable.** Phase 1 contains only a smoke test.
+
+## Planned test files
+
+See [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.2.
+
+## Running
+
+```bash
+cd backend
+pytest ../tests/backend
+pytest ../tests/backend -k test_admin_auth   # subset
+```
+
+## Conventions
+
+- One file per router (`test_games_router.py`, `test_admin_songs.py`, etc.) plus cross-cutting (`test_admin_auth.py`, `test_rate_limits.py`).
+- Use the `app_with_db` fixture (added in Phase 4) — gives you a configured TestClient.
+- Test the auth gate on every protected endpoint (lazy way: parametrized fixture).
+- For validation, test edge-of-spec values (max-length team name, empty genres, etc.), not just happy path.

--- a/tests/backend/test_smoke.py
+++ b/tests/backend/test_smoke.py
@@ -1,0 +1,18 @@
+"""Phase 1 smoke test — proves the test harness works.
+
+Real tests arrive in Phase 4 per docs/testing-strategy.md §4.2.
+"""
+
+from __future__ import annotations
+
+
+def test_smoke() -> None:
+    """Sanity: 1 + 1 = 2. Replaces with real tests in Phase 4."""
+    assert 1 + 1 == 2
+
+
+def test_import_app() -> None:
+    """The FastAPI app module imports without error."""
+    from app.main import app
+
+    assert app.title == "Sound Clash API"

--- a/tests/db/README.md
+++ b/tests/db/README.md
@@ -1,0 +1,42 @@
+# Database tests
+
+Tests for PL/pgSQL functions, RLS policies, schema constraints, and the pg_cron sweeper.
+
+These tests spin up a fresh Postgres 15 instance via `testcontainers-postgres`, apply all `db/migrations/*.sql` files in order, then run the test logic.
+
+**Phase 3 deliverable.** Empty in Phase 1.
+
+## Planned test files
+
+See [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.1 for the full list. Highlights:
+
+- `test_buzz_in_race.py` — 10 concurrent calls → exactly 1 winner. **Stress mode runs 100×.**
+- `test_buzz_in_edge_cases.py` — game waiting/ended/missing; bad UUID; lock-already-held.
+- `test_award_points.py` — happy path; **idempotency** (second call → 409); timeout case skips score update.
+- `test_rls_anon.py` — as `anon` role: SELECT works on every table; INSERT/UPDATE/DELETE rejected.
+- `test_rls_function_grants.py` — only `buzz_in` is anon-callable.
+- `test_cleanup_expired_games.py` — manually set `expires_at` to past; invoke cleanup; verify cascade.
+- `test_migrations_idempotent.py` — applying migrations twice is a no-op.
+
+## Running
+
+```bash
+# From repo root, requires Docker for testcontainers
+cd backend
+pytest ../tests/db
+pytest ../tests/db -m stress       # the 100× race loop
+```
+
+## Authoring conventions
+
+- Each test file owns one PL/pgSQL function (or one cross-cutting concern like RLS).
+- Use the `db_with_migrations` fixture (in `conftest.py`) — it gives you a fresh testcontainer with all migrations applied.
+- Don't share state between tests. Create the game/teams/etc. inside each test.
+- Race-condition tests use `asyncio.gather` over `asyncpg`. **No `time.sleep`.**
+- Mark race tests with `@pytest.mark.stress` so they're opt-in in CI.
+
+## What NOT to do
+
+- ❌ Don't connect to production Supabase from these tests. Ever.
+- ❌ Don't mock Postgres. The point is to exercise the real engine.
+- ❌ Don't use `pytest.mark.skip` to "fix later." Either delete the test or the marker.

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest fixtures for database tests.
+
+Phase 1 placeholder. The actual `db_with_migrations` fixture (testcontainers-postgres
+spinning up Postgres 15 + applying all `db/migrations/*.sql`) is implemented in Phase 3.
+
+See docs/testing-strategy.md §4.1 and docs/rpc-functions.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def placeholder() -> str:
+    """Phase 1 placeholder fixture so this conftest is non-empty."""
+    return "Phase 3 will replace this with `db_with_migrations`."

--- a/tests/db/test_smoke.py
+++ b/tests/db/test_smoke.py
@@ -1,0 +1,16 @@
+"""Phase 1 smoke test for the db tests directory.
+
+Real DB tests arrive in Phase 3 per docs/testing-strategy.md §4.1.
+"""
+
+from __future__ import annotations
+
+
+def test_smoke() -> None:
+    """Sanity test so CI confirms pytest discovery works in tests/db/."""
+    assert True
+
+
+def test_placeholder_fixture(placeholder: str) -> None:
+    """The conftest fixture is wired up correctly."""
+    assert "Phase 3" in placeholder

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,54 @@
+# End-to-End tests
+
+Playwright multi-browser, multi-context tests. Run against the `Sound-Clash-Preview` Supabase project (or local dev stack).
+
+**Phase 6 deliverable.** Phase 1 contains only the config skeleton.
+
+## Planned specs
+
+See [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.4 for the full list:
+
+- `buzzer_race.spec.ts` — 4 contexts; both teams click within 5ms; deterministic winner; all contexts agree.
+- `full_game.spec.ts` — 3-round happy path.
+- `reconnection.spec.ts` — team disconnect mid-game; reload; state restored.
+- `expiration.spec.ts` — game with past `expires_at`; cron runs; all clients redirect.
+- `admin_login.spec.ts` — wrong password rejected; correct admits.
+- `admin_songs_crud.spec.ts` — song CRUD via UI.
+- `kick_team.spec.ts` — team kicked; their tab redirects.
+- `mobile_team.spec.ts` — iPhone SE viewport; buzzer reachable.
+
+## Browser matrix
+
+Every spec must pass in:
+- **chromium** (Desktop Chrome)
+- **firefox** (Desktop Firefox)
+- **webkit** (Desktop Safari)
+- **mobile** (iPhone SE)
+
+## Running
+
+```bash
+cd tests/e2e
+npm install
+npx playwright install --with-deps  # one-time
+npx playwright test                 # all browsers, all specs
+npx playwright test --ui            # interactive
+npx playwright test buzzer_race     # one spec
+npx playwright test --project=mobile  # one browser
+```
+
+## Required env vars
+
+```
+SUPABASE_URL=https://xxx.supabase.co
+SUPABASE_ANON_KEY=...
+SUPABASE_SERVICE_ROLE_KEY=...
+ADMIN_PASSWORD=...
+BASE_URL=http://localhost:5173    # or preview URL
+```
+
+## Important rules
+
+- **Never run against the prod Supabase project.** Use preview only.
+- **Never embed secrets** in test code; always env vars.
+- **Single retry max** in CI (`retries: 1`) — flake should fail fast.

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sound-clash-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^22.9.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Phase 1 placeholder. Real specs added in Phase 6 per docs/testing-strategy.md §4.4.
+
+export default defineConfig({
+  testDir: ".",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  reporter: process.env.CI ? [["html"], ["github"]] : "html",
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+    { name: "mobile", use: { ...devices["iPhone SE"] } },
+  ],
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,6 @@
+// Phase 1 smoke test. Real specs in Phase 6.
+import { expect, test } from "@playwright/test";
+
+test("smoke: arithmetic", () => {
+  expect(1 + 1).toBe(2);
+});

--- a/tests/frontend/README.md
+++ b/tests/frontend/README.md
@@ -1,0 +1,31 @@
+# Frontend tests
+
+Most frontend tests are **co-located** with the component they test:
+
+```
+frontend/src/hooks/useBuzzer.ts
+frontend/src/hooks/useBuzzer.test.ts        ← test next to source
+
+frontend/src/components/BuzzButton.tsx
+frontend/src/components/BuzzButton.test.tsx
+```
+
+This directory is reserved for **cross-component integration tests** that don't naturally belong next to a single source file (e.g., a test that exercises `useGameChannel` + `useBuzzer` + a router page together with a mocked Supabase client).
+
+If you don't need this, the directory can stay nearly empty.
+
+## Running
+
+```bash
+cd frontend
+npm test                  # watch mode (vitest)
+npm run test:run          # single run
+npm run test:coverage     # with coverage
+```
+
+## Conventions
+
+- Mock the Supabase client at the boundary (`frontend/src/lib/supabase.ts`); don't reach into Realtime internals.
+- Use `@testing-library/react` queries (`getByRole`, `findByText`, …); avoid querying by class or id.
+- For async hooks, use `waitFor` with default timeout; don't add `await new Promise(setTimeout, N)`.
+- Assert on user-visible behavior, not implementation details.

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,19 @@
+# Smoke tests
+
+Run **after each production deploy** to verify the live system works end-to-end.
+
+These are lightweight, take <2 minutes, and hit the real prod URL with synthetic traffic.
+
+**Phase 7 deliverable.** Empty in Phase 1.
+
+## Planned scripts
+
+- `post_deploy.sh` — curl `/health`; create a synthetic game; join 2 teams; start round; end game; clean up.
+- `prod_realtime.spec.ts` — Playwright against prod URL; one buzzer race round end-to-end.
+
+## Running (after Phase 7 ships)
+
+```bash
+ADMIN_PASSWORD=... ./tests/smoke/post_deploy.sh https://api.soundclash.org
+npx playwright test tests/smoke/prod_realtime.spec.ts
+```


### PR DESCRIPTION
## Summary

Phase 1 of the Sound Clash rewrite: scaffold the empty repo so subsequent phases land on a solid base. No application code yet — just structure, configs, planning docs, CI gates, and placeholder tests so CI runs green from day 1.

### What landed

- **Directory layout**: `backend/`, `frontend/`, `db/{migrations,seed}/`, `tests/{db,backend,frontend,e2e,smoke}/`, `docs/`, `scripts/`, `.github/{workflows,ISSUE_TEMPLATE}/`
- **Planning docs (16)**: copied into `docs/` — architecture, realtime-design, tech-stack, game-rules, data-model, rpc-functions, security-rls, api-contracts, free-tier-budget, local-development, runbook, roadmap, tasks, testing-strategy, aws-teardown-checklist
- **Templates**: `README.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, three issue templates
- **Configs**: `.gitignore` (excludes `.claude/settings.local.json` and `.claude/rules/`), `LICENSE` (MIT), `.editorconfig`, `.pre-commit-config.yaml`, `CODEOWNERS`, root `.env.example`
- **Backend scaffold**: `backend/pyproject.toml` (pytest+coverage+ruff+mypy config), `backend/app/main.py` with `/health`, `backend/Dockerfile` (placeholder), one passing smoke test
- **Frontend scaffold**: `frontend/package.json`, `tsconfig.json`, `vite.config.ts`, `vitest.config.ts` (v8 coverage), `eslint.config.js`, `.prettierrc.json`, `index.html`, `src/main.tsx`, one passing smoke test
- **CI workflows (4)**: `backend.yml` (ruff+mypy+pytest+cov+codecov+Render deploy), `frontend.yml` (eslint+prettier+tsc+vitest+cov+Pages deploy + bundle-leak check), `e2e.yml` (Playwright + label-gated 100x stress race), `db-migrate.yml` (manual dispatch with confirmation)
- **Test scaffolding**: READMEs in every test dir; passing smoke tests in `tests/backend/`, `tests/db/`, `frontend/src/`, `tests/e2e/`; Playwright config with chromium+firefox+webkit+mobile matrix; `tests/db/conftest.py` placeholder
- **DB**: `db/README.md` and `db/migrate.sh` (idempotent runner; exits 0 with no migrations yet)

### Test gates configured (will ratchet up per phase)

| Gate | Phase 1 threshold | Final |
|---|---|---|
| Backend coverage `--cov-fail-under` | 0 (empty app) | 90 |
| Frontend coverage thresholds | 0 | 85 |
| All tests pass | always 100% | always 100% |
| No `pragma: no cover` in `backend/app/` | enforced | enforced |
| No skipped tests in frontend `src/` | enforced | enforced |
| No service-role key in built bundle | enforced | enforced |
| Race test 100x | label-gated (`run-stress`) | label-gated |

Thresholds start at 0 because the app is empty; per `docs/testing-strategy.md` §5 they ratchet up at each phase exit.

### Notes

- Created `.github/workflows/` from scratch — flagging this since the project rule asks for a flag on workflow changes. They were pre-authorized in planning as part of Phase 1, but calling out for visibility.
- The `main` branch was bootstrapped with an empty initial commit so this PR could exist. Default branch on GitHub is still `feature/phase-1-scaffold` (set automatically when first pushed); change it to `main` after merge if you want.

## Test plan

- [x] CI green on this branch (`backend.yml` + `frontend.yml`; `e2e.yml` and `db-migrate.yml` are manual/label-gated, not auto-running on PRs without the label)
- [x] Read-through of `docs/` makes sense to a fresh reader
- [x] Spot-check one workflow file and `pyproject.toml`/`vitest.config.ts` for sanity
- [x] Verify `.claude/settings.local.json` and `.claude/rules/` are NOT in the diff (gitignored)

## Out of scope for this PR

- No application code (FastAPI routers, React components, SQL migrations) — Phases 3-5
- No real tests — only smoke tests so CI runs
- No external service provisioning (Supabase, Render, Cloudflare Pages, Sentry, cron-job.org) — done outside the repo