### PR TITLE
Mark CodeQL analyze step as continue-on-error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,11 @@ jobs:
           # Use the security-and-quality query suite (broader than default).
           queries: security-and-quality
 
+      # The upload step inside `analyze` will fail until "Code scanning" is
+      # enabled in repo Settings → Code security & analysis. Mark as
+      # continue-on-error so the workflow stays green; the analysis still runs
+      # and surfaces issues in the run log. Remove this once code scanning is on.
       - uses: github/codeql-action/analyze@v3
+        continue-on-error: true
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the `github/codeql-action/analyze` step in `codeql.yml`. The action's SARIF upload phase fails (and marks the run red) because Code scanning is not yet enabled in repo Settings → Code security & analysis.
- The analysis itself still runs and findings are visible in the run log.

## Why now
Every push to `main` and every Monday's scheduled run currently fails with `Code scanning is not enabled for this repository`. The failures are noise — they don't block PRs (the workflow already excludes `pull_request:`) but they pollute the run history.

## How to actually flip it on (the proper fix, separate from this PR)
GitHub repo → Settings → Code security and analysis → Code scanning → **Set up** → Default. CodeQL is free for public repos. Once enabled, remove the `continue-on-error: true` line (or this whole comment block) so failed analyses show as failed again.

## Test plan
- [ ] Wait for the next push to main / scheduled run; confirm the workflow shows green even though SARIF upload still errors.
- [ ] After enabling Code scanning in repo settings, revert the `continue-on-error` change.