### PR TITLE
Port UI design from legacy — light theme, role buttons, animated logo

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Sound Clash — real-time multiplayer music trivia. Buzz in, name the tune, win the round."
+    />
+    <meta name="theme-color" content="#3b82f6" />
     <title>Sound Clash</title>
   </head>
   <body>

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
 describe("App router", () => {
   it("renders the home page at /", () => {
     render(<App />);
-    expect(screen.getByText(/sound clash/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /welcome to sound clash/i })).toBeInTheDocument();
   });
 
   it("guards /manager/create when no admin password is set", () => {
@@ -35,6 +35,6 @@ describe("App router", () => {
   it("redirects unknown paths home", () => {
     window.history.pushState({}, "", "/totally-bogus");
     render(<App />);
-    expect(screen.getByRole("link", { name: /host a game/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /manager console/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/BuzzButton.module.css
+++ b/frontend/src/components/BuzzButton.module.css
@@ -1,65 +1,115 @@
 .button {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
   width: min(80vw, 360px);
   height: min(80vw, 360px);
   border-radius: 50%;
-  border: 4px solid transparent;
-  background: radial-gradient(circle at 30% 25%, #ff7479 0%, #d93b3f 60%, #8a1c1f 100%);
+  border: none;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
   color: #fff;
   font-family: var(--font-display);
-  font-size: 2.4rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
+  font-size: 3rem;
+  font-weight: 900;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   cursor: pointer;
   box-shadow:
-    0 24px 48px rgba(217, 59, 63, 0.45),
-    inset 0 -8px 16px rgba(0, 0, 0, 0.35),
-    inset 0 6px 14px rgba(255, 255, 255, 0.18);
+    0 10px 40px rgba(16, 185, 129, 0.4),
+    0 0 0 0 rgba(16, 185, 129, 0.7);
   transition:
-    transform 80ms ease-out,
-    box-shadow 120ms ease-out,
+    transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1),
     filter 200ms ease;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  animation: buzz-pulse 2s infinite;
 }
 
 .button:hover:not(:disabled) {
-  filter: brightness(1.06);
+  transform: scale(1.05);
+  filter: brightness(1.05);
+  box-shadow:
+    0 15px 50px rgba(16, 185, 129, 0.5),
+    0 0 0 0 rgba(16, 185, 129, 0.7);
 }
 
 .button:active:not(:disabled),
 .pressed {
-  transform: translateY(4px) scale(0.97);
+  transform: scale(0.95);
   box-shadow:
-    0 8px 16px rgba(217, 59, 63, 0.35),
-    inset 0 -4px 8px rgba(0, 0, 0, 0.4),
-    inset 0 4px 8px rgba(255, 255, 255, 0.12);
+    0 5px 20px rgba(16, 185, 129, 0.6),
+    0 0 0 10px rgba(16, 185, 129, 0.25);
 }
 
 .button:focus-visible {
   outline: none;
-  border-color: #fff;
+  box-shadow:
+    0 10px 40px rgba(16, 185, 129, 0.4),
+    0 0 0 6px rgba(255, 255, 255, 0.95),
+    0 0 0 10px rgba(16, 185, 129, 0.6);
 }
 
 .button:disabled {
   cursor: not-allowed;
-  filter: grayscale(0.6) brightness(0.6);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
+  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+  color: #e5e7eb;
+  box-shadow: 0 6px 18px rgba(107, 114, 128, 0.3);
+  animation: none;
+  opacity: 0.85;
 }
 
 .label {
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  position: relative;
+  z-index: 1;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
 .subtitle {
-  margin-top: 8px;
   font-size: 0.95rem;
-  font-weight: 500;
-  letter-spacing: 0.02em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: none;
-  opacity: 0.85;
+  opacity: 0.92;
+}
+
+@keyframes buzz-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 10px 40px rgba(16, 185, 129, 0.4),
+      0 0 0 0 rgba(16, 185, 129, 0.7);
+  }
+  50% {
+    box-shadow:
+      0 10px 40px rgba(16, 185, 129, 0.4),
+      0 0 0 18px rgba(16, 185, 129, 0);
+  }
+}
+
+@media (max-width: 768px) {
+  .button {
+    font-size: 2.5rem;
+    width: min(85vw, 320px);
+    height: min(85vw, 320px);
+  }
+}
+
+@media (max-width: 480px) {
+  .button {
+    font-size: 2rem;
+    width: min(90vw, 280px);
+    height: min(90vw, 280px);
+  }
+}
+
+@media (min-width: 1200px) {
+  .button {
+    font-size: 3.5rem;
+    width: 420px;
+    height: 420px;
+  }
 }

--- a/frontend/src/components/Logo.module.css
+++ b/frontend/src/components/Logo.module.css
@@ -1,0 +1,102 @@
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  user-select: none;
+}
+
+.text {
+  font-weight: 800;
+  background: linear-gradient(135deg, #10b981 0%, #06b6d4 50%, #3b82f6 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  letter-spacing: -0.02em;
+}
+
+.small .text {
+  font-size: 1.25rem;
+}
+.medium .text {
+  font-size: 2rem;
+}
+.large .text {
+  font-size: 3rem;
+}
+
+@media (min-width: 1400px) {
+  .large .text {
+    font-size: 3.5rem;
+  }
+}
+
+.icon {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 40px;
+}
+
+.small .icon {
+  height: 24px;
+  gap: 2px;
+}
+
+.large .icon {
+  height: 56px;
+  gap: 4px;
+}
+
+.bar {
+  display: block;
+  width: 6px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #10b981 0%, #06b6d4 50%, #3b82f6 100%);
+}
+
+.small .bar {
+  width: 3px;
+}
+.large .bar {
+  width: 8px;
+}
+
+.bar:nth-child(1) {
+  height: 50%;
+}
+.bar:nth-child(2) {
+  height: 80%;
+}
+.bar:nth-child(3) {
+  height: 100%;
+}
+.bar:nth-child(4) {
+  height: 65%;
+}
+
+.animated .bar {
+  animation: bar-bounce 1.2s ease-in-out infinite;
+}
+
+.animated .bar:nth-child(1) {
+  animation-delay: 0s;
+}
+.animated .bar:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.animated .bar:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.animated .bar:nth-child(4) {
+  animation-delay: 0.45s;
+}
+
+@keyframes bar-bounce {
+  0%,
+  100% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(0.55);
+  }
+}

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,20 @@
+import styles from "./Logo.module.css";
+
+interface Props {
+  size?: "small" | "medium" | "large";
+  animated?: boolean;
+}
+
+export function Logo({ size = "medium", animated = true }: Props) {
+  return (
+    <div className={`${styles.logo} ${styles[size]}`}>
+      <div className={`${styles.icon} ${animated ? styles.animated : ""}`}>
+        <span className={styles.bar} />
+        <span className={styles.bar} />
+        <span className={styles.bar} />
+        <span className={styles.bar} />
+      </div>
+      <span className={styles.text}>Sound Clash</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Scoreboard.module.css
+++ b/frontend/src/components/Scoreboard.module.css
@@ -4,33 +4,42 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .row {
   display: grid;
-  grid-template-columns: 36px 1fr auto;
+  grid-template-columns: 40px 1fr auto;
   align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  background: var(--color-card);
+  gap: 14px;
+  padding: 14px 18px;
+  background: var(--color-bg-elev);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
   transition:
     background 200ms ease,
     border-color 200ms ease,
-    transform 200ms ease;
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.row:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 10px rgba(59, 130, 246, 0.1);
 }
 
 .rank {
-  font-weight: 700;
-  color: var(--color-text-dim);
+  font-weight: 800;
+  color: var(--color-text-mute);
   font-variant-numeric: tabular-nums;
+  font-size: 1.05rem;
 }
 
 .name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 1.05rem;
+  color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -38,20 +47,24 @@
 
 .score {
   font-weight: 800;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   font-variant-numeric: tabular-nums;
-  color: var(--color-text);
+  color: var(--color-primary-strong);
 }
 
 .buzzed {
-  border-color: var(--color-accent);
-  background: linear-gradient(90deg, rgba(255, 90, 95, 0.18) 0%, var(--color-card) 60%);
+  border-color: var(--color-warning);
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0%, var(--color-bg-elev) 100%);
+  transform: scale(1.02);
+  box-shadow: 0 6px 16px rgba(245, 158, 11, 0.25);
 }
 
-.buzzed .rank,
-.buzzed .name,
+.buzzed .name {
+  color: #92400e;
+}
+
 .buzzed .score {
-  color: #fff;
+  color: #b45309;
 }
 
 .empty {

--- a/frontend/src/components/YouTubePlayer.module.css
+++ b/frontend/src/components/YouTubePlayer.module.css
@@ -5,6 +5,8 @@
   border-radius: var(--radius-md);
   overflow: hidden;
   aspect-ratio: 16 / 9;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
 }
 
 .player {
@@ -15,14 +17,14 @@
 .cover {
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, var(--color-bg-elev) 0%, #000 60%);
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-text-dim);
+  color: rgba(255, 255, 255, 0.7);
   font-weight: 600;
   letter-spacing: 0.05em;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   pointer-events: none;
   transition: opacity 320ms ease;
 }
@@ -32,6 +34,6 @@
 }
 
 .loading {
-  color: var(--color-text-dim);
+  color: rgba(255, 255, 255, 0.65);
   font-size: 0.95rem;
 }

--- a/frontend/src/pages/DisplayPage.module.css
+++ b/frontend/src/pages/DisplayPage.module.css
@@ -1,9 +1,11 @@
 .shell {
   min-height: 100%;
-  padding: var(--space-xl);
+  padding: 2rem var(--space-xl);
   display: flex;
   flex-direction: column;
-  gap: var(--space-xl);
+  gap: 2rem;
+  max-width: 1300px;
+  margin: 0 auto;
 }
 
 .entry {
@@ -11,33 +13,70 @@
   align-items: center;
   justify-content: center;
   min-height: 100%;
+  padding: var(--space-xl) var(--space-lg);
 }
 
 .entryCard {
   width: 100%;
-  max-width: 420px;
-  padding: var(--space-xl);
-  background: var(--color-card);
+  max-width: 460px;
+  padding: 2.5rem 2.25rem;
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.25rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.entryCard::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #06b6d4 0%, #3b82f6 100%);
+}
+
+.entryCard h1 {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
 }
 
 .entryInput {
   letter-spacing: 0.5em;
   text-align: center;
-  font-size: 1.6rem;
-  font-weight: 700;
+  font-size: 1.75rem;
+  font-weight: 800;
   text-transform: uppercase;
+  color: var(--color-primary-strong);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-md);
+  gap: 1rem;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.5rem;
+  box-shadow: var(--shadow-md);
+}
+
+.header h1 {
+  font-size: 2rem;
+  background: linear-gradient(135deg, #10b981 0%, #06b6d4 50%, #3b82f6 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  letter-spacing: -0.02em;
 }
 
 .code {
@@ -45,26 +84,43 @@
   font-size: 2.2rem;
   letter-spacing: 0.18em;
   font-weight: 800;
+  color: var(--color-primary-strong);
 }
 
 .banner {
-  padding: var(--space-lg);
-  font-size: 1.6rem;
-  font-weight: 700;
+  padding: 1.5rem 1.75rem;
+  font-size: 1.75rem;
+  font-weight: 800;
   text-align: center;
-  background: var(--color-bg-elev);
+  background: #ffffff;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
+  color: var(--color-text-dim);
+  box-shadow: var(--shadow-md);
+  letter-spacing: -0.01em;
 }
 
 .bannerLocked {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-  color: #fff;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0%, rgba(251, 191, 36, 0.1) 100%);
+  border-color: var(--color-warning);
+  color: #92400e;
+  animation: locked-pulse 1s ease-in-out infinite;
+}
+
+@keyframes locked-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.015);
+  }
 }
 
 .bannerEnded {
   color: var(--color-text-dim);
+  background: rgba(148, 163, 184, 0.12);
+  border-color: var(--color-border-strong);
 }
 
 .scores {
@@ -77,39 +133,84 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .bigRow {
   display: grid;
-  grid-template-columns: 64px 1fr auto;
+  grid-template-columns: 80px 1fr auto;
   align-items: center;
-  gap: var(--space-md);
-  padding: 16px 24px;
-  background: var(--color-card);
+  gap: 1.25rem;
+  padding: 1.5rem 2rem;
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   font-size: 1.6rem;
-  transition: background 200ms ease;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background 250ms ease,
+    border-color 250ms ease,
+    transform 250ms ease,
+    box-shadow 250ms ease;
 }
 
 .bigRowBuzzed {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
+  border-color: var(--color-warning);
+  background: linear-gradient(90deg, rgba(245, 158, 11, 0.18) 0%, #ffffff 80%);
+  transform: scale(1.02);
+  box-shadow: 0 8px 24px rgba(245, 158, 11, 0.3);
 }
 
 .bigRank {
   font-weight: 800;
-  color: var(--color-text-dim);
+  color: var(--color-text-mute);
   font-variant-numeric: tabular-nums;
+  font-size: 2rem;
+}
+
+.bigRowBuzzed .bigRank {
+  color: var(--color-warning);
 }
 
 .bigName {
   font-weight: 700;
+  color: #0f172a;
 }
 
 .bigScore {
   font-weight: 800;
-  font-size: 2rem;
+  font-size: 2.4rem;
   font-variant-numeric: tabular-nums;
+  color: var(--color-primary-strong);
+}
+
+.bigRowBuzzed .bigScore {
+  color: #b45309;
+}
+
+@media (max-width: 768px) {
+  .shell {
+    padding: 1.25rem var(--space-md);
+  }
+  .header h1 {
+    font-size: 1.5rem;
+  }
+  .code {
+    font-size: 1.5rem;
+  }
+  .banner {
+    font-size: 1.35rem;
+    padding: 1rem 1.25rem;
+  }
+  .bigRow {
+    padding: 1rem 1.25rem;
+    grid-template-columns: 56px 1fr auto;
+    font-size: 1.25rem;
+  }
+  .bigRank {
+    font-size: 1.5rem;
+  }
+  .bigScore {
+    font-size: 1.85rem;
+  }
 }

--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -1,75 +1,408 @@
-.shell {
+.page {
   min-height: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-xl);
-  background:
-    radial-gradient(ellipse at top, rgba(255, 90, 95, 0.08) 0%, transparent 50%), var(--color-bg);
+  flex-direction: column;
 }
 
-.hero {
-  max-width: 720px;
-  width: 100%;
-  text-align: center;
+.header {
+  padding: 1.75rem 0;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(59, 130, 246, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #3b82f6 0%, #06b6d4 50%, #10b981 100%);
+  opacity: 0.6;
+}
+
+.container {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.header .container {
+  display: flex;
+  justify-content: center;
+}
+
+.main {
+  flex: 1;
+  padding: 4rem 0 5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.content {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xl);
-}
-
-.title {
-  font-size: clamp(2.4rem, 6vw, 4rem);
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  background: linear-gradient(135deg, #fff 0%, var(--color-accent) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.subtitle {
-  font-size: 1.1rem;
-  color: var(--color-text-dim);
-  max-width: 520px;
+  gap: 4rem;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: var(--space-md);
+.hero {
+  text-align: center;
+  padding: 1rem 0 1.5rem;
+  animation: fade-in-up 0.8s ease-out;
 }
 
-.card {
+.title {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 1rem 0;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+.subtitle {
+  font-size: clamp(1.2rem, 3vw, 1.75rem);
+  font-weight: 600;
+  background: linear-gradient(120deg, #3b82f6 0%, #06b6d4 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  margin: 0 0 1rem 0;
+  line-height: 1.3;
+}
+
+.description {
+  font-size: 1.1rem;
+  color: var(--color-text-dim);
+  margin: 0;
+  font-weight: 500;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.75rem;
+  width: 100%;
+  animation: fade-in-up 0.8s ease-out 0.15s both;
+}
+
+.roleBtn {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
-  padding: var(--space-lg);
-  background: var(--color-card);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  text-align: left;
-  color: var(--color-text);
-  transition:
-    border-color 200ms ease,
-    transform 200ms ease,
-    background 200ms ease;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  padding: 2.5rem 1.75rem;
+  border: 2px solid transparent;
+  border-radius: 20px;
+  background: #ffffff;
   cursor: pointer;
+  transition: all 0.4s var(--easing-spring);
+  text-align: center;
+  width: 100%;
+  min-height: 220px;
+  box-shadow:
+    0 4px 20px rgba(15, 23, 42, 0.06),
+    0 1px 3px rgba(15, 23, 42, 0.04);
+  text-decoration: none;
+  color: inherit;
+  position: relative;
+  overflow: hidden;
 }
 
-.card:hover {
-  border-color: var(--color-accent);
-  transform: translateY(-2px);
-  background: var(--color-bg-elev);
+.roleBtn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roleBtn > * {
+  position: relative;
+  z-index: 1;
+}
+
+.rolePrimary {
+  border-color: rgba(59, 130, 246, 0.18);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.04) 0%, #ffffff 100%);
+}
+.rolePrimary::before {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(96, 165, 250, 0.04) 100%);
+}
+
+.roleSecondary {
+  border-color: rgba(16, 185, 129, 0.18);
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.04) 0%, #ffffff 100%);
+}
+.roleSecondary::before {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.1) 0%, rgba(52, 211, 153, 0.04) 100%);
+}
+
+.roleAccent {
+  border-color: rgba(6, 182, 212, 0.18);
+  background: linear-gradient(135deg, rgba(6, 182, 212, 0.04) 0%, #ffffff 100%);
+}
+.roleAccent::before {
+  background: linear-gradient(135deg, rgba(6, 182, 212, 0.1) 0%, rgba(34, 211, 238, 0.04) 100%);
+}
+
+.roleBtn:hover {
+  transform: translateY(-6px);
+  box-shadow:
+    0 12px 40px rgba(15, 23, 42, 0.14),
+    0 4px 10px rgba(15, 23, 42, 0.08);
   text-decoration: none;
 }
 
-.cardTitle {
-  font-size: 1.2rem;
-  font-weight: 700;
+.roleBtn:hover::before {
+  opacity: 1;
 }
 
-.cardDesc {
+.rolePrimary:hover {
+  border-color: rgba(59, 130, 246, 0.45);
+}
+.roleSecondary:hover {
+  border-color: rgba(16, 185, 129, 0.45);
+}
+.roleAccent:hover {
+  border-color: rgba(6, 182, 212, 0.45);
+}
+
+.roleBtn:active {
+  transform: translateY(-3px);
+  transition: transform 0.1s ease;
+}
+
+.roleIcon {
+  font-size: 3.5rem;
+  line-height: 1;
+  display: block;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.1));
+  transition: transform 0.5s var(--easing-spring);
+}
+
+.roleBtn:hover .roleIcon {
+  transform: scale(1.12) translateY(-4px) rotate(5deg);
+}
+
+.roleContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.roleTitle {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.rolePrimary .roleTitle {
+  color: #1e40af;
+}
+.rolePrimary:hover .roleTitle {
+  color: #1d4ed8;
+}
+.roleSecondary .roleTitle {
+  color: #047857;
+}
+.roleSecondary:hover .roleTitle {
+  color: #059669;
+}
+.roleAccent .roleTitle {
+  color: #0e7490;
+}
+.roleAccent:hover .roleTitle {
+  color: #0891b2;
+}
+
+.roleSubtitle {
   font-size: 0.95rem;
+  font-weight: 500;
   color: var(--color-text-dim);
+  line-height: 1.4;
+}
+
+.info {
+  margin: 1rem auto 0;
+  animation: fade-in-up 0.8s ease-out 0.3s both;
+}
+
+.infoTitle {
+  font-size: clamp(1.6rem, 4vw, 2.5rem);
+  font-weight: 800;
+  color: #0f172a;
+  text-align: center;
+  margin: 0 0 2.5rem 0;
+  letter-spacing: -0.02em;
+  position: relative;
+  padding-bottom: 1rem;
+}
+
+.infoTitle::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80px;
+  height: 4px;
+  background: linear-gradient(90deg, #3b82f6, #06b6d4);
+  border-radius: 2px;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.infoItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.1rem;
+  padding: 2.25rem 1.75rem;
+  background: #ffffff;
+  border-radius: 20px;
+  border: 2px solid rgba(59, 130, 246, 0.08);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+  transition: all 0.4s var(--easing-spring);
+  position: relative;
+  overflow: hidden;
+}
+
+.infoItem::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #3b82f6, #06b6d4);
+  transform: scaleX(0);
+  transition: transform 0.4s ease;
+}
+
+.infoItem:hover::before {
+  transform: scaleX(1);
+}
+
+.infoItem:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.22);
+}
+
+.infoNumber {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  font-weight: 800;
+  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3);
+  transition: transform 0.4s var(--easing-spring);
+}
+
+.infoItem:hover .infoNumber {
+  transform: scale(1.1) rotate(5deg);
+}
+
+.infoContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.infoContent h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.infoContent p {
+  font-size: 1rem;
+  color: var(--color-text-dim);
+  margin: 0;
+  line-height: 1.55;
+  font-weight: 500;
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1100px) {
+  .actions {
+    grid-template-columns: 1fr;
+    max-width: 480px;
+    margin: 0 auto;
+    gap: 1.25rem;
+  }
+  .roleBtn {
+    min-height: 180px;
+  }
+  .infoGrid {
+    grid-template-columns: 1fr;
+    max-width: 520px;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .main {
+    padding: 3rem 0 4rem;
+  }
+  .content {
+    gap: 3rem;
+  }
+  .container {
+    padding: 0 1.5rem;
+  }
+  .roleBtn {
+    padding: 2rem 1.5rem;
+    min-height: 170px;
+  }
+  .roleIcon {
+    font-size: 3rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0 1.25rem;
+  }
+  .main {
+    padding: 2.5rem 0 3.5rem;
+  }
+  .content {
+    gap: 2.5rem;
+  }
 }

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -10,11 +10,23 @@ describe("HomePage", () => {
         <HomePage />
       </MemoryRouter>,
     );
-    const host = screen.getByRole("link", { name: /host a game/i });
-    const join = screen.getByRole("link", { name: /join a team/i });
-    const display = screen.getByRole("link", { name: /open display/i });
+    const host = screen.getByRole("link", { name: /manager console/i });
+    const join = screen.getByRole("link", { name: /join as team/i });
+    const display = screen.getByRole("link", { name: /display screen/i });
     expect(host).toHaveAttribute("href", "/manager/login");
     expect(join).toHaveAttribute("href", "/join");
     expect(display).toHaveAttribute("href", "/display");
+  });
+
+  it("renders the How to Play steps", () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: /how to play/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /teams join/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /listen & buzz/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /manager awards/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,35 +1,88 @@
 import { Link } from "react-router-dom";
+import { Logo } from "../components/Logo";
 import styles from "./HomePage.module.css";
 
 export function HomePage() {
   return (
-    <main className={styles.shell}>
-      <div className={styles.hero}>
-        <div>
-          <h1 className={styles.title}>Sound Clash</h1>
-          <p className={styles.subtitle}>
-            Real-time multiplayer music trivia. Buzz in, name the tune, win the round.
-          </p>
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.container}>
+          <Logo size="large" />
         </div>
-        <div className={styles.cards}>
-          <Link to="/manager/login" className={styles.card}>
-            <span className={styles.cardTitle}>Host a game</span>
-            <span className={styles.cardDesc}>Create a game, pick genres, run the round.</span>
-          </Link>
-          <Link to="/join" className={styles.card}>
-            <span className={styles.cardTitle}>Join a team</span>
-            <span className={styles.cardDesc}>
-              Enter a 6-letter code, pick a name, start buzzing.
-            </span>
-          </Link>
-          <Link to="/display" className={styles.card}>
-            <span className={styles.cardTitle}>Open display</span>
-            <span className={styles.cardDesc}>
-              Read-only scoreboard for a screen everyone can see.
-            </span>
-          </Link>
+      </header>
+
+      <main className={styles.main}>
+        <div className={styles.container}>
+          <div className={styles.content}>
+            <section className={styles.hero}>
+              <h1 className={styles.title}>Welcome to Sound Clash</h1>
+              <p className={styles.subtitle}>The ultimate music trivia buzzer game</p>
+              <p className={styles.description}>Choose your role to get started</p>
+            </section>
+
+            <section className={styles.actions}>
+              <Link to="/manager/login" className={`${styles.roleBtn} ${styles.rolePrimary}`}>
+                <span className={styles.roleIcon} aria-hidden="true">
+                  🎮
+                </span>
+                <span className={styles.roleContent}>
+                  <span className={styles.roleTitle}>Manager Console</span>
+                  <span className={styles.roleSubtitle}>Host a game</span>
+                </span>
+              </Link>
+
+              <Link to="/join" className={`${styles.roleBtn} ${styles.roleSecondary}`}>
+                <span className={styles.roleIcon} aria-hidden="true">
+                  📱
+                </span>
+                <span className={styles.roleContent}>
+                  <span className={styles.roleTitle}>Join as Team</span>
+                  <span className={styles.roleSubtitle}>Play on your phone</span>
+                </span>
+              </Link>
+
+              <Link to="/display" className={`${styles.roleBtn} ${styles.roleAccent}`}>
+                <span className={styles.roleIcon} aria-hidden="true">
+                  📺
+                </span>
+                <span className={styles.roleContent}>
+                  <span className={styles.roleTitle}>Display Screen</span>
+                  <span className={styles.roleSubtitle}>Show scoreboard</span>
+                </span>
+              </Link>
+            </section>
+
+            <section className={styles.info}>
+              <h2 className={styles.infoTitle}>How to Play</h2>
+              <div className={styles.infoGrid}>
+                <article className={styles.infoItem}>
+                  <span className={styles.infoNumber}>1</span>
+                  <div className={styles.infoContent}>
+                    <h3>Teams Join</h3>
+                    <p>Each team uses their phone to join with a 6-letter game code.</p>
+                  </div>
+                </article>
+
+                <article className={styles.infoItem}>
+                  <span className={styles.infoNumber}>2</span>
+                  <div className={styles.infoContent}>
+                    <h3>Listen & Buzz</h3>
+                    <p>First team to buzz gets to answer the song.</p>
+                  </div>
+                </article>
+
+                <article className={styles.infoItem}>
+                  <span className={styles.infoNumber}>3</span>
+                  <div className={styles.infoContent}>
+                    <h3>Manager Awards</h3>
+                    <p>The host approves or declines, and the next round starts.</p>
+                  </div>
+                </article>
+              </div>
+            </section>
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </div>
   );
 }

--- a/frontend/src/pages/JoinTeamPage.module.css
+++ b/frontend/src/pages/JoinTeamPage.module.css
@@ -3,57 +3,89 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-xl);
+  padding: var(--space-xl) var(--space-lg);
 }
 
 .card {
   width: 100%;
-  max-width: 420px;
-  background: var(--color-card);
+  max-width: 460px;
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  padding: var(--space-xl);
+  padding: 2.5rem 2.25rem;
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.5rem;
   box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #3b82f6 0%, #06b6d4 50%, #10b981 100%);
 }
 
 .title {
-  font-size: 1.6rem;
-  font-weight: 700;
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 
 .subtitle {
   color: var(--color-text-dim);
-  font-size: 0.95rem;
+  font-size: 1rem;
+  margin: 0.25rem 0 0;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: 0.5rem;
 }
 
 .label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-text-dim);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .codeInput {
   letter-spacing: 0.5em;
   text-align: center;
-  font-size: 1.6rem;
-  font-weight: 700;
+  font-size: 1.75rem;
+  font-weight: 800;
   text-transform: uppercase;
+  color: var(--color-primary-strong);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 .actions {
   display: flex;
-  gap: var(--space-sm);
-  justify-content: space-between;
+  gap: 0.75rem;
+  justify-content: flex-end;
   align-items: center;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 2rem 1.5rem;
+  }
+  .title {
+    font-size: 1.5rem;
+  }
+  .codeInput {
+    font-size: 1.5rem;
+    letter-spacing: 0.4em;
+  }
 }

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -1,19 +1,24 @@
 .shell {
   min-height: 100%;
-  padding: var(--space-lg);
-  max-width: 1100px;
+  padding: 1.75rem var(--space-lg);
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.5rem;
 }
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-md);
+  gap: 1rem;
   flex-wrap: wrap;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.5rem;
+  box-shadow: var(--shadow-md);
 }
 
 .codeBlock {
@@ -23,47 +28,55 @@
 }
 
 .codeLabel {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--color-text-dim);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .code {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 1.8rem;
+  font-size: 1.85rem;
   font-weight: 800;
   letter-spacing: 0.16em;
+  background: linear-gradient(135deg, #3b82f6 0%, #06b6d4 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .statusPill {
-  padding: 4px 12px;
+  padding: 6px 14px;
   border-radius: var(--radius-pill);
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: 0.75rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   border: 1px solid currentColor;
 }
 
 .statusWaiting {
   color: var(--color-warning);
+  background: rgba(245, 158, 11, 0.1);
 }
 .statusPlaying {
   color: var(--color-success);
+  background: rgba(16, 185, 129, 0.1);
 }
 .statusEnded {
   color: var(--color-text-dim);
+  background: rgba(148, 163, 184, 0.12);
+  border-color: var(--color-border-strong);
 }
 
 .grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--space-lg);
+  gap: 1.5rem;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 960px) {
   .grid {
     grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
   }
@@ -72,98 +85,174 @@
 .column {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.5rem;
 }
 
 .card {
-  background: var(--color-card);
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #3b82f6 0%, #06b6d4 100%);
+  opacity: 0.85;
 }
 
 .cardTitle {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--color-text-dim);
-  font-weight: 600;
-  margin-bottom: var(--space-md);
+  font-weight: 700;
+  margin-bottom: 1rem;
 }
 
 .songLine {
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0f172a;
 }
 
 .songMeta {
   font-size: 0.95rem;
   color: var(--color-text-dim);
+  margin-top: 0.2rem;
 }
 
 .timer {
   font-variant-numeric: tabular-nums;
-  font-size: 1.4rem;
-  font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 800;
   color: var(--color-warning);
+  letter-spacing: 0.02em;
 }
 
 .timerLow {
   color: var(--color-danger);
+  animation: timer-pulse 0.7s ease-in-out infinite;
+}
+
+@keyframes timer-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.06);
+    opacity: 0.85;
+  }
 }
 
 .checkRow {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-md);
+  gap: 1rem;
+  padding: 0.5rem 0;
 }
 
 .checkLabel {
   display: flex;
-  gap: var(--space-sm);
+  gap: 0.5rem;
   align-items: center;
   font-weight: 600;
   cursor: pointer;
   user-select: none;
+  padding: 8px 14px;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: #ffffff;
+  transition:
+    border-color 200ms ease,
+    background 200ms ease,
+    color 200ms ease;
+}
+
+.checkLabel:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+}
+
+.checkLabel input {
+  padding: 0;
+  width: auto;
+  accent-color: var(--color-primary);
+}
+
+.checkLabel input:disabled + * {
+  opacity: 0.5;
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-sm);
-  justify-content: space-between;
+  gap: 0.6rem;
+  justify-content: flex-end;
 }
 
 .teamRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
-  background: var(--color-bg-elev);
-  border-radius: var(--radius-sm);
-  margin-bottom: 6px;
+  padding: 12px 16px;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  margin-bottom: 8px;
+  transition: border-color 200ms ease;
 }
 
 .teamRow:last-child {
   margin-bottom: 0;
 }
 
+.teamRow:hover {
+  border-color: var(--color-primary);
+}
+
 .teamRowName {
-  font-weight: 600;
+  font-weight: 700;
+  color: #0f172a;
 }
 
 .teamRowMeta {
   display: flex;
-  gap: var(--space-md);
+  gap: 1rem;
   align-items: center;
   color: var(--color-text-dim);
   font-size: 0.95rem;
 }
 
 .lockedBanner {
-  padding: var(--space-md);
+  padding: 1rem 1.25rem;
   border-radius: var(--radius-md);
-  background: var(--color-accent-soft);
-  border: 1px solid var(--color-accent);
-  font-weight: 600;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0%, rgba(251, 191, 36, 0.1) 100%);
+  border: 2px solid var(--color-warning);
+  font-weight: 700;
+  color: #92400e;
+  font-size: 1.05rem;
+}
+
+@media (max-width: 600px) {
+  .shell {
+    padding: 1.25rem var(--space-md);
+  }
+  .header {
+    padding: 0.85rem 1rem;
+  }
+  .code {
+    font-size: 1.5rem;
+  }
 }

--- a/frontend/src/pages/ManagerCreateGamePage.module.css
+++ b/frontend/src/pages/ManagerCreateGamePage.module.css
@@ -1,71 +1,125 @@
 .shell {
   min-height: 100%;
-  padding: var(--space-xl);
-  max-width: 720px;
+  padding: 2.5rem var(--space-lg);
+  max-width: 800px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 2rem;
+}
+
+.shell > header h1 {
+  font-size: 2rem;
+  color: #0f172a;
+  letter-spacing: -0.02em;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: 0.75rem;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.5rem 1.5rem;
+  box-shadow: var(--shadow-md);
 }
 
 .label {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-text-dim);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .genres {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: var(--space-sm);
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.6rem;
 }
 
 .genre {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
-  padding: 10px 12px;
-  background: var(--color-bg-elev);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  gap: 0.6rem;
+  padding: 12px 14px;
+  background: #ffffff;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
   cursor: pointer;
   user-select: none;
-  transition: border-color 160ms ease;
+  font-weight: 600;
+  color: var(--color-text-dim);
+  transition:
+    border-color 200ms ease,
+    background 200ms ease,
+    color 200ms ease,
+    transform 100ms ease;
 }
 
 .genre:hover {
-  border-color: var(--color-border-strong);
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+  transform: translateY(-1px);
+}
+
+.genre input {
+  width: auto;
+  padding: 0;
+  margin: 0;
+  accent-color: var(--color-primary);
 }
 
 .genreSelected {
-  border-color: var(--color-accent);
-  background: var(--color-accent-soft);
+  border-color: var(--color-primary);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, var(--color-primary-soft) 100%);
+  color: var(--color-primary-strong);
+  box-shadow: 0 2px 6px rgba(59, 130, 246, 0.18);
 }
 
 .actions {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-md);
+  gap: 1rem;
+  margin-top: 0.5rem;
 }
 
 .rounds {
   display: flex;
   align-items: center;
-  gap: var(--space-md);
+  gap: 1rem;
+}
+
+.rounds input[type="range"] {
+  flex: 1;
+  padding: 0;
+  background: transparent;
+  border: none;
+  accent-color: var(--color-primary);
+}
+
+.rounds input[type="range"]:focus {
+  background: transparent;
+  box-shadow: none;
 }
 
 .roundsValue {
-  font-size: 1.4rem;
-  font-weight: 700;
+  font-size: 1.5rem;
+  font-weight: 800;
   font-variant-numeric: tabular-nums;
   min-width: 2.5em;
+  color: var(--color-primary-strong);
+  text-align: right;
+}
+
+@media (max-width: 600px) {
+  .shell {
+    padding: 1.5rem var(--space-md);
+  }
+  .field {
+    padding: 1.25rem;
+  }
 }

--- a/frontend/src/pages/ManagerLoginPage.module.css
+++ b/frontend/src/pages/ManagerLoginPage.module.css
@@ -3,33 +3,50 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-xl);
+  padding: var(--space-xl) var(--space-lg);
 }
 
 .card {
   width: 100%;
-  max-width: 380px;
-  padding: var(--space-xl);
-  background: var(--color-card);
+  max-width: 400px;
+  padding: 2.5rem 2.25rem;
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.25rem;
   box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #3b82f6 0%, #06b6d4 100%);
 }
 
 .title {
-  font-size: 1.6rem;
-  font-weight: 700;
+  font-size: 1.65rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 
 .subtitle {
   color: var(--color-text-dim);
   font-size: 0.95rem;
+  margin: 0.25rem 0 0;
 }
 
 .actions {
   display: flex;
   justify-content: flex-end;
+  margin-top: 0.5rem;
 }

--- a/frontend/src/pages/TeamGameplayPage.module.css
+++ b/frontend/src/pages/TeamGameplayPage.module.css
@@ -1,9 +1,9 @@
 .shell {
   min-height: 100%;
-  padding: var(--space-lg);
+  padding: 1.5rem var(--space-lg);
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: 1.5rem;
   max-width: 720px;
   margin: 0 auto;
 }
@@ -12,7 +12,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-md);
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1.25rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .identity {
@@ -22,8 +28,10 @@
 }
 
 .teamName {
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.01em;
 }
 
 .gameCode {
@@ -31,53 +39,71 @@
   font-size: 0.95rem;
   color: var(--color-text-dim);
   letter-spacing: 0.16em;
+  font-weight: 600;
 }
 
 .statusBanner {
   text-align: center;
-  padding: var(--space-md);
+  padding: 1rem 1.25rem;
   border-radius: var(--radius-md);
-  background: var(--color-bg-elev);
-  border: 1px solid var(--color-border);
-  font-weight: 600;
+  background: #ffffff;
+  border: 2px solid var(--color-border);
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--color-text-dim);
+  box-shadow: var(--shadow-sm);
 }
 
 .statusPlaying {
-  background: rgba(40, 199, 111, 0.12);
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.16) 0%, rgba(52, 211, 153, 0.08) 100%);
   border-color: var(--color-success);
-  color: var(--color-success);
+  color: #065f46;
 }
 
 .statusEnded {
-  background: rgba(91, 101, 115, 0.12);
+  background: rgba(148, 163, 184, 0.12);
   border-color: var(--color-border-strong);
   color: var(--color-text-dim);
 }
 
 .statusLocked {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-  color: var(--color-accent);
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0%, rgba(251, 191, 36, 0.08) 100%);
+  border-color: var(--color-warning);
+  color: #92400e;
 }
 
 .buzzZone {
   display: flex;
   justify-content: center;
-  padding: var(--space-xl) 0;
+  padding: 1.5rem 0;
 }
 
 .scoreCard {
-  background: var(--color-card);
+  background: #ffffff;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-md);
 }
 
 .scoreCardTitle {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--color-text-dim);
-  font-weight: 600;
-  margin-bottom: var(--space-md);
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 480px) {
+  .shell {
+    padding: 1rem var(--space-md);
+    gap: 1.25rem;
+  }
+  .teamName {
+    font-size: 1.05rem;
+  }
+  .gameCode {
+    font-size: 0.85rem;
+  }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,27 +1,36 @@
 :root {
-  --color-bg: #0a0e14;
-  --color-bg-elev: #131820;
-  --color-card: #161b22;
-  --color-text: #e8edf2;
-  --color-text-dim: #8b95a3;
-  --color-text-mute: #5b6573;
-  --color-accent: #ff5a5f;
-  --color-accent-hover: #ff7479;
-  --color-accent-soft: rgba(255, 90, 95, 0.18);
-  --color-success: #28c76f;
-  --color-warning: #ffb547;
-  --color-danger: #ff4757;
-  --color-border: #20262e;
-  --color-border-strong: #2c3340;
+  --color-bg: #f8fafc;
+  --color-bg-elev: #ffffff;
+  --color-card: #ffffff;
+  --color-bg-tint: #f0f4ff;
+  --color-text: #0f172a;
+  --color-text-dim: #475569;
+  --color-text-mute: #94a3b8;
+
+  --color-primary: #3b82f6;
+  --color-primary-strong: #2563eb;
+  --color-primary-soft: rgba(59, 130, 246, 0.08);
+  --color-secondary: #10b981;
+  --color-secondary-strong: #059669;
+  --color-secondary-soft: rgba(16, 185, 129, 0.08);
+  --color-accent: #06b6d4;
+  --color-accent-strong: #0891b2;
+  --color-accent-soft: rgba(6, 182, 212, 0.08);
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-success: #10b981;
+
+  --color-border: #e2e8f0;
+  --color-border-strong: #cbd5e1;
 
   --radius-sm: 6px;
   --radius-md: 12px;
   --radius-lg: 20px;
   --radius-pill: 999px;
 
-  --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.25);
-  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.35);
-  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.45);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07), 0 1px 3px rgba(0, 0, 0, 0.05);
+  --shadow-lg: 0 12px 30px rgba(15, 23, 42, 0.12), 0 4px 8px rgba(15, 23, 42, 0.06);
 
   --space-xs: 4px;
   --space-sm: 8px;
@@ -30,9 +39,11 @@
   --space-xl: 40px;
   --space-2xl: 64px;
 
-  --font-display: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-display:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
 
-  color-scheme: dark;
+  --easing-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 * {
@@ -47,20 +58,26 @@ body,
 
 body {
   margin: 0;
-  background: var(--color-bg);
+  background:
+    radial-gradient(circle at 20% 30%, rgba(59, 130, 246, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 80% 70%, rgba(6, 182, 212, 0.05) 0%, transparent 50%),
+    linear-gradient(180deg, #f8fafc 0%, #e0e7ff 60%, #dbeafe 100%);
+  background-attachment: fixed;
   color: var(--color-text);
   font-family: var(--font-display);
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1,
 h2,
 h3 {
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   margin: 0;
+  color: var(--color-text);
 }
 
 h1 {
@@ -80,7 +97,7 @@ p {
 }
 
 a {
-  color: var(--color-accent);
+  color: var(--color-primary-strong);
   text-decoration: none;
 }
 
@@ -100,23 +117,28 @@ textarea {
   font-size: 1rem;
   color: var(--color-text);
   background: var(--color-bg-elev);
-  border: 1px solid var(--color-border);
+  border: 2px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 10px 12px;
+  padding: 10px 14px;
   outline: none;
-  transition: border-color 160ms ease;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    background 200ms ease;
 }
 
 input:focus,
 select:focus,
 textarea:focus {
-  border-color: var(--color-accent);
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
 }
 
 input:disabled,
 select:disabled,
 textarea:disabled {
-  opacity: 0.5;
+  opacity: 0.6;
   cursor: not-allowed;
 }
 
@@ -129,22 +151,25 @@ textarea:disabled {
   align-items: center;
   justify-content: center;
   gap: var(--space-sm);
-  padding: 12px 20px;
+  padding: 12px 22px;
   font-size: 1rem;
   font-weight: 600;
-  border: 1px solid transparent;
+  border: 2px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-elev);
   color: var(--color-text);
   transition:
-    background 160ms ease,
-    border-color 160ms ease,
+    background 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease,
+    box-shadow 200ms ease,
     transform 80ms ease;
 }
 
 .btn:hover:not(:disabled) {
-  background: var(--color-card);
-  border-color: var(--color-border-strong);
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
 }
 
 .btn:active:not(:disabled) {
@@ -157,24 +182,29 @@ textarea:disabled {
 }
 
 .btn-primary {
-  background: var(--color-accent);
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
   color: #fff;
-  border-color: var(--color-accent);
+  border-color: transparent;
+  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.2);
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.35);
 }
 
 .btn-ghost {
   background: transparent;
+  border-color: transparent;
   color: var(--color-text-dim);
 }
 
 .btn-ghost:hover:not(:disabled) {
-  color: var(--color-text);
-  background: var(--color-bg-elev);
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+  border-color: transparent;
 }
 
 .btn-danger {
@@ -184,7 +214,9 @@ textarea:disabled {
 }
 
 .btn-danger:hover:not(:disabled) {
-  background: rgba(255, 71, 87, 0.12);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--color-danger);
+  border-color: var(--color-danger);
 }
 
 .card {
@@ -192,6 +224,7 @@ textarea:disabled {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
+  box-shadow: var(--shadow-md);
 }
 
 .stack {
@@ -213,6 +246,7 @@ textarea:disabled {
 .error {
   color: var(--color-danger);
   font-size: 0.95rem;
+  font-weight: 500;
 }
 
 .code {


### PR DESCRIPTION
## Summary
- Port the legacy frontend's design language: light gradient backgrounds, blue/cyan/green palette, system font stack
- Add an animated Logo component (sound-wave bars + gradient text) used in HomePage header
- Restructure HomePage with three role buttons (Manager Console / Join as Team / Display Screen) and a "How to Play" section
- Restyle every page CSS module + BuzzButton/Scoreboard/YouTubePlayer components to match
- BuzzButton is now a pulsing green circle that scales on hover and locks gray when disabled

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (115/115 pass)
- [x] `npm run test:coverage` — 91.03 / 83.96 / 93.84 / 94.20 (above the 85/80/85/85 floor)
- [x] `npm run build` — production bundle builds clean
- [ ] Visual smoke: open localhost:5173 with `npm run dev`, click through home → join → manager → display
- [ ] Mobile viewport check (DevTools responsive mode)