### PR TITLE
fix: stabilization pass (config, hydration race, YT onError, health log)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -62,4 +62,6 @@ def get_settings() -> Settings:
     }
     if cors:
         kwargs["cors_origins"] = cors
+    # reason: kwargs is dict[str, object] because cors_origins is conditionally
+    # added as list[str]; mypy can't narrow the union per-key for **kwargs.
     return Settings(**kwargs)  # type: ignore[arg-type]

--- a/backend/app/db/supabase_client.py
+++ b/backend/app/db/supabase_client.py
@@ -7,6 +7,7 @@ with the service-role key; tests inject a fake via
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Any, Literal, Protocol, runtime_checkable
@@ -15,6 +16,8 @@ import anyio
 from supabase import Client, create_client
 
 from app.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -57,6 +60,7 @@ async def health_check_supabase() -> Literal["ok", "degraded"]:
             await anyio.to_thread.run_sync(_probe)
         return "ok"
     except Exception:
+        logger.warning("supabase health probe failed", exc_info=True)
         return "degraded"
 
 

--- a/frontend/src/components/YouTubePlayer.module.css
+++ b/frontend/src/components/YouTubePlayer.module.css
@@ -37,3 +37,10 @@
   color: rgba(255, 255, 255, 0.65);
   font-size: 0.95rem;
 }
+
+.error {
+  color: #fecaca;
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 0 1rem;
+}

--- a/frontend/src/components/YouTubePlayer.test.tsx
+++ b/frontend/src/components/YouTubePlayer.test.tsx
@@ -12,12 +12,22 @@ interface FakeYTPlayer {
 }
 
 let lastPlayer: FakeYTPlayer | null = null;
-let lastConfig: { events?: { onReady?: () => void } } | null = null;
+let lastConfig: {
+  events?: {
+    onReady?: () => void;
+    onError?: (event: { data: number }) => void;
+  };
+} | null = null;
 
 function installFakeYT() {
   function FakePlayer(
     _el: HTMLElement,
-    config: { events?: { onReady?: () => void } },
+    config: {
+      events?: {
+        onReady?: () => void;
+        onError?: (event: { data: number }) => void;
+      };
+    },
   ): FakeYTPlayer {
     const instance: FakeYTPlayer = {
       loadVideoById: vi.fn(),
@@ -83,6 +93,33 @@ describe("YouTubePlayer", () => {
       lastConfig?.events?.onReady?.();
     });
     expect(onReady).toHaveBeenCalled();
+  });
+
+  it("renders an error message and invokes onError when YT fires onError", async () => {
+    installFakeYT();
+    const onError = vi.fn();
+    const { findByRole } = render(<YouTubePlayer onError={onError} />);
+    await waitFor(() => expect(lastConfig).not.toBeNull());
+    act(() => {
+      lastConfig?.events?.onError?.({ data: 150 });
+    });
+    const alert = await findByRole("alert");
+    expect(alert.textContent).toContain("Video unavailable");
+    expect(onError).toHaveBeenCalledWith(150);
+  });
+
+  it("keeps the overlay visible on error even when hideOverlay is true", async () => {
+    installFakeYT();
+    const { findByRole } = render(<YouTubePlayer hideOverlay />);
+    await waitFor(() => expect(lastConfig).not.toBeNull());
+    act(() => {
+      lastConfig?.events?.onReady?.();
+    });
+    act(() => {
+      lastConfig?.events?.onError?.({ data: 100 });
+    });
+    const alert = await findByRole("alert");
+    expect(alert.className).not.toContain("coverHidden");
   });
 
   it("loads the iframe API script when YT is not yet on window", async () => {

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -11,6 +11,7 @@ export interface YouTubePlayerHandle {
 interface Props {
   hideOverlay?: boolean;
   onReady?: () => void;
+  onError?: (code: number) => void;
 }
 
 interface YTPlayer {
@@ -19,6 +20,10 @@ interface YTPlayer {
   playVideo: () => void;
   stopVideo: () => void;
   destroy: () => void;
+}
+
+interface YTErrorEvent {
+  data: number;
 }
 
 interface YTNamespace {
@@ -30,6 +35,7 @@ interface YTNamespace {
       playerVars?: Record<string, number | string>;
       events?: {
         onReady?: () => void;
+        onError?: (event: YTErrorEvent) => void;
       };
     },
   ) => YTPlayer;
@@ -62,12 +68,13 @@ function loadApi(): Promise<YTNamespace> {
 }
 
 export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function YouTubePlayer(
-  { hideOverlay, onReady },
+  { hideOverlay, onReady, onError },
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<YTPlayer | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [errorCode, setErrorCode] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -86,8 +93,13 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
         },
         events: {
           onReady: () => {
+            setErrorCode(null);
             setLoaded(true);
             onReady?.();
+          },
+          onError: (event) => {
+            setErrorCode(event.data);
+            onError?.(event.data);
           },
         },
       });
@@ -97,7 +109,7 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
       playerRef.current?.destroy();
       playerRef.current = null;
     };
-  }, [onReady]);
+  }, [onReady, onError]);
 
   useImperativeHandle(
     ref,
@@ -115,11 +127,19 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     [],
   );
 
+  const overlayHidden = hideOverlay && loaded && errorCode === null;
   return (
     <div className={styles.wrapper}>
       <div ref={containerRef} className={styles.player} />
-      <div className={`${styles.cover} ${hideOverlay && loaded ? styles.coverHidden : ""}`}>
-        <span className={styles.loading}>{loaded ? "Ready" : "Loading player..."}</span>
+      <div
+        className={`${styles.cover} ${overlayHidden ? styles.coverHidden : ""}`}
+        role={errorCode !== null ? "alert" : undefined}
+      >
+        {errorCode !== null ? (
+          <span className={styles.error}>Video unavailable — manager can pick a new song.</span>
+        ) : (
+          <span className={styles.loading}>{loaded ? "Ready" : "Loading player..."}</span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -320,4 +320,30 @@ describe("useGameChannel - subscription", () => {
     });
     await waitFor(() => expect(result.current.status).toBe("gone"));
   });
+
+  it("queues Realtime events that arrive during hydration and replays them after HYDRATE", async () => {
+    const game = makeActiveGame({ status: "waiting" });
+    setHydrate({ game, teams: [], rounds: [] });
+    const { result } = renderHook(() => useGameChannel("ABCDEF"));
+
+    // Begin subscription handshake but don't await it yet — we want to
+    // interleave a Realtime UPDATE before hydrate's SELECTs settle.
+    const subPromise = fireSubscribed();
+
+    // This UPDATE arrives while state is still null. Without queuing the
+    // reducer's null guards drop it; with queuing it replays after HYDRATE.
+    fireGame(
+      makePayload("active_games", "UPDATE", {
+        new: { ...game, status: "playing" },
+      }),
+    );
+
+    await act(async () => {
+      await subPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.state?.game.status).toBe("playing");
+    });
+  });
 });

--- a/frontend/src/hooks/useGameChannel.ts
+++ b/frontend/src/hooks/useGameChannel.ts
@@ -84,8 +84,22 @@ export function useGameChannel(gameCode: string): {
   useEffect(() => {
     if (!gameCode) return;
     let cancelled = false;
+    let hydrated = false;
+    // Realtime events that arrive between SUBSCRIBED and HYDRATE land on
+    // state===null and are dropped by the reducer's null guards. Queue them
+    // here and replay after HYDRATE; gameReducer is idempotent so replay is safe.
+    const pending: GameAction[] = [];
     setStatus("connecting");
     setError(null);
+
+    function dispatchOrQueue(action: GameAction): void {
+      if (cancelled) return;
+      if (!hydrated) {
+        pending.push(action);
+        return;
+      }
+      dispatch(action);
+    }
 
     const filter = `game_code=eq.${gameCode}`;
     type LooseChannel = {
@@ -103,7 +117,7 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<ActiveGame>;
           observeServerTime(typed.commit_timestamp);
-          dispatch({ type: "GAME_CHANGE", payload: typed });
+          dispatchOrQueue({ type: "GAME_CHANGE", payload: typed });
           if (typed.eventType === "DELETE") setStatus("gone");
         },
       )
@@ -113,7 +127,7 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<Team>;
           observeServerTime(typed.commit_timestamp);
-          dispatch({ type: "TEAM_CHANGE", payload: typed });
+          dispatchOrQueue({ type: "TEAM_CHANGE", payload: typed });
         },
       )
       .on(
@@ -122,7 +136,7 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<GameRound>;
           observeServerTime(typed.commit_timestamp);
-          dispatch({ type: "ROUND_CHANGE", payload: typed });
+          dispatchOrQueue({ type: "ROUND_CHANGE", payload: typed });
         },
       )
       .subscribe((subStatus) => {
@@ -144,25 +158,32 @@ export function useGameChannel(gameCode: string): {
           supabase.from("game_teams").select("*").eq("game_code", gameCode),
           supabase.from("game_rounds").select("*").eq("game_code", gameCode),
         ]);
-        if (cancelled) return;
-        if (gameRes.error) throw gameRes.error;
-        if (teamsRes.error) throw teamsRes.error;
-        if (roundsRes.error) throw roundsRes.error;
-        if (!gameRes.data) {
-          setStatus("gone");
-          dispatch({ type: "GAME_DELETED" });
-          return;
+        if (!cancelled) {
+          if (gameRes.error) throw gameRes.error;
+          if (teamsRes.error) throw teamsRes.error;
+          if (roundsRes.error) throw roundsRes.error;
+          if (!gameRes.data) {
+            setStatus("gone");
+            dispatch({ type: "GAME_DELETED" });
+          } else {
+            dispatch({
+              type: "HYDRATE",
+              game: gameRes.data as ActiveGame,
+              teams: (teamsRes.data ?? []) as Team[],
+              rounds: (roundsRes.data ?? []) as GameRound[],
+            });
+          }
         }
-        dispatch({
-          type: "HYDRATE",
-          game: gameRes.data as ActiveGame,
-          teams: (teamsRes.data ?? []) as Team[],
-          rounds: (roundsRes.data ?? []) as GameRound[],
-        });
       } catch (e) {
-        if (cancelled) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
+        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
       }
+      hydrated = true;
+      if (!cancelled) {
+        for (const action of pending) {
+          dispatch(action);
+        }
+      }
+      pending.length = 0;
     }
 
     return () => {


### PR DESCRIPTION
## Summary

Cleanup-and-stabilization pass — no new features. Four small, verified fixes:

- `backend/app/config.py:65` — type-ignore now carries the reason comment CLAUDE.md requires.
- `backend/app/db/supabase_client.py` — health probe logs at `WARNING` before swallowing the exception, so a bad service-role key isn't silent.
- `frontend/src/hooks/useGameChannel.ts` — Realtime events that fire between `SUBSCRIBED` and `HYDRATE` were landing on `state===null` and getting dropped by the reducer's null guards. Queue them while hydrate is in flight, drain after `HYDRATE`. The reducer is already idempotent so replay is safe.
- `frontend/src/components/YouTubePlayer.tsx` — added an `onError` handler. Geo-blocked or removed videos used to leave the loading overlay visible forever; now the overlay shows "Video unavailable" and an optional `onError` prop is exposed for callers.

Also explicitly considered and rejected:

- **`buzz_in` "RETURNING race"** — Postgres serializes `UPDATE…WHERE buzzed_team_id IS NULL` via row locks and the existing 100× stress job in CI proves single-winner. Not a bug.
- **`award_points` "silent no-buzzer"** — correct gameplay: no buzzer ⇒ no team to award. Not a bug.
- **Dead code removed** — none. The repo was already clean (no unused imports, no commented-out blocks, no stray `console.log`/`print`, no orphan files, no TODO/FIXME).

## Test plan

- [x] `cd backend && ruff check . && ruff format --check . && mypy app` — green
- [x] `cd backend && pytest` — 29 passing locally; 114 require Docker (testcontainers) and run on CI's Postgres service container instead
- [x] `cd frontend && npm run lint && npm run typecheck && npm run format:check` — green
- [x] `cd frontend && npm run test:run` — 136 / 136 passing (133 baseline + 3 new: 1 hydration-race, 2 YT error-path)
- [ ] CI: backend + frontend + e2e workflows (gated server-side)