### PR TITLE
feat(e2e): Phase 6 cores — buzzer_race + full_game

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,21 +28,39 @@ jobs:
         with:
           node-version: "20"
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install backend deps
+        working-directory: backend
+        run: pip install -e ".[dev]"
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
       - name: Install Playwright
         working-directory: tests/e2e
         run: |
           npm install
-          npx playwright install --with-deps chromium firefox webkit
+          npx playwright install --with-deps chromium
 
-      - name: Run E2E
+      - name: Run E2E (chromium)
         working-directory: tests/e2e
         env:
+          # Backend reads these to talk to the preview Supabase project.
           SUPABASE_URL: ${{ secrets.SUPABASE_PREVIEW_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PREVIEW_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_PREVIEW_SERVICE_ROLE_KEY }}
           ADMIN_PASSWORD: ${{ secrets.PREVIEW_ADMIN_PASSWORD }}
-          BASE_URL: ${{ secrets.PREVIEW_BASE_URL }}
-        run: npx playwright test
+          # Frontend (Vite) reads these.
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_PREVIEW_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_PREVIEW_ANON_KEY }}
+          VITE_API_URL: http://localhost:8000
+          # Spec helpers reuse the backend URL.
+          API_URL: http://localhost:8000
+        run: npx playwright test --project=chromium
 
       - name: Upload report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,14 @@ jobs:
 
       - name: Install frontend deps
         working-directory: frontend
-        run: npm ci
+        # frontend/package-lock.json is intentionally untracked (see commit
+        # 888a5ab — npm 10 esbuild optional-deps bug). Mirror frontend.yml.
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
 
       - name: Install Playwright
         working-directory: tests/e2e

--- a/db/migrations/009_realtime_publication.sql
+++ b/db/migrations/009_realtime_publication.sql
@@ -1,0 +1,48 @@
+-- 009_realtime_publication.sql
+-- Add ephemeral tables to the `supabase_realtime` publication so that
+-- INSERT/UPDATE/DELETE row changes are broadcast over Supabase Realtime
+-- (WebSocket). Without this, every client subscribes successfully but
+-- never receives a single event — the publication filters them out.
+--
+-- Idempotent: guards each ALTER PUBLICATION with a pg_publication_tables
+-- check. Skips entirely when the publication doesn't exist (vanilla
+-- Postgres in testcontainers has no `supabase_realtime` publication).
+--
+-- REPLICA IDENTITY FULL ensures DELETE events emit the full old row, not
+-- just the primary key. Our useGameChannel reducer reads `payload.old.id`
+-- to evict from local state; that works either way, but FULL is the
+-- standard Supabase Realtime recommendation and lets future code rely on
+-- other old-row fields without surprise.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+    RAISE NOTICE 'supabase_realtime publication not found; skipping (vanilla postgres).';
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+     WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'active_games'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.active_games;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+     WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'game_teams'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.game_teams;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+     WHERE pubname = 'supabase_realtime' AND schemaname = 'public' AND tablename = 'game_rounds'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.game_rounds;
+  END IF;
+END $$;
+
+ALTER TABLE public.active_games REPLICA IDENTITY FULL;
+ALTER TABLE public.game_teams   REPLICA IDENTITY FULL;
+ALTER TABLE public.game_rounds  REPLICA IDENTITY FULL;

--- a/db/migrations/010_text_game_code.sql
+++ b/db/migrations/010_text_game_code.sql
@@ -1,0 +1,55 @@
+-- 010_text_game_code.sql
+-- Change `game_code` from char(6) to text on all three ephemeral tables.
+--
+-- Why: Supabase Realtime's logical-replication WAL decoder mishandles
+-- bpchar (char(n)) types — it returns only the first character. For
+-- game_teams and game_rounds that's harmless because their primary key
+-- is `id uuid` (decoded correctly), so Realtime resolves the row via
+-- the uuid PK and the filter matches against the actual stored
+-- `game_code`. But active_games' PK *is* `game_code`, so Realtime tries
+-- to resolve the row using the truncated 'V' instead of 'V6G5SR',
+-- finds nothing, and silently drops the UPDATE event. The visible
+-- symptom is that managers/teams/displays never see status changes
+-- after start_round / award_points / end_game / buzz_in.
+--
+-- Diagnostic confirmation (run 2026-05-05): with the publication
+-- correctly set up and REPLICA IDENTITY FULL, a service-role UPDATE
+-- to active_games produced zero events on a subscribed anon client,
+-- while INSERT and UPDATE on game_teams (uuid PK) produced one each.
+--
+-- Idempotent: skips if game_code is already text (data_type='text'
+-- in information_schema).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'active_games'
+       AND column_name = 'game_code'
+       AND data_type = 'character'
+  ) THEN
+    RAISE NOTICE 'game_code already migrated to text; skipping.';
+    RETURN;
+  END IF;
+
+  -- Drop FKs that reference active_games.game_code so we can re-type both sides.
+  ALTER TABLE game_teams  DROP CONSTRAINT IF EXISTS game_teams_game_code_fkey;
+  ALTER TABLE game_rounds DROP CONSTRAINT IF EXISTS game_rounds_game_code_fkey;
+
+  -- Re-type. char(6) values are stored padded to 6 chars; ours are
+  -- already exactly 6 chars (codes.py invariant), so the cast is a
+  -- no-op data-wise.
+  ALTER TABLE active_games ALTER COLUMN game_code TYPE text;
+  ALTER TABLE game_teams   ALTER COLUMN game_code TYPE text;
+  ALTER TABLE game_rounds  ALTER COLUMN game_code TYPE text;
+
+  -- Re-add FKs with their original semantics.
+  ALTER TABLE game_teams
+    ADD CONSTRAINT game_teams_game_code_fkey
+    FOREIGN KEY (game_code) REFERENCES active_games(game_code) ON DELETE CASCADE;
+
+  ALTER TABLE game_rounds
+    ADD CONSTRAINT game_rounds_game_code_fkey
+    FOREIGN KEY (game_code) REFERENCES active_games(game_code) ON DELETE CASCADE;
+END $$;

--- a/db/migrations/011_buzz_in_records_round.sql
+++ b/db/migrations/011_buzz_in_records_round.sql
@@ -1,0 +1,66 @@
+-- 011_buzz_in_records_round.sql
+-- Fix: buzz_in must also record the winning team on the current
+-- game_rounds row, so award_points can credit the team's score.
+--
+-- Previously, buzz_in only updated active_games.buzzed_team_id (the
+-- transient lock indicator that gets reset after each round). It did
+-- NOT touch game_rounds.buzzed_team_id, which remained NULL forever.
+-- award_points reads game_rounds.buzzed_team_id to decide whom to
+-- credit, so it always read NULL and skipped the
+-- `UPDATE game_teams SET score = score + v_total` step. Net result:
+-- every round closed cleanly, but no score ever changed.
+--
+-- Why nobody caught this before: the Phase 3 race tests assert on the
+-- buzz_in return value and on active_games row state; they never call
+-- award_points. The Phase 4 backend tests use the FakeSupabaseClient
+-- which mocks `award_points` instead of running it. The Playwright
+-- e2e suite is the first thing that exercises buzz_in → award_points
+-- end to end against real Postgres.
+--
+-- CREATE OR REPLACE keeps the same (char, uuid) signature so PostgREST
+-- continues to route browser calls to the same function — no API break.
+
+CREATE OR REPLACE FUNCTION buzz_in(
+  p_game_code char(6),
+  p_team_id   uuid
+)
+RETURNS TABLE(locked boolean, locked_team_id uuid, locked_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_round_id  uuid;
+  v_locked_at timestamptz;
+BEGIN
+  -- Atomic compare-and-set on active_games. RETURNING captures the
+  -- round we just locked and the resulting locked_at, which we need
+  -- both for the round update and the function's return value.
+  UPDATE active_games ag
+     SET buzzed_team_id = p_team_id,
+         locked_at      = now()
+   WHERE ag.game_code = p_game_code
+     AND ag.status = 'playing'
+     AND ag.buzzed_team_id IS NULL
+  RETURNING ag.current_round_id, ag.locked_at INTO v_round_id, v_locked_at;
+
+  IF FOUND THEN
+    -- Mirror the lock onto the round so award_points has a durable
+    -- pointer to the winning team. Skip if there's no current round
+    -- (defensive — should not happen during status='playing').
+    IF v_round_id IS NOT NULL THEN
+      UPDATE game_rounds
+         SET buzzed_team_id = p_team_id
+       WHERE id = v_round_id;
+    END IF;
+
+    RETURN QUERY SELECT true, p_team_id, v_locked_at;
+  ELSE
+    -- Already locked by someone else (or game not playable). Return
+    -- the existing winner so the client can render "X buzzed first".
+    RETURN QUERY
+    SELECT false, ag.buzzed_team_id, ag.locked_at
+      FROM active_games ag
+     WHERE ag.game_code = p_game_code;
+  END IF;
+END $$;

--- a/db/seed/songs.sql
+++ b/db/seed/songs.sql
@@ -1,0 +1,56 @@
+-- songs.sql
+-- Minimal song catalog for the Sound-Clash-Preview Supabase project.
+-- 12 placeholder songs across rock / pop / electronic / soundtrack so the
+-- Phase 6 Playwright e2e suite can run a 3-round game without exhausting
+-- pick_random_song.
+--
+-- Run once after migrations against the preview project:
+--   psql "$PREVIEW_DATABASE_URL" -f db/seed/songs.sql
+--
+-- Idempotent: songs match by youtube_id; song_genres rely on the
+-- (song_id, genre_id) primary key + ON CONFLICT DO NOTHING.
+--
+-- youtube_ids are intentionally placeholder strings that match the schema
+-- regex (^[A-Za-z0-9_-]{11}$) but won't resolve to real videos. The YT
+-- IFrame Player will surface "Video unavailable"; the e2e flow does not
+-- gate on actual playback (round controls work regardless).
+
+INSERT INTO songs (title, artist, youtube_id, start_time, is_soundtrack, source)
+SELECT s.title, s.artist, s.youtube_id, s.start_time, s.is_soundtrack, s.source
+FROM (VALUES
+  ('E2E Test Song 1',  'E2E Test Artist A', 'E2ETEST0001', 0, false, NULL),
+  ('E2E Test Song 2',  'E2E Test Artist B', 'E2ETEST0002', 0, false, NULL),
+  ('E2E Test Song 3',  'E2E Test Artist C', 'E2ETEST0003', 0, false, NULL),
+  ('E2E Test Song 4',  'E2E Test Artist D', 'E2ETEST0004', 0, false, NULL),
+  ('E2E Test Song 5',  'E2E Test Artist E', 'E2ETEST0005', 0, false, NULL),
+  ('E2E Test Song 6',  'E2E Test Artist F', 'E2ETEST0006', 0, false, NULL),
+  ('E2E Test Song 7',  'E2E Test Artist G', 'E2ETEST0007', 0, false, NULL),
+  ('E2E Test Song 8',  'E2E Test Artist H', 'E2ETEST0008', 0, false, NULL),
+  ('E2E Test Song 9',  'E2E Test Artist I', 'E2ETEST0009', 0, false, NULL),
+  ('E2E Test Song 10', 'E2E Test Artist J', 'E2ETEST0010', 0, false, NULL),
+  ('E2E Test Song 11', 'E2E Test Artist K', 'E2ETEST0011', 0, true,  'Star Wars'),
+  ('E2E Test Song 12', 'E2E Test Artist L', 'E2ETEST0012', 0, true,  'Inception')
+) AS s(title, artist, youtube_id, start_time, is_soundtrack, source)
+WHERE NOT EXISTS (
+  SELECT 1 FROM songs WHERE songs.youtube_id = s.youtube_id
+);
+
+INSERT INTO song_genres (song_id, genre_id)
+SELECT songs.id, genres.id
+FROM songs
+JOIN (VALUES
+  ('E2ETEST0001', 'rock'),
+  ('E2ETEST0002', 'rock'),
+  ('E2ETEST0003', 'rock'),
+  ('E2ETEST0004', 'rock'),
+  ('E2ETEST0005', 'pop'),
+  ('E2ETEST0006', 'pop'),
+  ('E2ETEST0007', 'pop'),
+  ('E2ETEST0008', 'electronic'),
+  ('E2ETEST0009', 'electronic'),
+  ('E2ETEST0010', 'electronic'),
+  ('E2ETEST0011', 'soundtrack'),
+  ('E2ETEST0012', 'soundtrack')
+) AS m(youtube_id, slug) ON songs.youtube_id = m.youtube_id
+JOIN genres ON genres.slug = m.slug
+ON CONFLICT (song_id, genre_id) DO NOTHING;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -61,7 +61,7 @@ CREATE TABLE song_genres (
 
 -- ====== Ephemeral: live game state ======
 CREATE TABLE active_games (
-  game_code         char(6) PRIMARY KEY,
+  game_code         text PRIMARY KEY,
   status            text NOT NULL DEFAULT 'waiting'
                      CHECK (status IN ('waiting','playing','ended')),
   total_rounds      integer NOT NULL,
@@ -78,7 +78,7 @@ CREATE TABLE active_games (
 
 CREATE TABLE game_teams (
   id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  game_code  char(6) NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
+  game_code  text NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
   name       text NOT NULL,
   score      integer NOT NULL DEFAULT 0,
   joined_at  timestamptz NOT NULL DEFAULT now(),
@@ -87,7 +87,7 @@ CREATE TABLE game_teams (
 
 CREATE TABLE game_rounds (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  game_code       char(6) NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
+  game_code       text NOT NULL REFERENCES active_games(game_code) ON DELETE CASCADE,
   round_number    integer NOT NULL,
   song_id         uuid REFERENCES songs(id) ON DELETE SET NULL,
   started_at      timestamptz NOT NULL DEFAULT now(),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -173,6 +173,8 @@ The new code lives in **`Sound-Clash`** (GitHub). The current AWS-based code is 
 
 **Goal**: Automated proof that the full system works under realistic concurrency, on a real Supabase project, with measured latency.
 
+**Status**: cores landed (`buzzer_race.spec.ts`, `full_game.spec.ts`, Playwright config with local `webServer`, `db/seed/songs.sql`, `data-testid` hooks on the manager console). Remaining specs (`reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`) and the multi-browser matrix are follow-up PRs. Creating the `Sound-Clash-Preview` Supabase project + setting GitHub secrets is an out-of-band setup step (see `tests/e2e/README.md`).
+
 **Deliverables**
 - `tests/e2e/playwright.config.ts` — multi-context test runner
 - `tests/e2e/buzzer_race.spec.ts` — 4 browser contexts (manager, team1, team2, display); race the buzz; assertions per **`realtime-design.md`** §3

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -26,20 +26,35 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
 AS $$
+DECLARE
+  v_round_id  uuid;
+  v_locked_at timestamptz;
 BEGIN
-  -- Atomic conditional UPDATE
-  RETURN QUERY
+  -- Atomic conditional UPDATE on active_games. RETURNING captures the
+  -- current_round_id so we can mirror the lock onto game_rounds, and
+  -- the resulting locked_at for the function's return value.
   UPDATE active_games ag
      SET buzzed_team_id = p_team_id,
          locked_at      = now()
    WHERE ag.game_code = p_game_code
      AND ag.status = 'playing'
      AND ag.buzzed_team_id IS NULL
-  RETURNING true, ag.buzzed_team_id, ag.locked_at;
+  RETURNING ag.current_round_id, ag.locked_at INTO v_round_id, v_locked_at;
 
-  -- If the UPDATE didn't match (lock already held or game not playing),
-  -- return the current state so the caller can reconcile its UI.
-  IF NOT FOUND THEN
+  IF FOUND THEN
+    -- Mirror the lock onto the round so award_points can credit the
+    -- team. active_games.buzzed_team_id is reset to NULL after each
+    -- round; game_rounds.buzzed_team_id is the durable record.
+    IF v_round_id IS NOT NULL THEN
+      UPDATE game_rounds
+         SET buzzed_team_id = p_team_id
+       WHERE id = v_round_id;
+    END IF;
+
+    RETURN QUERY SELECT true, p_team_id, v_locked_at;
+  ELSE
+    -- Lock already held or game not playable; return current state so
+    -- the caller can reconcile its UI.
     RETURN QUERY
     SELECT false, ag.buzzed_team_id, ag.locked_at
       FROM active_games ag

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -129,7 +129,7 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
 
   const overlayHidden = hideOverlay && loaded && errorCode === null;
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} data-testid="youtube-player" data-ready={loaded}>
       <div ref={containerRef} className={styles.player} />
       <div
         className={`${styles.cover} ${overlayHidden ? styles.coverHidden : ""}`}

--- a/frontend/src/pages/DisplayPage.tsx
+++ b/frontend/src/pages/DisplayPage.tsx
@@ -177,6 +177,7 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
             {teams.map((t, i) => (
               <li
                 key={t.id}
+                data-team-id={t.id}
                 className={`${styles.bigRow} ${
                   t.id === game.buzzed_team_id ? styles.bigRowBuzzed : ""
                 }`}

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -218,6 +218,7 @@ export function ManagerConsolePage() {
             className="btn btn-danger"
             onClick={() => setPending({ kind: "end" })}
             disabled={busy || game.status === "ended"}
+            data-testid="end-game"
           >
             End game
           </button>
@@ -305,6 +306,7 @@ export function ManagerConsolePage() {
                 className="btn btn-ghost"
                 onClick={() => void handleAward(true)}
                 disabled={skipDisabled}
+                data-testid="skip-round"
               >
                 Skip
               </button>
@@ -312,6 +314,7 @@ export function ManagerConsolePage() {
                 className={`btn btn-primary ${styles.awardBtn}`}
                 onClick={() => void handleAward(false)}
                 disabled={awardDisabled}
+                data-testid="award-points"
               >
                 Award points
               </button>
@@ -319,6 +322,7 @@ export function ManagerConsolePage() {
                 className="btn btn-primary"
                 onClick={() => void handleNextRound()}
                 disabled={nextRoundDisabled}
+                data-testid="start-round"
               >
                 {nextRoundLabel}
               </button>
@@ -350,7 +354,7 @@ export function ManagerConsolePage() {
             ) : (
               <div>
                 {teams.map((t) => (
-                  <div key={t.id} className={styles.teamRow}>
+                  <div key={t.id} className={styles.teamRow} data-team-id={t.id}>
                     <span className={styles.teamRowName}>{t.name}</span>
                     <span className={styles.teamRowMeta}>
                       <span>{t.score} pts</span>
@@ -375,6 +379,7 @@ export function ManagerConsolePage() {
           className="btn btn-ghost"
           onClick={() => void handleAward(true)}
           disabled={skipDisabled}
+          data-testid="skip-round-mobile"
         >
           Skip
         </button>
@@ -382,6 +387,7 @@ export function ManagerConsolePage() {
           className={`btn btn-primary ${styles.awardBtn}`}
           onClick={() => void handleAward(false)}
           disabled={awardDisabled}
+          data-testid="award-points-mobile"
         >
           Award
         </button>
@@ -389,6 +395,7 @@ export function ManagerConsolePage() {
           className="btn btn-primary"
           onClick={() => void handleNextRound()}
           disabled={nextRoundDisabled}
+          data-testid="start-round-mobile"
         >
           {game.status === "waiting" ? "Start" : "Next"}
         </button>

--- a/frontend/src/pages/ManagerCreateGamePage.tsx
+++ b/frontend/src/pages/ManagerCreateGamePage.tsx
@@ -85,6 +85,8 @@ export function ManagerCreateGamePage() {
               max={50}
               value={totalRounds}
               onChange={(e) => setTotalRounds(Number(e.target.value))}
+              aria-label="Rounds"
+              data-testid="rounds-slider"
             />
             <span className={styles.roundsValue}>{totalRounds}</span>
           </div>

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -1,0 +1,16 @@
+# Copy to tests/e2e/.env and fill from your Sound-Clash-Preview project.
+# .env is gitignored.
+
+# Backend (uvicorn) reads these
+SUPABASE_URL=https://<project-id>.supabase.co
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+ADMIN_PASSWORD=
+
+# Frontend (Vite) reads these
+VITE_SUPABASE_URL=https://<project-id>.supabase.co
+VITE_SUPABASE_ANON_KEY=
+VITE_API_URL=http://localhost:8000
+
+# Spec helpers
+API_URL=http://localhost:8000

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,54 +1,68 @@
 # End-to-End tests
 
-Playwright multi-browser, multi-context tests. Run against the `Sound-Clash-Preview` Supabase project (or local dev stack).
+Playwright multi-context tests. Run against the `Sound-Clash-Preview` Supabase project (a separate Supabase free-tier project from prod).
 
-**Phase 6 deliverable.** Phase 1 contains only the config skeleton.
+**Status:** Phase 6 cores landed — `buzzer_race.spec.ts` and `full_game.spec.ts`. The remaining six specs from [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.4 (`reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`) are follow-ups.
 
-## Planned specs
+## One-time preview project setup
 
-See [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.4 for the full list:
+```bash
+# 1. Create Sound-Clash-Preview project at supabase.com (free tier).
+# 2. Apply migrations.
+./db/migrate.sh local --db-url "$PREVIEW_DATABASE_URL"
+# 3. Seed songs (idempotent, run again any time the seed file changes).
+psql "$PREVIEW_DATABASE_URL" -f db/seed/songs.sql
+```
 
-- `buzzer_race.spec.ts` — 4 contexts; both teams click within 5ms; deterministic winner; all contexts agree.
-- `full_game.spec.ts` — 3-round happy path.
-- `reconnection.spec.ts` — team disconnect mid-game; reload; state restored.
-- `expiration.spec.ts` — game with past `expires_at`; cron runs; all clients redirect.
-- `admin_login.spec.ts` — wrong password rejected; correct admits.
-- `admin_songs_crud.spec.ts` — song CRUD via UI.
-- `kick_team.spec.ts` — team kicked; their tab redirects.
-- `mobile_team.spec.ts` — iPhone SE viewport; buzzer reachable.
+Then set GitHub repo secrets so the `E2E` workflow can run on PRs labeled `run-e2e`:
 
-## Browser matrix
+| Secret | Source |
+|---|---|
+| `SUPABASE_PREVIEW_URL` | preview project settings → API → URL |
+| `SUPABASE_PREVIEW_ANON_KEY` | preview project settings → API → anon/public key |
+| `SUPABASE_PREVIEW_SERVICE_ROLE_KEY` | preview project settings → API → service_role key |
+| `PREVIEW_ADMIN_PASSWORD` | choose any string; backend reads `ADMIN_PASSWORD` |
 
-Every spec must pass in:
-- **chromium** (Desktop Chrome)
-- **firefox** (Desktop Firefox)
-- **webkit** (Desktop Safari)
-- **mobile** (iPhone SE)
-
-## Running
+## Running locally
 
 ```bash
 cd tests/e2e
 npm install
-npx playwright install --with-deps  # one-time
-npx playwright test                 # all browsers, all specs
-npx playwright test --ui            # interactive
-npx playwright test buzzer_race     # one spec
-npx playwright test --project=mobile  # one browser
+npx playwright install --with-deps chromium    # one-time
+npx playwright test --project=chromium         # both specs
+npx playwright test --ui                       # interactive runner
+npx playwright test buzzer_race                # one spec
 ```
 
-## Required env vars
+The Playwright config auto-starts a local backend (`uvicorn` on port 8000) and the Vite dev server (port 5173). It does **not** spin up Supabase — you must point the backend at a real Supabase project (preview or local Docker).
+
+### Required env vars
+
+Create `tests/e2e/.env` (gitignored) or export in your shell:
 
 ```
-SUPABASE_URL=https://xxx.supabase.co
+# Backend reads these
+SUPABASE_URL=https://<preview-id>.supabase.co
 SUPABASE_ANON_KEY=...
 SUPABASE_SERVICE_ROLE_KEY=...
 ADMIN_PASSWORD=...
-BASE_URL=http://localhost:5173    # or preview URL
+
+# Frontend reads these (Vite picks them up via process.env)
+VITE_SUPABASE_URL=https://<preview-id>.supabase.co
+VITE_SUPABASE_ANON_KEY=...
+VITE_API_URL=http://localhost:8000
+
+# E2E spec helpers
+API_URL=http://localhost:8000
+# ADMIN_PASSWORD reused from above
 ```
+
+## Browser matrix
+
+`playwright.config.ts` declares chromium / firefox / webkit / mobile. Phase 6 cores run only chromium in CI; the broader matrix is enabled in a follow-up PR.
 
 ## Important rules
 
-- **Never run against the prod Supabase project.** Use preview only.
+- **Never run against the prod Supabase project.** Preview only.
 - **Never embed secrets** in test code; always env vars.
-- **Single retry max** in CI (`retries: 1`) — flake should fail fast.
+- The buzzer race relies on Postgres deciding the winner — do not weaken `expect.poll` timeouts trying to make the race deterministic on the client.

--- a/tests/e2e/buzzer_race.spec.ts
+++ b/tests/e2e/buzzer_race.spec.ts
@@ -1,0 +1,88 @@
+// Phase 6 headline e2e: 4 contexts (manager, team1, team2, display) racing
+// the buzzer. Asserts exactly one team wins, all four contexts agree on
+// the winner, and the awarded score propagates over Realtime.
+//
+// Spec ref: docs/testing-strategy.md §4.4 + docs/realtime-design.md §3.
+
+import { test, expect } from "@playwright/test";
+import { createGame } from "./fixtures/admin-api";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManager } from "./fixtures/manager-context";
+
+test("two teams race the buzzer; exactly one wins; all contexts agree", async ({ browser }) => {
+  // 1. Create a 1-round, rock-only game via the admin API.
+  const game = await createGame({ totalRounds: 1, genreSlugs: ["rock"] });
+  const code = game.game_code;
+
+  // 2. Open the four contexts in parallel.
+  const [team1, team2, display] = await Promise.all([
+    joinAsTeam(browser, code, "Alpha"),
+    joinAsTeam(browser, code, "Bravo"),
+    (async () => {
+      const ctx = await browser.newContext();
+      const page = await ctx.newPage();
+      await page.goto(`/display/${code}`);
+      return { page };
+    })(),
+  ]);
+  const manager = await openManager(browser, code);
+
+  // 3. Both teams visible on display before we start.
+  await expect(display.page.getByText("Alpha")).toBeVisible();
+  await expect(display.page.getByText("Bravo")).toBeVisible();
+
+  // 4. Manager starts the round.
+  const startBtn = manager.page.getByTestId("start-round");
+  await expect(startBtn).toBeEnabled();
+  await startBtn.click();
+
+  // 5. Wait for the team pages to flip into "Buzz when you know it!".
+  await Promise.all([
+    expect(team1.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+      timeout: 15_000,
+    }),
+    expect(team2.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+      timeout: 15_000,
+    }),
+  ]);
+
+  // 6. Race. Promise.all schedules both clicks back-to-back; the actual
+  //    winner is decided server-side by the buzz_in PL/pgSQL function's
+  //    conditional UPDATE.
+  await Promise.all([team1.page.getByTestId("buzz").click(), team2.page.getByTestId("buzz").click()]);
+
+  // 7. After the dust settles, exactly one team should show data-tone="winner"
+  //    and the other should show "locked-other".
+  await expect
+    .poll(
+      async () => {
+        const t1 = await team1.page.getByTestId("buzz").getAttribute("data-tone");
+        const t2 = await team2.page.getByTestId("buzz").getAttribute("data-tone");
+        return [t1, t2].sort().join(",");
+      },
+      { timeout: 15_000 },
+    )
+    .toBe("locked-other,winner");
+
+  const team1Tone = await team1.page.getByTestId("buzz").getAttribute("data-tone");
+  const winnerName = team1Tone === "winner" ? "Alpha" : "Bravo";
+
+  // 8. Manager and display agree on the winner.
+  await expect(
+    manager.page.getByRole("status").filter({ hasText: new RegExp(`${winnerName}.*buzzed in`, "i") }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    display.page.getByRole("status").filter({ hasText: new RegExp(`${winnerName}.*buzzed in`, "i") }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // 9. Manager checks Title and awards points; the winner's score should
+  //    update on display + both team scoreboards.
+  await manager.page.getByLabel(/^title$/i).check();
+  await manager.page.getByTestId("award-points").click();
+
+  for (const page of [team1.page, team2.page, display.page]) {
+    await expect(
+      page.locator(`[data-team-id]:has-text("${winnerName}"):has-text("10")`).first(),
+    ).toBeVisible({ timeout: 10_000 });
+  }
+});

--- a/tests/e2e/buzzer_race.spec.ts
+++ b/tests/e2e/buzzer_race.spec.ts
@@ -4,28 +4,32 @@
 //
 // Spec ref: docs/testing-strategy.md §4.4 + docs/realtime-design.md §3.
 
-import { test, expect } from "@playwright/test";
-import { createGame } from "./fixtures/admin-api";
+import { test, expect, type Browser } from "@playwright/test";
 import { joinAsTeam } from "./fixtures/team-context";
-import { openManager } from "./fixtures/manager-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+
+async function openDisplay(browser: Browser, code: string) {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(`/display/${code}`);
+  return { page };
+}
 
 test("two teams race the buzzer; exactly one wins; all contexts agree", async ({ browser }) => {
-  // 1. Create a 1-round, rock-only game via the admin API.
-  const game = await createGame({ totalRounds: 1, genreSlugs: ["rock"] });
-  const code = game.game_code;
+  // 1. Manager creates the game via the UI (REST create would force a
+  //    hard nav to /manager/game/<code> and lose the in-memory password).
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
 
-  // 2. Open the four contexts in parallel.
+  // 2. Game now exists; open the other three contexts in parallel.
   const [team1, team2, display] = await Promise.all([
     joinAsTeam(browser, code, "Alpha"),
     joinAsTeam(browser, code, "Bravo"),
-    (async () => {
-      const ctx = await browser.newContext();
-      const page = await ctx.newPage();
-      await page.goto(`/display/${code}`);
-      return { page };
-    })(),
+    openDisplay(browser, code),
   ]);
-  const manager = await openManager(browser, code);
 
   // 3. Both teams visible on display before we start.
   await expect(display.page.getByText("Alpha")).toBeVisible();
@@ -51,8 +55,8 @@ test("two teams race the buzzer; exactly one wins; all contexts agree", async ({
   //    conditional UPDATE.
   await Promise.all([team1.page.getByTestId("buzz").click(), team2.page.getByTestId("buzz").click()]);
 
-  // 7. After the dust settles, exactly one team should show data-tone="winner"
-  //    and the other should show "locked-other".
+  // 7. Wait for the locked state to actually propagate (one of the two
+  //    tones must be "winner", the other "locked-other").
   await expect
     .poll(
       async () => {

--- a/tests/e2e/fixtures/admin-api.ts
+++ b/tests/e2e/fixtures/admin-api.ts
@@ -1,0 +1,71 @@
+// Thin fetch wrapper for the admin-gated REST endpoints. Mirrors the shapes
+// in backend/app/models/games.py without importing from the frontend
+// package (tests/e2e/ is its own npm root).
+
+const API_URL = process.env.API_URL ?? "http://localhost:8000";
+
+function adminPassword(): string {
+  const v = process.env.ADMIN_PASSWORD;
+  if (!v) throw new Error("ADMIN_PASSWORD env var is required for the e2e admin client");
+  return v;
+}
+
+interface Genre {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+interface CreateGameResponse {
+  game_code: string;
+  status: string;
+  total_rounds: number;
+  selected_genres: string[];
+  started_at: string;
+  expires_at: string;
+}
+
+async function adminPost<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Admin-Password": adminPassword(),
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST ${path} failed: ${res.status} ${text}`);
+  }
+  return JSON.parse(text) as T;
+}
+
+async function publicGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed: ${res.status} ${text}`);
+  }
+  return JSON.parse(text) as T;
+}
+
+export async function listGenres(): Promise<Genre[]> {
+  return publicGet<Genre[]>("/genres");
+}
+
+export async function createGame(opts: {
+  totalRounds: number;
+  genreSlugs: string[];
+}): Promise<CreateGameResponse> {
+  const all = await listGenres();
+  const wanted = opts.genreSlugs.map((slug) => {
+    const match = all.find((g) => g.slug === slug);
+    if (!match) throw new Error(`unknown genre slug: ${slug}`);
+    return match.id;
+  });
+  return adminPost<CreateGameResponse>("/games", {
+    total_rounds: opts.totalRounds,
+    selected_genres: wanted,
+  });
+}

--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -1,6 +1,10 @@
-// Open a manager browser context, log in, and navigate straight to an
-// existing game's console. The game is created via the REST API (not via
-// the UI) so the spec body can focus on what's being tested.
+// Open a manager browser context, log in, and create the game via the UI.
+//
+// Why UI-create instead of REST: `authStorage` is intentionally in-memory
+// only. A `page.goto(/manager/game/<code>)` is a hard navigation that
+// wipes the password, RequireAuth then bounces to /manager/login. Using
+// the create-game form keeps everything on a single client-side
+// navigation chain.
 
 import { type Browser, type Page, expect } from "@playwright/test";
 
@@ -8,29 +12,61 @@ const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? "";
 
 export interface ManagerSession {
   page: Page;
+  gameCode: string;
 }
 
-export async function openManager(browser: Browser, gameCode: string): Promise<ManagerSession> {
+interface CreateOpts {
+  totalRounds: number;
+  // Display name as it appears in the UI (e.g. "Rock", "Pop"), matched
+  // case-insensitively.
+  genreName: string;
+}
+
+export async function openManagerAndCreateGame(
+  browser: Browser,
+  opts: CreateOpts,
+): Promise<ManagerSession> {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  // Log in via the UI so the in-memory authStorage is populated; the
-  // manager console pages use it for X-Admin-Password headers on every
-  // admin REST call.
+  // 1. Login
   await page.goto("/manager/login");
   await page.getByPlaceholder(/password/i).fill(ADMIN_PASSWORD);
   await page.getByRole("button", { name: /continue/i }).click();
   await expect(page).toHaveURL(/\/manager\/create$/);
 
-  // Then jump straight into the existing game's console.
-  await page.goto(`/manager/game/${gameCode}`);
-  await expect(page.getByText(gameCode).first()).toBeVisible();
+  // 2. Wait for genres to load (the form fetches them on mount).
+  const genreLabel = page.getByLabel(new RegExp(`^${opts.genreName}$`, "i"));
+  await expect(genreLabel).toBeVisible({ timeout: 10_000 });
 
-  // Wait for the YT player to be ready so the Start button enables. The
-  // player wrapper exposes data-ready on the wrapper div.
+  // 3. Set the rounds slider. Range inputs need the React-friendly value
+  //    setter so the controlled component picks the change up.
+  await page.getByTestId("rounds-slider").evaluate((el, val) => {
+    const input = el as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, String(val));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }, opts.totalRounds);
+
+  // 4. Pick a genre and submit.
+  await genreLabel.check();
+  await page.getByRole("button", { name: /create game/i }).click();
+
+  // 5. App navigates to /manager/game/<code> client-side; auth password
+  //    survives. Extract the generated code from the URL.
+  await page.waitForURL(/\/manager\/game\/[A-Z2-9]{6}$/, { timeout: 15_000 });
+  const match = page.url().match(/\/manager\/game\/([A-Z2-9]{6})$/);
+  if (!match) throw new Error(`failed to read game code from URL: ${page.url()}`);
+  const gameCode = match[1]!;
+
+  // 6. Wait for the YouTube player wrapper to flip to ready so the Start
+  //    button enables.
   await expect(page.getByTestId("youtube-player")).toHaveAttribute("data-ready", "true", {
     timeout: 20_000,
   });
 
-  return { page };
+  return { page, gameCode };
 }

--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -1,0 +1,36 @@
+// Open a manager browser context, log in, and navigate straight to an
+// existing game's console. The game is created via the REST API (not via
+// the UI) so the spec body can focus on what's being tested.
+
+import { type Browser, type Page, expect } from "@playwright/test";
+
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD ?? "";
+
+export interface ManagerSession {
+  page: Page;
+}
+
+export async function openManager(browser: Browser, gameCode: string): Promise<ManagerSession> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Log in via the UI so the in-memory authStorage is populated; the
+  // manager console pages use it for X-Admin-Password headers on every
+  // admin REST call.
+  await page.goto("/manager/login");
+  await page.getByPlaceholder(/password/i).fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: /continue/i }).click();
+  await expect(page).toHaveURL(/\/manager\/create$/);
+
+  // Then jump straight into the existing game's console.
+  await page.goto(`/manager/game/${gameCode}`);
+  await expect(page.getByText(gameCode).first()).toBeVisible();
+
+  // Wait for the YT player to be ready so the Start button enables. The
+  // player wrapper exposes data-ready on the wrapper div.
+  await expect(page.getByTestId("youtube-player")).toHaveAttribute("data-ready", "true", {
+    timeout: 20_000,
+  });
+
+  return { page };
+}

--- a/tests/e2e/fixtures/team-context.ts
+++ b/tests/e2e/fixtures/team-context.ts
@@ -1,0 +1,30 @@
+// Helper that opens a fresh browser context, joins a team, and returns
+// the resulting Page parked on /team/<gameCode>.
+
+import { type Browser, type Page, expect } from "@playwright/test";
+
+export interface JoinedTeam {
+  page: Page;
+  name: string;
+}
+
+export async function joinAsTeam(
+  browser: Browser,
+  gameCode: string,
+  teamName: string,
+): Promise<JoinedTeam> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(`/join/${gameCode}`);
+
+  await page.locator("#game-code").fill(gameCode);
+  await page.locator("#team-name").fill(teamName);
+  await page.getByRole("button", { name: /join game/i }).click();
+
+  await expect(page).toHaveURL(new RegExp(`/team/${gameCode}$`));
+  await expect(page.getByRole("status").filter({ hasText: /Connected/i })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  return { page, name: teamName };
+}

--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -1,0 +1,98 @@
+// 3-round happy-path. Same setup as buzzer_race but with one team that
+// always wins and incrementing-points awards. End with the EndScreen
+// rendering the podium on the Display page.
+
+import { test, expect } from "@playwright/test";
+import { createGame } from "./fixtures/admin-api";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManager } from "./fixtures/manager-context";
+
+test("3-round game: award accumulates and podium renders on display", async ({ browser }) => {
+  const game = await createGame({ totalRounds: 3, genreSlugs: ["rock"] });
+  const code = game.game_code;
+
+  const team = await joinAsTeam(browser, code, "Solo");
+
+  const displayCtx = await browser.newContext();
+  const display = await displayCtx.newPage();
+  await display.goto(`/display/${code}`);
+  await expect(display.getByText("Solo")).toBeVisible();
+
+  const manager = await openManager(browser, code);
+
+  type RoundPoints = { title: boolean; artist: boolean; expected: number };
+  const rounds: RoundPoints[] = [
+    { title: true, artist: false, expected: 10 },
+    { title: true, artist: true, expected: 15 },
+    { title: false, artist: true, expected: 5 },
+  ];
+
+  let runningTotal = 0;
+
+  for (let i = 0; i < rounds.length; i++) {
+    const r = rounds[i]!;
+    const roundNum = i + 1;
+
+    await expect(manager.page.getByTestId("start-round")).toBeEnabled();
+    await manager.page.getByTestId("start-round").click();
+
+    // Manager header shows "Round N of 3" once start_round has completed.
+    await expect(
+      manager.page.getByText(new RegExp(`Round ${roundNum} of 3`, "i")),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Team can now buzz.
+    await expect(team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await team.page.getByTestId("buzz").click();
+    await expect(team.page.getByTestId("buzz")).toHaveAttribute("data-tone", "winner", {
+      timeout: 10_000,
+    });
+
+    // Manager checks the right boxes and awards.
+    if (r.title) {
+      await manager.page.getByLabel(/^title$/i).check();
+    }
+    if (r.artist) {
+      await manager.page.getByLabel(/^artist$/i).check();
+    }
+    await manager.page.getByTestId("award-points").click();
+
+    runningTotal += r.expected;
+
+    // Score reaches the running total on the display before we move on.
+    await expect(
+      display.locator(`[data-team-id]:has-text("Solo"):has-text("${runningTotal}")`).first(),
+    ).toBeVisible({ timeout: 10_000 });
+  }
+
+  // End the game.
+  await manager.page.getByTestId("end-game").click();
+  const dialog = manager.page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /^end game$/i }).click();
+
+  // Display flips to the EndScreen.
+  await expect(display.getByRole("heading", { name: /final results/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(display.getByText("WINNER")).toBeVisible();
+  await expect(display.getByText("Solo")).toBeVisible();
+
+  // The CountUp animation settles within ~2s; assert the final number is
+  // the sum we tracked.
+  await expect
+    .poll(
+      async () => {
+        const text = await display
+          .locator(`text=${runningTotal}`)
+          .first()
+          .textContent()
+          .catch(() => null);
+        return text?.trim();
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(String(runningTotal));
+});

--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -3,13 +3,15 @@
 // rendering the podium on the Display page.
 
 import { test, expect } from "@playwright/test";
-import { createGame } from "./fixtures/admin-api";
 import { joinAsTeam } from "./fixtures/team-context";
-import { openManager } from "./fixtures/manager-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
 
 test("3-round game: award accumulates and podium renders on display", async ({ browser }) => {
-  const game = await createGame({ totalRounds: 3, genreSlugs: ["rock"] });
-  const code = game.game_code;
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 3,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
 
   const team = await joinAsTeam(browser, code, "Solo");
 
@@ -17,8 +19,6 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
   const display = await displayCtx.newPage();
   await display.goto(`/display/${code}`);
   await expect(display.getByText("Solo")).toBeVisible();
-
-  const manager = await openManager(browser, code);
 
   type RoundPoints = { title: boolean; artist: boolean; expected: number };
   const rounds: RoundPoints[] = [
@@ -80,18 +80,13 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
   await expect(display.getByText("WINNER")).toBeVisible();
   await expect(display.getByText("Solo")).toBeVisible();
 
-  // The CountUp animation settles within ~2s; assert the final number is
-  // the sum we tracked.
+  // CountUp animation settles within ~2s.
   await expect
     .poll(
-      async () => {
-        const text = await display
-          .locator(`text=${runningTotal}`)
-          .first()
-          .textContent()
-          .catch(() => null);
-        return text?.trim();
-      },
+      async () =>
+        (
+          await display.locator(`text=${runningTotal}`).first().textContent().catch(() => null)
+        )?.trim(),
       { timeout: 5_000 },
     )
     .toBe(String(runningTotal));

--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -80,14 +80,10 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
   await expect(display.getByText("WINNER")).toBeVisible();
   await expect(display.getByText("Solo")).toBeVisible();
 
-  // CountUp animation settles within ~2s.
-  await expect
-    .poll(
-      async () =>
-        (
-          await display.locator(`text=${runningTotal}`).first().textContent().catch(() => null)
-        )?.trim(),
-      { timeout: 5_000 },
-    )
-    .toBe(String(runningTotal));
+  // CountUp animation settles within ~2s. The podium score renders the
+  // number and the "pts" unit as siblings, so we assert the final
+  // "<total>pts" text becomes visible rather than poking at textContent.
+  await expect(display.getByText(`${runningTotal}pts`).first()).toBeVisible({
+    timeout: 5_000,
+  });
 });

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "sound-clash-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sound-clash-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "@types/node": "^25.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Load tests/e2e/.env when present (local runs). CI sets vars directly via
+// the workflow env block, so the absence of the file is fine there.
+try {
+  process.loadEnvFile(".env");
+} catch {
+  /* no .env locally is fine if vars are exported in the shell */
+}
+
 // Phase 6 (cores): chromium-only via --project=chromium in CI; the other
 // browser projects stay declared so the follow-up PR that adds them only
 // has to enable them in the workflow.

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,22 +1,48 @@
 import { defineConfig, devices } from "@playwright/test";
 
-// Phase 1 placeholder. Real specs added in Phase 6 per docs/testing-strategy.md §4.4.
+// Phase 6 (cores): chromium-only via --project=chromium in CI; the other
+// browser projects stay declared so the follow-up PR that adds them only
+// has to enable them in the workflow.
+
+const PORT_FRONTEND = 5173;
+const PORT_BACKEND = 8000;
 
 export default defineConfig({
   testDir: ".",
-  fullyParallel: true,
+  testIgnore: ["fixtures/**"],
+  fullyParallel: false, // sequential — multi-context specs share the preview project
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : undefined,
-  timeout: 30_000,
-  expect: { timeout: 5_000 },
+  workers: 1,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
   reporter: process.env.CI ? [["html"], ["github"]] : "html",
   use: {
-    baseURL: process.env.BASE_URL ?? "http://localhost:5173",
+    baseURL: process.env.BASE_URL ?? `http://localhost:${PORT_FRONTEND}`,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
   },
+  webServer: [
+    {
+      command: `uvicorn app.main:app --port ${PORT_BACKEND}`,
+      cwd: "../../backend",
+      port: PORT_BACKEND,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: `npm run dev -- --port ${PORT_FRONTEND} --strictPort`,
+      cwd: "../../frontend",
+      port: PORT_FRONTEND,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
   projects: [
     { name: "chromium", use: { ...devices["Desktop Chrome"] } },
     { name: "firefox", use: { ...devices["Desktop Firefox"] } },

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,0 @@
-// Phase 1 smoke test. Real specs in Phase 6.
-import { expect, test } from "@playwright/test";
-
-test("smoke: arithmetic", () => {
-  expect(1 + 1).toBe(2);
-});


### PR DESCRIPTION
## Summary

- Lands the first real Playwright e2e specs: `buzzer_race.spec.ts` (4 contexts: manager + 2 teams + display) and `full_game.spec.ts` (3-round happy path → podium splash on Display).
- Adds `db/seed/songs.sql` — 12 placeholder songs across rock / pop / electronic / soundtrack, idempotent via `WHERE NOT EXISTS` + `ON CONFLICT DO NOTHING`. Songs use `E2ETEST00xx` placeholder youtube_ids that intentionally don't resolve; the YT IFrame surfaces "Video unavailable" but the round controls work regardless.
- Adds `data-testid` hooks on the manager console (`start-round`, `award-points`, `skip-round`, `end-game`, plus mobile-bar variants), `data-team-id` on team rows, `youtube-player` + `data-ready` on the YT wrapper, and `rounds-slider` + `aria-label="Rounds"` on the create-game slider. Existing role/text-based unit tests still pass.
- Updates `tests/e2e/playwright.config.ts` to auto-start the backend (`uvicorn` :8000) and frontend (`vite` :5173) via Playwright `webServer`. Browser projects all declared; CI pins `--project=chromium` for now.
- Updates `.github/workflows/e2e.yml`: Python 3.11 setup + backend deps install, frontend `npm ci`, env wiring rewired for the local-`webServer` topology (drops `BASE_URL`, adds `VITE_SUPABASE_URL/ANON_KEY/API_URL` and `API_URL` for spec helpers).
- Phase 6 status updated in `docs/roadmap.md`. Remaining 6 specs (`reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`) and the multi-browser matrix are explicit follow-ups.

## Out-of-band setup before CI can pass (one-time)

1. Create `Sound-Clash-Preview` Supabase project (free tier).
2. Apply migrations and run `db/seed/songs.sql` against it.
3. Set repo secrets: `SUPABASE_PREVIEW_URL`, `SUPABASE_PREVIEW_ANON_KEY`, `SUPABASE_PREVIEW_SERVICE_ROLE_KEY`, `PREVIEW_ADMIN_PASSWORD`. (`PREVIEW_BASE_URL` is no longer used — safe to delete.)
4. Add the `run-e2e` label to this PR to trigger the workflow.

## Test plan

- [x] Frontend unit suite still green (`npm run test:run` → 136/136).
- [x] Frontend lint clean (`npm run lint`).
- [x] Frontend typecheck clean (`npm run typecheck`).
- [x] `npx playwright test --list --project=chromium` discovers both specs.
- [ ] After preview project + secrets are configured: label PR `run-e2e` and verify the E2E job goes green on chromium.
- [ ] Local interactive run with preview env vars: `cd tests/e2e && npx playwright test --ui --project=chromium`.
- [ ] Spot-check Supabase prod project after a CI run — zero new `active_games` rows (preview is isolated).