### PR TITLE
feat(e2e): six follow-up specs complete Phase 6

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -173,7 +173,7 @@ The new code lives in **`Sound-Clash`** (GitHub). The current AWS-based code is 
 
 **Goal**: Automated proof that the full system works under realistic concurrency, on a real Supabase project, with measured latency.
 
-**Status**: cores landed (`buzzer_race.spec.ts`, `full_game.spec.ts`, Playwright config with local `webServer`, `db/seed/songs.sql`, `data-testid` hooks on the manager console). Remaining specs (`reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`) and the multi-browser matrix are follow-up PRs. Creating the `Sound-Clash-Preview` Supabase project + setting GitHub secrets is an out-of-band setup step (see `tests/e2e/README.md`).
+**Status**: complete. All eight specs from §4.4 are landed (`buzzer_race`, `full_game`, `reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`). `admin_songs_crud` is API-driven (the `/admin/songs` UI is a deferred Phase 5 carve-out; the backend contract is exercised end-to-end). The multi-browser matrix (firefox / webkit / iPhone-SE project) and the 100×-stress `buzz_race_stress` job stay declared but label-gated. Creating the `Sound-Clash-Preview` Supabase project + setting GitHub secrets is an out-of-band setup step (see `tests/e2e/README.md`).
 
 **Deliverables**
 - `tests/e2e/playwright.config.ts` — multi-context test runner

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -131,7 +131,7 @@ Playwright with multi-browser-context. Runs against a dedicated `Sound-Clash-Pre
 | `reconnection.spec.ts` | team disconnects mid-game; reload; state restored; can buzz |
 | `expiration.spec.ts` | game with expires_at in past; cron runs; all clients redirect to "expired" page |
 | `admin_login.spec.ts` | wrong password rejected; correct password admits |
-| `admin_songs_crud.spec.ts` | create/edit/delete song via admin UI |
+| `admin_songs_crud.spec.ts` | create/edit/delete song via admin API + bulk-import idempotency (UI deferred — see roadmap) |
 | `kick_team.spec.ts` | manager kicks team; team's tab redirects |
 | `mobile_team.spec.ts` | iPhone viewport; buzzer reachable + tappable |
 

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -150,6 +150,17 @@ export function ManagerConsolePage() {
     }
   }
 
+  // status="gone" must be checked before the skeleton: an active_games
+  // DELETE flips the reducer to null state AND status to "gone" in the
+  // same tick, and the user should see the explanation, not a skeleton.
+  if (status === "gone" || (state && !state.game)) {
+    return (
+      <main className={styles.shell}>
+        <p className="error">This game no longer exists.</p>
+      </main>
+    );
+  }
+
   if (!state || status === "connecting") {
     return (
       <main className={styles.shell} aria-busy="true">
@@ -159,14 +170,6 @@ export function ManagerConsolePage() {
           <Skeleton height={260} />
           <Skeleton height={180} />
         </div>
-      </main>
-    );
-  }
-
-  if (status === "gone" || !state.game) {
-    return (
-      <main className={styles.shell}>
-        <p className="error">This game no longer exists.</p>
       </main>
     );
   }
@@ -362,6 +365,7 @@ export function ManagerConsolePage() {
                         className="btn btn-danger"
                         onClick={() => setPending({ kind: "kick", teamId: t.id, teamName: t.name })}
                         disabled={busy}
+                        data-testid="kick-team"
                       >
                         Kick
                       </button>

--- a/frontend/src/pages/ManagerLoginPage.tsx
+++ b/frontend/src/pages/ManagerLoginPage.tsx
@@ -30,9 +30,15 @@ export function ManagerLoginPage() {
           placeholder="Password"
           autoComplete="current-password"
           required
+          data-testid="admin-password"
         />
         <div className={styles.actions}>
-          <button type="submit" className="btn btn-primary" disabled={!password}>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={!password}
+            data-testid="admin-login-submit"
+          >
             Continue
           </button>
         </div>

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,7 +2,7 @@
 
 Playwright multi-context tests. Run against the `Sound-Clash-Preview` Supabase project (a separate Supabase free-tier project from prod).
 
-**Status:** Phase 6 cores landed — `buzzer_race.spec.ts` and `full_game.spec.ts`. The remaining six specs from [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.4 (`reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`) are follow-ups.
+**Status:** all eight specs from [`docs/testing-strategy.md`](../../docs/testing-strategy.md) §4.4 are landed: `buzzer_race`, `full_game`, `reconnection`, `expiration`, `admin_login`, `admin_songs_crud` (API-driven — the `/admin/songs` UI is a deferred carve-out), `kick_team`, `mobile_team`. The multi-browser matrix (firefox / webkit / iPhone-SE project) is declared in `playwright.config.ts` but the CI job runs `--project=chromium` only.
 
 ## One-time preview project setup
 

--- a/tests/e2e/admin_login.spec.ts
+++ b/tests/e2e/admin_login.spec.ts
@@ -1,0 +1,49 @@
+// Admin login: the password input on /manager/login is accepted blindly
+// (validation happens server-side on the first admin call). Wrong
+// password manifests as a 401 on POST /games, which ManagerCreateGamePage
+// catches and treats as logout + redirect back to /manager/login.
+//
+// Spec ref: docs/testing-strategy.md §4.4
+// + frontend/src/pages/ManagerCreateGamePage.tsx:60-64
+// + backend/app/middleware/admin_auth.py (constant-time compare).
+
+import { test, expect } from "@playwright/test";
+import { listGenres } from "./fixtures/admin-api";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+
+test("wrong admin password is rejected at first admin action", async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  await page.goto("/manager/login");
+  await page.getByTestId("admin-password").fill("definitely-wrong-password");
+  await page.getByTestId("admin-login-submit").click();
+
+  // Frontend doesn't validate; we land on /manager/create.
+  await expect(page).toHaveURL(/\/manager\/create$/);
+
+  // Pick a genre so the submit button enables, then attempt to create.
+  // Use the first genre the public /genres endpoint returns (e.g. "Rock").
+  const genres = await listGenres();
+  expect(genres.length).toBeGreaterThan(0);
+  const first = genres[0]!;
+  await expect(page.getByLabel(new RegExp(`^${first.name}$`, "i"))).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByLabel(new RegExp(`^${first.name}$`, "i")).check();
+  await page.getByRole("button", { name: /create game/i }).click();
+
+  // ApiError(401) -> logout() + navigate replace to /manager/login.
+  await expect(page).toHaveURL(/\/manager\/login$/, { timeout: 10_000 });
+});
+
+test("correct admin password admits and creates a game", async ({ browser }) => {
+  // openManagerAndCreateGame uses ADMIN_PASSWORD; if it lands at
+  // /manager/game/<code>, the credential round-trip worked.
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  expect(manager.gameCode).toMatch(/^[A-Z2-9]{6}$/);
+  await expect(manager.page).toHaveURL(new RegExp(`/manager/game/${manager.gameCode}$`));
+});

--- a/tests/e2e/admin_songs_crud.spec.ts
+++ b/tests/e2e/admin_songs_crud.spec.ts
@@ -1,0 +1,136 @@
+// Admin song catalog CRUD against the /admin/songs REST endpoints.
+//
+// This spec is API-driven (no /admin/songs UI exists yet — that page is
+// a deferred Phase 5 carve-out). The contract under test is:
+//   POST   /admin/songs              -> 201 SongPayload
+//   GET    /admin/songs/{id}         -> 200 SongPayload | 404
+//   PUT    /admin/songs/{id}         -> 200 SongPayload (full replace)
+//   DELETE /admin/songs/{id}         -> 204
+//   GET    /admin/songs?search=...   -> 200 SongList
+//   POST   /admin/songs/bulk-import  -> 200 BulkImportSummary (idempotent on youtube_id)
+//
+// Spec ref: docs/testing-strategy.md §4.4 (admin_songs_crud row notes
+// "via admin API"); contract in docs/api-contracts.md §3.
+
+import { test, expect } from "@playwright/test";
+import {
+  bulkImportSongs,
+  createSong,
+  deleteSong,
+  getSong,
+  getSongStatus,
+  listGenres,
+  listSongs,
+  updateSong,
+} from "./fixtures/admin-api";
+
+// All test rows use this prefix so the cleanup pass at the end can find
+// and prune anything that survived a mid-test failure.
+const TAG = "E2ETEMPCRUD";
+
+// 11-char strings matching ^[A-Za-z0-9_-]{11}$ — required by the
+// SongCreate.youtube_id validator. E2ETEMP prefix mirrors the existing
+// E2ETEST seed prefix in db/seed/songs.sql so the rows are easy to spot.
+const Y1 = "E2ETEMPaa01";
+const Y2 = "E2ETEMPbb02";
+const Y3 = "E2ETEMPcc03";
+
+test("admin songs: full CRUD round-trip + bulk-import idempotency", async () => {
+  const genres = await listGenres();
+  expect(genres.length).toBeGreaterThan(0);
+  const first = genres[0]!;
+  const second = genres[1] ?? first;
+
+  // Track ids for cleanup; populated as we go.
+  const created: string[] = [];
+
+  try {
+    // -- CREATE -----------------------------------------------------------
+    const made = await createSong({
+      title: `${TAG}-create`,
+      artist: "tmp",
+      youtube_id: Y1,
+      start_time: 0,
+      is_soundtrack: false,
+      source: "manual",
+      genre_ids: [first.id],
+    });
+    expect(made.id).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(made.title).toBe(`${TAG}-create`);
+    created.push(made.id);
+
+    // -- READ -------------------------------------------------------------
+    const fetched = await getSong(made.id);
+    expect(fetched).toMatchObject({
+      id: made.id,
+      title: `${TAG}-create`,
+      artist: "tmp",
+      youtube_id: Y1,
+      start_time: 0,
+      is_soundtrack: false,
+    });
+
+    // -- UPDATE (full replace) --------------------------------------------
+    const updated = await updateSong(made.id, {
+      title: `${TAG}-updated`,
+      artist: "tmp2",
+      youtube_id: Y1,
+      start_time: 5,
+      is_soundtrack: true,
+      source: "manual",
+      genre_ids: [second.id],
+    });
+    expect(updated.title).toBe(`${TAG}-updated`);
+    expect(updated.is_soundtrack).toBe(true);
+    expect(updated.start_time).toBe(5);
+
+    // -- LIST with search filter -----------------------------------------
+    const listed = await listSongs({ search: `${TAG}-updated` });
+    expect(listed.items.length).toBe(1);
+    expect(listed.items[0]!.id).toBe(made.id);
+
+    // -- BULK IMPORT (1 update of existing yt_id + 2 fresh inserts) ------
+    const csv = [
+      "title,artist,youtube_id,start_time,is_soundtrack,source,genres",
+      `${TAG}-updated-via-bulk,tmp3,${Y1},0,false,manual,${first.slug}`,
+      `${TAG}-bulk-1,tmp,${Y2},0,false,manual,${first.slug}`,
+      `${TAG}-bulk-2,tmp,${Y3},0,false,manual,${first.slug}`,
+    ].join("\n");
+    const summary = await bulkImportSongs(csv);
+    expect(summary).toEqual({ inserted: 2, updated: 1, total: 3 });
+
+    // The original row should now reflect the bulk update.
+    const afterBulk = await getSong(made.id);
+    expect(afterBulk.title).toBe(`${TAG}-updated-via-bulk`);
+
+    // The two bulk inserts should be discoverable; capture their ids for
+    // cleanup. Search-by-title is case-insensitive ILIKE, so the prefix
+    // match returns both rows.
+    const bulkListed = await listSongs({ search: `${TAG}-bulk-` });
+    expect(bulkListed.items.length).toBe(2);
+    for (const item of bulkListed.items) created.push(item.id);
+
+    // -- DELETE -----------------------------------------------------------
+    for (const id of created) {
+      await deleteSong(id);
+    }
+    created.length = 0;
+
+    // -- 404 after delete -------------------------------------------------
+    const status = await getSongStatus(made.id);
+    expect(status).toBe(404);
+
+    // -- final state: nothing tagged remains ------------------------------
+    const final = await listSongs({ search: TAG });
+    expect(final.items.length).toBe(0);
+  } finally {
+    // Best-effort cleanup if an earlier assertion threw.
+    for (const id of created) {
+      try {
+        await deleteSong(id);
+      } catch {
+        /* already gone or fail-by-design */
+      }
+    }
+  }
+});

--- a/tests/e2e/expiration.spec.ts
+++ b/tests/e2e/expiration.spec.ts
@@ -1,0 +1,72 @@
+// Game whose `expires_at` is backdated past, then swept by
+// cleanup_expired_games(): all open clients (manager, team, display)
+// surface the "gone" banner once Realtime delivers the DELETE on
+// active_games. Reuses the existing UI status banners (no /expired
+// route — see the plan).
+//
+// Spec ref: docs/testing-strategy.md §4.4 + db/migrations/005_rpc_functions.sql
+// (cleanup_expired_games at line 178) + frontend/src/hooks/useGameChannel.ts
+// (DELETE on active_games -> status="gone").
+
+import { test, expect, type Browser } from "@playwright/test";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+import { setExpiresAtPast, cleanupExpiredGames } from "./fixtures/supabase-admin";
+
+async function openDisplay(browser: Browser, code: string) {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(`/display/${code}`);
+  return { page };
+}
+
+test("expired game is swept; all clients surface the 'gone' banner", async ({ browser }) => {
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
+
+  const [team, display] = await Promise.all([
+    joinAsTeam(browser, code, "Ephemeral"),
+    openDisplay(browser, code),
+  ]);
+
+  // Display should already show the team before we expire the game.
+  await expect(display.page.getByText("Ephemeral")).toBeVisible({ timeout: 10_000 });
+
+  // Backdate expires_at and run the cleanup that pg_cron normally fires
+  // hourly. The function returns the number of rows it deleted.
+  await setExpiresAtPast(code);
+  const deleted = await cleanupExpiredGames();
+  expect(deleted).toBeGreaterThanOrEqual(1);
+
+  // The cleanup deletes active_games; ON DELETE CASCADE prunes
+  // game_teams. Logical replication can emit the parent or the child
+  // event first depending on transaction ordering, so the team page
+  // settles in one of two valid states:
+  //   - team row vanishes first: TeamGameplayPage's "kicked" path
+  //     (clearStoredTeam + navigate("/")) fires.
+  //   - active_games vanishes first: status="gone" renders the
+  //     "this game has ended or expired" banner.
+  // Manager/display have no team identity to lose; they always hit the
+  // "gone" banner.
+  await expect
+    .poll(
+      async () => {
+        const url = team.page.url();
+        if (/\/$/.test(url) && !/\/team\//.test(url)) return "redirected-home";
+        const banner = await team.page.getByText(/this game has ended or expired/i).count();
+        return banner > 0 ? "banner-shown" : "still-loading";
+      },
+      { timeout: 15_000 },
+    )
+    .not.toBe("still-loading");
+
+  await expect(
+    manager.page.getByText(/this game no longer exists/i),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    display.page.getByText(/game has ended or expired/i),
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/tests/e2e/fixtures/admin-api.ts
+++ b/tests/e2e/fixtures/admin-api.ts
@@ -10,7 +10,7 @@ function adminPassword(): string {
   return v;
 }
 
-interface Genre {
+export interface Genre {
   id: string;
   slug: string;
   name: string;
@@ -25,20 +25,65 @@ interface CreateGameResponse {
   expires_at: string;
 }
 
-async function adminPost<T>(path: string, body: unknown): Promise<T> {
+export interface SongPayload {
+  id: string;
+  title: string;
+  artist: string;
+  youtube_id: string;
+  start_time: number;
+  is_soundtrack: boolean;
+  source: string | null;
+}
+
+export interface SongCreate {
+  title: string;
+  artist: string;
+  youtube_id: string;
+  start_time?: number;
+  is_soundtrack?: boolean;
+  source?: string | null;
+  genre_ids: string[];
+}
+
+export interface SongList {
+  items: SongPayload[];
+  page: number;
+  per_page: number;
+  total: number;
+}
+
+export interface BulkImportSummary {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+interface AdminResponse {
+  status: number;
+  text: string;
+}
+
+async function adminFetch(method: string, path: string, body?: unknown): Promise<AdminResponse> {
+  const headers: Record<string, string> = { "X-Admin-Password": adminPassword() };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
   const res = await fetch(`${API_URL}${path}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Admin-Password": adminPassword(),
-    },
-    body: JSON.stringify(body),
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
-  const text = await res.text();
-  if (!res.ok) {
-    throw new Error(`POST ${path} failed: ${res.status} ${text}`);
+  return { status: res.status, text: await res.text() };
+}
+
+async function adminJson<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const r = await adminFetch(method, path, body);
+  if (r.status < 200 || r.status >= 300) {
+    throw new Error(`${method} ${path} failed: ${r.status} ${r.text}`);
   }
-  return JSON.parse(text) as T;
+  return JSON.parse(r.text) as T;
+}
+
+async function adminPost<T>(path: string, body: unknown): Promise<T> {
+  return adminJson<T>("POST", path, body);
 }
 
 async function publicGet<T>(path: string): Promise<T> {
@@ -68,4 +113,59 @@ export async function createGame(opts: {
     total_rounds: opts.totalRounds,
     selected_genres: wanted,
   });
+}
+
+export async function createSong(body: SongCreate): Promise<SongPayload> {
+  return adminJson<SongPayload>("POST", "/admin/songs", body);
+}
+
+export async function getSong(id: string): Promise<SongPayload> {
+  return adminJson<SongPayload>("GET", `/admin/songs/${id}`);
+}
+
+export async function updateSong(id: string, body: SongCreate): Promise<SongPayload> {
+  return adminJson<SongPayload>("PUT", `/admin/songs/${id}`, body);
+}
+
+export async function deleteSong(id: string): Promise<void> {
+  const r = await adminFetch("DELETE", `/admin/songs/${id}`);
+  if (r.status !== 204) {
+    throw new Error(`DELETE /admin/songs/${id} failed: ${r.status} ${r.text}`);
+  }
+}
+
+export async function getSongStatus(id: string): Promise<number> {
+  const r = await adminFetch("GET", `/admin/songs/${id}`);
+  return r.status;
+}
+
+export async function listSongs(opts: {
+  search?: string;
+  genre?: string;
+  page?: number;
+  per_page?: number;
+} = {}): Promise<SongList> {
+  const params = new URLSearchParams();
+  if (opts.search) params.set("search", opts.search);
+  if (opts.genre) params.set("genre", opts.genre);
+  if (opts.page) params.set("page", String(opts.page));
+  if (opts.per_page) params.set("per_page", String(opts.per_page));
+  const qs = params.toString();
+  return adminJson<SongList>("GET", `/admin/songs${qs ? `?${qs}` : ""}`);
+}
+
+export async function bulkImportSongs(csvText: string): Promise<BulkImportSummary> {
+  const fd = new FormData();
+  fd.append("file", new Blob([csvText], { type: "text/csv" }), "songs.csv");
+  // Don't set Content-Type — fetch sets the multipart boundary itself.
+  const res = await fetch(`${API_URL}/admin/songs/bulk-import`, {
+    method: "POST",
+    headers: { "X-Admin-Password": adminPassword() },
+    body: fd,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST /admin/songs/bulk-import failed: ${res.status} ${text}`);
+  }
+  return JSON.parse(text) as BulkImportSummary;
 }

--- a/tests/e2e/fixtures/supabase-admin.ts
+++ b/tests/e2e/fixtures/supabase-admin.ts
@@ -1,0 +1,51 @@
+// Service-role HTTP helpers for the e2e suite. Used by expiration.spec.ts
+// to backdate `active_games.expires_at` and run the cleanup function
+// directly (the production cron job runs hourly, which is too slow to
+// observe from a test).
+//
+// Both calls go straight to PostgREST with the service-role JWT; no
+// supabase-js dependency.
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+function serviceHeaders(): HeadersInit {
+  if (!SUPABASE_URL) throw new Error("SUPABASE_URL env var is required");
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY env var is required");
+  }
+  return {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export async function setExpiresAtPast(gameCode: string): Promise<void> {
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/active_games?game_code=eq.${encodeURIComponent(gameCode)}`,
+    {
+      method: "PATCH",
+      headers: { ...serviceHeaders(), Prefer: "return=minimal" },
+      body: JSON.stringify({ expires_at: "1970-01-01T00:00:00Z" }),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`PATCH active_games failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+export async function cleanupExpiredGames(): Promise<number> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/cleanup_expired_games`, {
+    method: "POST",
+    headers: serviceHeaders(),
+    body: "{}",
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`rpc/cleanup_expired_games failed: ${res.status} ${text}`);
+  }
+  // PostgREST RPC returns the bare scalar — `cleanup_expired_games()`
+  // returns the number of deleted rows.
+  return Number(text);
+}

--- a/tests/e2e/kick_team.spec.ts
+++ b/tests/e2e/kick_team.spec.ts
@@ -1,0 +1,85 @@
+// Manager kicks a team mid-game. The kicked team's tab redirects home
+// (TeamGameplayPage detects its own row missing post-hydrate and clears
+// localStorage). The other team stays put.
+//
+// Spec ref: docs/testing-strategy.md §4.4
+// + frontend/src/pages/TeamGameplayPage.tsx:61-70 (kick detection)
+// + backend/app/routers/games.py (DELETE /games/{code}/teams/{id}).
+
+import { test, expect, type Browser } from "@playwright/test";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+
+async function openDisplay(browser: Browser, code: string) {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(`/display/${code}`);
+  return { page };
+}
+
+test("manager kicks a team; that team's tab redirects, other team stays", async ({ browser }) => {
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
+
+  const [kicked, survivor, display] = await Promise.all([
+    joinAsTeam(browser, code, "KickMe"),
+    joinAsTeam(browser, code, "Survivor"),
+    openDisplay(browser, code),
+  ]);
+
+  // Both teams visible on the display before the kick.
+  await expect(display.page.getByText("KickMe")).toBeVisible({ timeout: 10_000 });
+  await expect(display.page.getByText("Survivor")).toBeVisible({ timeout: 10_000 });
+  expect(await display.page.locator("[data-team-id]").count()).toBe(2);
+
+  // Resolve the kicked team's UUID by reading its localStorage on the
+  // team page (the manager UI uses the same id via data-team-id).
+  const kickedStored = await kicked.page.evaluate(
+    (c) => window.localStorage.getItem(`game:${c}:team`),
+    code,
+  );
+  expect(kickedStored).not.toBeNull();
+  const kickedId = (JSON.parse(kickedStored!) as { id: string }).id;
+
+  // Click Kick inside the Teams-panel row scoped by data-team-id; the
+  // Scoreboard component also renders a `[data-team-id]` element so we
+  // disambiguate by filtering to the row that contains the Kick button.
+  const kickRow = manager.page
+    .locator(`[data-team-id="${kickedId}"]`)
+    .filter({ has: manager.page.getByTestId("kick-team") });
+  await expect(kickRow).toBeVisible();
+  await kickRow.getByTestId("kick-team").click();
+  const dialog = manager.page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /remove team/i }).click();
+
+  // The kicked team's page detects its row missing in state.teams,
+  // clears localStorage, and navigates home.
+  await expect(kicked.page).toHaveURL(/^[^?]*\/$|\/$/, { timeout: 15_000 });
+  const storageAfter = await kicked.page.evaluate(
+    (c) => window.localStorage.getItem(`game:${c}:team`),
+    code,
+  );
+  expect(storageAfter).toBeNull();
+
+  // Display shows only the survivor; manager's Teams panel agrees.
+  await expect(display.page.getByText("KickMe")).toHaveCount(0, { timeout: 10_000 });
+  await expect(display.page.getByText("Survivor")).toBeVisible();
+  await expect
+    .poll(async () => display.page.locator("[data-team-id]").count(), { timeout: 10_000 })
+    .toBe(1);
+
+  // Survivor still functions: starts a round and buzzes successfully.
+  await expect(manager.page.getByTestId("start-round")).toBeEnabled();
+  await manager.page.getByTestId("start-round").click();
+  await expect(
+    survivor.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
+  ).toBeVisible({ timeout: 15_000 });
+  await survivor.page.getByTestId("buzz").click();
+  await expect(survivor.page.getByTestId("buzz")).toHaveAttribute("data-tone", "winner", {
+    timeout: 10_000,
+  });
+});

--- a/tests/e2e/mobile_team.spec.ts
+++ b/tests/e2e/mobile_team.spec.ts
@@ -1,0 +1,64 @@
+// Mobile team viewport: iPhone 12 dimensions, the buzzer is reachable
+// and tappable, and a buzz round still produces a winner-tone + score.
+// We don't switch to the dedicated `mobile` Playwright project (that's
+// a multi-browser-matrix follow-up); per-test test.use() overrides the
+// context to ship within the chromium-only CI gate.
+//
+// Spec ref: docs/testing-strategy.md §4.4
+// + frontend/src/pages/TeamGameplayPage.module.css (mobile breakpoint).
+
+import { test, expect, devices, type Browser } from "@playwright/test";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+
+async function joinAsMobileTeam(browser: Browser, code: string, name: string) {
+  // Phone-shaped browser context for just the team tab.
+  const ctx = await browser.newContext({ ...devices["iPhone 12"] });
+  const page = await ctx.newPage();
+  await page.goto(`/join/${code}`);
+  await page.locator("#game-code").fill(code);
+  await page.locator("#team-name").fill(name);
+  await page.getByRole("button", { name: /join game/i }).click();
+  await expect(page).toHaveURL(new RegExp(`/team/${code}$`));
+  await expect(page.getByRole("status").filter({ hasText: /Connected/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  return { page, name };
+}
+
+test("mobile viewport: team can join, buzz, and score", async ({ browser }) => {
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
+
+  const team = await joinAsMobileTeam(browser, code, "Mobile");
+
+  // Buzzer should be visible on the small viewport without horizontal
+  // scrolling — Playwright's auto-scroll-into-view + visible check
+  // approximates this.
+  const buzz = team.page.getByTestId("buzz");
+  await expect(buzz).toBeVisible();
+  expect(await buzz.boundingBox()).not.toBeNull();
+
+  // Manager starts the round (manager runs at desktop chromium viewport).
+  await expect(manager.page.getByTestId("start-round")).toBeEnabled();
+  await manager.page.getByTestId("start-round").click();
+  await expect(
+    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Tap. Playwright synthesizes a touch from .click() in a touch-enabled
+  // device descriptor.
+  await buzz.click();
+  await expect(buzz).toHaveAttribute("data-tone", "winner", { timeout: 10_000 });
+
+  // Award and confirm the score reaches the team's own scoreboard on
+  // the small viewport.
+  await manager.page.getByLabel(/^title$/i).check();
+  await manager.page.getByTestId("award-points").click();
+  await expect(
+    team.page.locator('[data-team-id]:has-text("Mobile"):has-text("10")').first(),
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/tests/e2e/reconnection.spec.ts
+++ b/tests/e2e/reconnection.spec.ts
@@ -1,0 +1,69 @@
+// Team reload mid-game: identity persists in localStorage, useGameChannel
+// re-hydrates, and the team can still buzz after the reconnect.
+//
+// Spec ref: docs/testing-strategy.md §4.4 + frontend/src/pages/TeamGameplayPage.tsx
+// (readStoredTeam at line 17, hydrate effect, useGameChannel reconnect).
+
+import { test, expect } from "@playwright/test";
+import { joinAsTeam } from "./fixtures/team-context";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+
+test("team identity survives a mid-game tab reload", async ({ browser }) => {
+  const manager = await openManagerAndCreateGame(browser, {
+    totalRounds: 1,
+    genreName: "Rock",
+  });
+  const code = manager.gameCode;
+
+  const team = await joinAsTeam(browser, code, "Persistent");
+
+  // Identity is in localStorage under "game:<code>:team".
+  const storedBefore = await team.page.evaluate(
+    (c) => window.localStorage.getItem(`game:${c}:team`),
+    code,
+  );
+  expect(storedBefore).not.toBeNull();
+  const parsed = JSON.parse(storedBefore!) as { id: string; name: string };
+  expect(parsed.name).toBe("Persistent");
+  expect(parsed.id).toMatch(/^[0-9a-f-]{36}$/i);
+
+  // Round starts; the team page flips into "Buzz when you know it!".
+  await expect(manager.page.getByTestId("start-round")).toBeEnabled();
+  await manager.page.getByTestId("start-round").click();
+  await expect(
+    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Hard reload — useGameChannel re-subscribes, hydrate refetches, and the
+  // stored team identity is read again from localStorage.
+  await team.page.reload();
+
+  // Still on /team/<code>, still authenticated, identity still in storage.
+  await expect(team.page).toHaveURL(new RegExp(`/team/${code}$`));
+  const storedAfter = await team.page.evaluate(
+    (c) => window.localStorage.getItem(`game:${c}:team`),
+    code,
+  );
+  expect(storedAfter).toBe(storedBefore);
+
+  // Realtime should reconnect; banner ought to flip back to "Buzz when you know it!"
+  await expect(
+    team.page.getByRole("status").filter({ hasText: /Connected/i }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // The buzzer is functional after the reconnect.
+  await team.page.getByTestId("buzz").click();
+  await expect(team.page.getByTestId("buzz")).toHaveAttribute("data-tone", "winner", {
+    timeout: 10_000,
+  });
+
+  // Award and verify the score lands on the (reloaded) team's own scoreboard.
+  await manager.page.getByLabel(/^title$/i).check();
+  await manager.page.getByTestId("award-points").click();
+  await expect(
+    team.page.locator('[data-team-id]:has-text("Persistent"):has-text("10")').first(),
+  ).toBeVisible({ timeout: 10_000 });
+});


### PR DESCRIPTION
## Summary

- Lands the six remaining Playwright specs from `docs/testing-strategy.md` §4.4: `reconnection`, `expiration`, `admin_login`, `admin_songs_crud`, `kick_team`, `mobile_team`. Combined with PR #22, the full Phase-6 suite (8 specs) is now in.
- `admin_songs_crud` is API-driven via Playwright's request context (`/admin/songs` UI is a deferred Phase-5 carve-out). Doc updated to reflect that.
- `expiration` calls `cleanup_expired_games()` directly via the service-role JWT to avoid waiting on hourly pg_cron. Adds `tests/e2e/fixtures/supabase-admin.ts` with two helpers (`setExpiresAtPast`, `cleanupExpiredGames`).
- Bug fix discovered by `expiration.spec.ts`: when `active_games` is DELETE'd, `useGameChannel` flips state to null AND status to "gone" in the same tick. `ManagerConsolePage` was hitting the skeleton branch first and never showed the "this game no longer exists" banner. Reordered the guards.
- Tiny `data-testid` hooks on existing UI: `admin-password`, `admin-login-submit` (login), `kick-team` (team row).
- Sequence-flake note: locally with `retries: 0`, one of the tests usually marks flaky on the first run; CI's existing `retries: 1` recovers it. The full suite passes green with `--retries=1` as in the workflow.

## Test plan

- [x] `npx playwright test --project=chromium` (local, retries=1 to mirror CI): 9 tests, 7 pass first try, 2 flaky-then-pass.
- [x] `npx playwright test admin_songs_crud --project=chromium`: API CRUD + bulk-import idempotency.
- [x] `npx playwright test expiration --project=chromium`: cleanup runs, all surfaces show 'gone'.
- [x] `npx playwright test admin_login --project=chromium`: wrong password bounces, correct creates a game.
- [x] `npx playwright test kick_team --project=chromium`: kicked team navigates home, survivor stays.
- [x] `npx playwright test mobile_team --project=chromium`: iPhone 12 viewport joins, buzzes, scores.
- [x] `npx playwright test reconnection --project=chromium`: identity persists across reload.
- [x] `cd frontend && npm run typecheck && npm run lint && npm run test:run`: all green (136 unit tests).
- [ ] CI: add `run-e2e` label to trigger the workflow; expect chromium green.