### PR TITLE
fix(frontend): a11y polish - focus, contrast, and SR live regions

### DIFF
--- a/frontend/src/components/BuzzButton.module.css
+++ b/frontend/src/components/BuzzButton.module.css
@@ -56,16 +56,16 @@
 
 .button:disabled {
   cursor: not-allowed;
-  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
-  color: #e5e7eb;
-  box-shadow: 0 6px 18px rgba(107, 114, 128, 0.3);
+  background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
+  color: #f9fafb;
+  box-shadow: 0 6px 18px rgba(75, 85, 99, 0.3);
   animation: none;
-  opacity: 0.85;
+  opacity: 1;
 }
 
 .toneLockedOther:disabled {
   background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  color: #fff5f5;
+  color: #ffffff;
   box-shadow:
     0 8px 28px rgba(239, 68, 68, 0.45),
     0 0 0 6px rgba(239, 68, 68, 0.18);

--- a/frontend/src/components/BuzzButton.test.tsx
+++ b/frontend/src/components/BuzzButton.test.tsx
@@ -56,6 +56,24 @@ describe("BuzzButton", () => {
     expect(onBuzz).not.toHaveBeenCalled();
   });
 
+  it("uses the visible label and subtitle as the accessible name", () => {
+    render(
+      <BuzzButton
+        disabled={false}
+        isBuzzing={false}
+        label="BUZZ"
+        subtitle="Tap or press space"
+        onBuzz={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /BUZZ Tap or press space/i })).toBeInTheDocument();
+  });
+
+  it("falls back to label-only accessible name when no subtitle", () => {
+    render(<BuzzButton disabled={false} isBuzzing={false} label="BUZZ" onBuzz={() => {}} />);
+    expect(screen.getByRole("button", { name: "BUZZ" })).toBeInTheDocument();
+  });
+
   it("reflects the tone prop via data-tone for styling", () => {
     const { rerender } = render(
       <BuzzButton disabled isBuzzing={false} tone="locked-other" onBuzz={() => {}} />,

--- a/frontend/src/components/BuzzButton.tsx
+++ b/frontend/src/components/BuzzButton.tsx
@@ -59,10 +59,14 @@ export function BuzzButton({
       onClick={handleClick}
       onKeyDown={handleKey}
       className={className}
-      aria-label={label}
     >
       <span className={styles.label}>{label}</span>
-      {subtitle ? <span className={styles.subtitle}>{subtitle}</span> : null}
+      {subtitle ? (
+        <>
+          {" "}
+          <span className={styles.subtitle}>{subtitle}</span>
+        </>
+      ) : null}
     </button>
   );
 }

--- a/frontend/src/components/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("renders title and message when open", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="End game?"
+        message="This cannot be undone."
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByRole("dialog", { name: "End game?" })).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<ConfirmDialog open={false} title="X" onConfirm={() => {}} onCancel={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("focuses the confirm button on open", () => {
+    render(
+      <ConfirmDialog open title="X" confirmLabel="Yes" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "Yes" })).toHaveFocus();
+  });
+
+  it("calls onCancel on Escape", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog open title="X" onConfirm={() => {}} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("traps Tab from confirm forward to cancel", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="X"
+        cancelLabel="No"
+        confirmLabel="Yes"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const confirm = screen.getByRole("button", { name: "Yes" });
+    const cancel = screen.getByRole("button", { name: "No" });
+    confirm.focus();
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(cancel).toHaveFocus();
+  });
+
+  it("traps Shift+Tab from cancel back to confirm", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="X"
+        cancelLabel="No"
+        confirmLabel="Yes"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const confirm = screen.getByRole("button", { name: "Yes" });
+    const cancel = screen.getByRole("button", { name: "No" });
+    cancel.focus();
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(confirm).toHaveFocus();
+  });
+
+  it("returns focus to the trigger when closed", () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button data-testid="trigger" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <ConfirmDialog
+            open={open}
+            title="X"
+            onConfirm={() => setOpen(false)}
+            onCancel={() => setOpen(false)}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByTestId("trigger");
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+    fireEvent.click(trigger);
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveFocus();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(trigger).toHaveFocus();
+  });
+
+  it("uses btn-danger styling when destructive", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="X"
+        destructive
+        confirmLabel="Delete"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Delete" }).className).toMatch(/btn-danger/);
+  });
+});

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Portal } from "./Portal";
 import styles from "./ConfirmDialog.module.css";
 
@@ -24,18 +24,47 @@ export function ConfirmDialog({
   onCancel,
 }: Props) {
   const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  // Ref callback runs when the Portal commits the button into the DOM, which
+  // is the only point at which we can focus it (the Portal mounts in an effect
+  // after the parent's first render).
+  const confirmCb = useCallback(
+    (node: HTMLButtonElement | null) => {
+      confirmRef.current = node;
+      if (node && open) node.focus();
+    },
+    [open],
+  );
 
   useEffect(() => {
     if (!open) return undefined;
+    triggerRef.current = document.activeElement as HTMLElement | null;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
         onCancel();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const first = cancelRef.current;
+      const last = confirmRef.current;
+      if (!first || !last) return;
+      const active = document.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
       }
     };
     window.addEventListener("keydown", onKey);
-    confirmRef.current?.focus();
-    return () => window.removeEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      triggerRef.current?.focus?.();
+    };
   }, [open, onCancel]);
 
   if (!open) return null;
@@ -55,11 +84,11 @@ export function ConfirmDialog({
           </h2>
           {message ? <p className={styles.message}>{message}</p> : null}
           <div className={styles.actions}>
-            <button type="button" className="btn btn-ghost" onClick={onCancel}>
+            <button ref={cancelRef} type="button" className="btn btn-ghost" onClick={onCancel}>
               {cancelLabel}
             </button>
             <button
-              ref={confirmRef}
+              ref={confirmCb}
               type="button"
               className={`btn ${destructive ? "btn-danger" : "btn-primary"}`}
               onClick={onConfirm}

--- a/frontend/src/components/Scoreboard.test.tsx
+++ b/frontend/src/components/Scoreboard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Scoreboard } from "./Scoreboard";
 import type { Team } from "../lib/types";
 
@@ -55,5 +55,56 @@ describe("Scoreboard", () => {
     rerender(<Scoreboard teams={updated} />);
     const flashed = screen.getByText("Alice").closest("li");
     expect(flashed?.className).toMatch(/flashing/);
+  });
+
+  describe("score-change announcement", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("announces a score gain via the live region", () => {
+      const initial: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 0 }];
+      const { rerender } = render(<Scoreboard teams={initial} />);
+      expect(screen.getByTestId("scoreboard-announcement").textContent).toBe("");
+
+      const updated: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 10 }];
+      rerender(<Scoreboard teams={updated} />);
+      expect(screen.getByTestId("scoreboard-announcement").textContent).toBe(
+        "Alice gained 10 points to 10",
+      );
+    });
+
+    it("announces a score loss with absolute delta", () => {
+      const initial: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 10 }];
+      const { rerender } = render(<Scoreboard teams={initial} />);
+      const updated: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 5 }];
+      rerender(<Scoreboard teams={updated} />);
+      expect(screen.getByTestId("scoreboard-announcement").textContent).toBe(
+        "Alice lost 5 points to 5",
+      );
+    });
+
+    it("clears the announcement after 700ms", () => {
+      const initial: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 0 }];
+      const { rerender } = render(<Scoreboard teams={initial} />);
+      const updated: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 10 }];
+      rerender(<Scoreboard teams={updated} />);
+      expect(screen.getByTestId("scoreboard-announcement").textContent).not.toBe("");
+      act(() => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(screen.getByTestId("scoreboard-announcement").textContent).toBe("");
+    });
+
+    it("uses polite live-region semantics", () => {
+      const teams: Team[] = [{ ...baseTeam, id: "1", name: "Alice", score: 0 }];
+      render(<Scoreboard teams={teams} />);
+      const region = screen.getByTestId("scoreboard-announcement");
+      expect(region).toHaveAttribute("aria-live", "polite");
+      expect(region).toHaveAttribute("role", "status");
+    });
   });
 });

--- a/frontend/src/components/Scoreboard.tsx
+++ b/frontend/src/components/Scoreboard.tsx
@@ -10,12 +10,19 @@ interface Props {
 export function Scoreboard({ teams, buzzedTeamId }: Props) {
   const prevScoresRef = useRef<Record<string, number>>({});
   const [flashingIds, setFlashingIds] = useState<Set<string>>(new Set());
+  const [announcement, setAnnouncement] = useState("");
 
   useEffect(() => {
     const changed = new Set<string>();
+    const messages: string[] = [];
     for (const t of teams) {
       const prev = prevScoresRef.current[t.id];
-      if (prev !== undefined && prev !== t.score) changed.add(t.id);
+      if (prev !== undefined && prev !== t.score) {
+        changed.add(t.id);
+        const delta = t.score - prev;
+        const verb = delta > 0 ? "gained" : "lost";
+        messages.push(`${t.name} ${verb} ${Math.abs(delta)} points to ${t.score}`);
+      }
       prevScoresRef.current[t.id] = t.score;
     }
     if (changed.size === 0) return undefined;
@@ -24,7 +31,11 @@ export function Scoreboard({ teams, buzzedTeamId }: Props) {
       changed.forEach((id) => next.add(id));
       return next;
     });
-    const handle = window.setTimeout(() => setFlashingIds(new Set()), 700);
+    setAnnouncement(messages.join(". "));
+    const handle = window.setTimeout(() => {
+      setFlashingIds(new Set());
+      setAnnouncement("");
+    }, 700);
     return () => window.clearTimeout(handle);
   }, [teams]);
 
@@ -50,27 +61,37 @@ export function Scoreboard({ teams, buzzedTeamId }: Props) {
   });
 
   return (
-    <ol className={styles.list} data-testid="scoreboard">
-      {sorted.map((team, index) => {
-        const isBuzzed = team.id === buzzedTeamId;
-        const isFlashing = flashingIds.has(team.id);
-        const rowClass = [
-          styles.row,
-          isBuzzed ? styles.buzzed : "",
-          isFlashing ? styles.flashing : "",
-        ]
-          .filter(Boolean)
-          .join(" ");
-        return (
-          <li key={team.id} className={rowClass} data-team-id={team.id}>
-            <span className={styles.rank}>{index + 1}</span>
-            <span className={styles.name}>{team.name}</span>
-            <span key={team.score} className={styles.score}>
-              {team.score}
-            </span>
-          </li>
-        );
-      })}
-    </ol>
+    <>
+      <ol className={styles.list} data-testid="scoreboard">
+        {sorted.map((team, index) => {
+          const isBuzzed = team.id === buzzedTeamId;
+          const isFlashing = flashingIds.has(team.id);
+          const rowClass = [
+            styles.row,
+            isBuzzed ? styles.buzzed : "",
+            isFlashing ? styles.flashing : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            <li key={team.id} className={rowClass} data-team-id={team.id}>
+              <span className={styles.rank}>{index + 1}</span>
+              <span className={styles.name}>{team.name}</span>
+              <span key={team.score} className={styles.score}>
+                {team.score}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+      <span
+        className="visually-hidden"
+        aria-live="polite"
+        role="status"
+        data-testid="scoreboard-announcement"
+      >
+        {announcement}
+      </span>
+    </>
   );
 }

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -183,9 +183,9 @@ describe("ManagerConsolePage", () => {
     await act(async () => {
       await fireSubscribed();
     });
-    const banner = screen.getByRole("status");
-    expect(banner.textContent).toMatch(/alice/i);
-    expect(banner.textContent).toMatch(/buzzed in/i);
+    const banner = screen.getByText(/buzzed in/i).closest('[role="status"]');
+    expect(banner?.textContent).toMatch(/alice/i);
+    expect(banner?.textContent).toMatch(/buzzed in/i);
     expect(screen.getByRole("button", { name: /award points/i })).toBeEnabled();
   });
 

--- a/frontend/src/pages/ManagerCreateGamePage.module.css
+++ b/frontend/src/pages/ManagerCreateGamePage.module.css
@@ -101,9 +101,9 @@
   accent-color: var(--color-primary);
 }
 
-.rounds input[type="range"]:focus {
-  background: transparent;
-  box-shadow: none;
+.rounds input[type="range"]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
 }
 
 .roundsValue {

--- a/frontend/src/pages/TeamGameplayPage.test.tsx
+++ b/frontend/src/pages/TeamGameplayPage.test.tsx
@@ -7,9 +7,11 @@ vi.mock("../lib/supabase", async () => {
   return { supabase: mod.supabaseMock };
 });
 
+import { _resetServerTime } from "../hooks/useServerTime";
 import {
   fireSubscribed,
   makeActiveGame,
+  makeRound,
   makeTeam,
   resetSupabaseMock,
   setHydrate,
@@ -20,6 +22,7 @@ import { TeamGameplayPage } from "./TeamGameplayPage";
 beforeEach(() => {
   resetSupabaseMock();
   window.localStorage.clear();
+  _resetServerTime();
 });
 
 afterEach(() => {
@@ -159,6 +162,55 @@ describe("TeamGameplayPage", () => {
     window.localStorage.setItem("game:ABCDEF:team", "{not json");
     renderAt("/team/ABCDEF");
     expect(screen.getByText("join page")).toBeInTheDocument();
+  });
+
+  describe("timer accessibility", () => {
+    function setupRunningRound(secondsAgo: number): void {
+      const FIXED_NOW = 1_780_000_000_000;
+      vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+      const startedAt = new Date(FIXED_NOW - secondsAgo * 1000).toISOString();
+      window.localStorage.setItem(
+        "game:ABCDEF:team",
+        JSON.stringify({ id: "team-1", name: "Alice" }),
+      );
+      setHydrate({
+        game: makeActiveGame({ status: "playing", current_round_id: "round-1" }),
+        teams: [makeTeam({ id: "team-1" })],
+        rounds: [makeRound({ id: "round-1", started_at: startedAt })],
+      });
+    }
+
+    it("uses a static aria-label on the timer (no per-tick rewrite)", async () => {
+      setupRunningRound(2);
+      renderAt("/team/ABCDEF");
+      await act(async () => {
+        await fireSubscribed();
+      });
+      const timer = await screen.findByRole("timer");
+      expect(timer).toHaveAttribute("aria-label", "Time remaining");
+    });
+
+    it("renders an empty live region when there is plenty of time left", async () => {
+      setupRunningRound(2);
+      renderAt("/team/ABCDEF");
+      await act(async () => {
+        await fireSubscribed();
+      });
+      const timer = await screen.findByRole("timer");
+      const liveRegion = timer.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toBe("");
+    });
+
+    it("announces low time when remaining seconds drop to the 5→1 tail", async () => {
+      setupRunningRound(17);
+      renderAt("/team/ABCDEF");
+      await act(async () => {
+        await fireSubscribed();
+      });
+      const timer = await screen.findByRole("timer");
+      const liveRegion = timer.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toBe("3 seconds left");
+    });
   });
 
   it("renders the rpc-mock click without error", async () => {

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -163,12 +163,15 @@ export function TeamGameplayPage() {
           className={`${styles.timer} ${remainingSec <= 5 ? styles.timerLow : ""}`}
           style={{ "--timer-pct": `${timerPct}%` } as CSSProperties}
           role="timer"
-          aria-label={`${remainingSec} seconds remaining`}
+          aria-label="Time remaining"
         >
           <div className={styles.timerBar}>
             <div className={styles.timerFill} />
           </div>
           <span className={styles.timerValue}>{remainingSec}s</span>
+          <span className="visually-hidden" aria-live="polite" role="status">
+            {remainingSec <= 5 && remainingSec > 0 ? `${remainingSec} seconds left` : ""}
+          </span>
         </div>
       ) : null}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -309,6 +309,18 @@ textarea:disabled {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

Seven concrete a11y bug fixes from the post-PR-26 audit. Bugs-only scope by design: no new dependencies, no token consolidation, no dark mode, no eslint-plugin-jsx-a11y. Coverage holds at 89.74/83.43/89.39/93.14 vs gates 85/80/85/85.

- **Range slider focus restored** (`ManagerCreateGamePage.module.css`) — the `:focus { box-shadow: none }` rule suppressed the focus indicator entirely (WCAG 2.4.7). Replaced with a visible `:focus-visible` outline.
- **BuzzButton disabled-state contrast** — `#e5e7eb` on `#9ca3af → #6b7280` was ~2.5:1. Darkened the gradient and switched to `#f9fafb` for ~6.4:1 against the darker stop.
- **BuzzButton locked-other contrast** — `#fff5f5` on red gradient → `#ffffff` for safer headroom on the lighter end.
- **BuzzButton aria-label override removed** — was suppressing the visible subtitle ("Tap or press space" / "X buzzed first") for AT users. The button's text content now becomes its accessible name; added a JSX-literal space so SRs read label and subtitle separately.
- **Timer aria-label thrash fixed** (`TeamGameplayPage.tsx`) — was rewriting the label every tick. Now static "Time remaining"; the visible `Ns` value is the running indicator. Added an sr-only polite live region that announces only the 5→1 second tail.
- **Scoreboard score-change announcements** — added an sr-only `aria-live="polite"` region that announces "Team X gained N points to M" / "Team X lost N points to M" alongside the existing visual flash. Cleared on the same 700ms timeout.
- **ConfirmDialog focus trap + return focus** — saves `document.activeElement` on open and restores it on close. Tab/Shift+Tab now cycles between Cancel and Confirm. Switched to a ref callback for the confirm button to fix a Portal-mount race that meant focus never actually landed on the confirm button on initial open.

Also added a reusable `.visually-hidden` utility class in `styles.css` (first sr-only utility in the codebase; consumed by the timer and scoreboard live regions).

Out of scope: heading hierarchy, semantic `<label>` migration, eslint-plugin-jsx-a11y, jest-axe, dark mode, color-token consolidation. Tracked for follow-ups.

YouTubePlayer error was already `role="alert"` — dropped from scope.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run format:check\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run test:run\` — 172/172 (4 new ConfirmDialog tests + 4 new Scoreboard tests + 3 new TeamGameplayPage tests + 2 new BuzzButton tests; one ManagerConsolePage test scoped past the new role="status" live region)
- [x] \`npm run test:coverage\` — 89.74/83.43/89.39/93.14 vs 85/80/85/85
- [x] \`npm run build\` — clean
- [ ] Manual a11y smoke (post-merge): tab through `/manager/create-game` slider; open and close `End game?` dialog; emulate low-vision on the disabled BuzzButton; VoiceOver / NVDA on team page (timer no longer floods, 5→1s tail announces) and display page (score changes announced).