### PR TITLE
fix: allow Sentry DE region in CSP + gitignore local secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ Thumbs.db
 # Claude Code local-only settings (project rules in CLAUDE.md are committed; local settings are not)
 .claude/settings.local.json
 .claude/rules/
+.claude/*.local
+.claude/*.local.*
 
 # Supabase local
 supabase/.branches/

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io https://o*.ingest.de.sentry.io


### PR DESCRIPTION
## Summary

Two small Phase 7 step-1 follow-ups discovered during Sentry project setup.

- **CSP fix** (`frontend/public/_headers`): Sentry created the org in the DE region, so DSNs target `o<num>.ingest.de.sentry.io`. The existing `https://o*.ingest.sentry.io` source-expression doesn't match the regional subdomain (CSP wildcards are single-label only). Adds `https://o*.ingest.de.sentry.io` alongside the existing pattern. Without this, the browser would silently refuse to send frontend errors to Sentry once `VITE_SENTRY_DSN` is set on Cloudflare Pages.
- **`.gitignore`**: adds `.claude/*.local` and `.claude/*.local.*` so the local-only secrets file (`.claude/phase7-secrets.local`, where Phase 7 DSNs and other env values live) can't be accidentally committed by future PRs. Currently the user has values in that file; this protects them.

## Test plan

- [x] Verified `git check-ignore -v .claude/phase7-secrets.local` matches `.gitignore:54:.claude/*.local`.
- [x] CSP change is single-line, syntactically valid CSP source-list.
- [ ] Post-merge: once frontend is deployed with `VITE_SENTRY_DSN` set, confirm Sentry receives a synthetic browser error (covered in cutover checklist step 9 sanity-check).