### PR TITLE
chore(frontend): commit .env.production with public build values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ frontend/package-lock.json
 .env.*
 !.env.example
 !.env.*.example
+# Production frontend env: explicitly tracked. Only contains values that ship
+# to the browser bundle anyway (Supabase anon key, Sentry DSN public form, etc).
+# Service-role keys / admin password / deploy hooks live in GitHub Actions
+# secrets and .claude/phase7-secrets.local — never in the repo.
+!frontend/.env.production
 
 # Editor / OS
 .vscode/
@@ -62,6 +67,9 @@ supabase/.temp/
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Wrangler local cache
+.wrangler/
 
 # Sentry
 .sentryclirc

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,14 @@
+# Sound Clash frontend — production build env.
+#
+# Vite reads this automatically when building in production mode (npm run build).
+# Every value here ends up baked into the browser JS bundle, so by definition
+# none of them is a secret. The Supabase anon key is gated by RLS; the Sentry
+# DSN is the public form designed to ship to clients.
+#
+# Sensitive values (service_role key, admin password, deploy hooks) live in
+# .claude/phase7-secrets.local (gitignored) and GitHub Actions secrets — never
+# in the repo.
+VITE_SUPABASE_URL=https://jvfddxuaqcsrguibkymp.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp2ZmRkeHVhcWNzcmd1aWJreW1wIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzgwODc1MDYsImV4cCI6MjA5MzY2MzUwNn0.dhQWQnHDwuZc2DolW98PQmCPdACi1O-4DFPuhKGUSpk
+VITE_API_URL=https://api.soundclash.org
+VITE_SENTRY_DSN=https://a6fdb6eb2af882876781c74169de0f07@o4511344399941632.ingest.de.sentry.io/4511344493199440


### PR DESCRIPTION
## Summary

Vite reads `frontend/.env.production` automatically when building in production mode (`npm run build`). The four `VITE_*` values it needs all end up baked into the browser JS bundle, so by definition none of them is a secret. Committing them here means the CI build (`.github/workflows/frontend.yml:103`) just works — no env block needed in the workflow.

What's in the file:
- `VITE_SUPABASE_URL` — new prod project (Frankfurt, ref jvfddxuaqcsrguibkymp)
- `VITE_SUPABASE_ANON_KEY` — JWT with `role: anon` (verified before commit). Gated by RLS.
- `VITE_API_URL` — `https://api.soundclash.org`
- `VITE_SENTRY_DSN` — Sentry DSN public form (designed to ship to clients)

What's NOT in the file (and never will be):
- `SUPABASE_SERVICE_ROLE_KEY` — JWT with `role: service_role`, bypasses RLS. Lives in GitHub Actions secrets + `.claude/phase7-secrets.local` only.
- `ADMIN_PASSWORD` — Render env var only.
- `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `RENDER_DEPLOY_HOOK` — GitHub Actions secrets only.

Verified before commit:
1. The anon key in the file decodes to `"role":"anon"` (not `service_role`).
2. `grep` for the service_role JWT signature, CF token, and admin password against the file returned 0 hits.

`.gitignore` change: added explicit `!frontend/.env.production` exception under the existing `.env.*` ignore (with an inline comment explaining why this specific file is allowed). Also added `.wrangler/` (local cache wrangler dropped during step 3).

## Test plan

- [x] `git check-ignore` confirms `frontend/.env.production` is no longer ignored after the gitignore change.
- [x] Anon key role claim verified as `"anon"` before commit.
- [x] No service-role / token / password values present in the committed file.
- [ ] Post-merge: the next push to main triggers `.github/workflows/frontend.yml` deploy job; build should succeed without the "Missing required env var" error.