### PR TITLE
fix(backend): pin Dockerfile to python 3.11-slim

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@
 # See docs/tech-stack.md and docs/local-development.md for context.
 
 # ---- builder ----
-FROM python:3.14-slim AS builder
+FROM python:3.11-slim AS builder
 
 WORKDIR /app
 RUN python -m venv /opt/venv
@@ -15,7 +15,7 @@ COPY app ./app
 RUN pip install --no-cache-dir -e .
 
 # ---- runtime ----
-FROM python:3.14-slim AS runtime
+FROM python:3.11-slim AS runtime
 
 # Non-root user
 RUN useradd --create-home --shell /bin/bash app


### PR DESCRIPTION
## Summary

Render's first build of the backend service failed:

```
ERROR: Failed building wheel for pyiceberg
error: command 'gcc' failed: No such file or directory
```

Root cause: backend/Dockerfile used python:3.14-slim, but the rest of the project targets 3.11 (pyproject.toml requires-python = ">=3.11", ruff target-version py311, mypy python_version 3.11). On Python 3.14, several transitive deps (e.g. pyiceberg, pulled in via the Supabase stack) don't have prebuilt wheels yet, so pip falls back to building from source — which fails because the slim image has no gcc.

Fix: change both Docker stages to python:3.11-slim. Prebuilt wheels exist for all our deps on 3.11, so no compiler is needed and the build is fast.

## Test plan

- target-version py311 in pyproject.toml — Dockerfile now matches.
- After merge: Render auto-rebuilds via its git connection.
- Verify the new Render deploy succeeds and /health returns 200.