### PR TITLE
fix(backend): drop -e from Dockerfile pip install

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY pyproject.toml ./
 COPY app ./app
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir .
 
 # ---- runtime ----
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
## Summary

After PR #31 fixed the Python version, Render's build now succeeds but the runtime crashes with:

\`\`\`
ModuleNotFoundError: No module named 'app'
\`\`\`

Root cause: the Dockerfile's builder stage uses \`pip install -e .\` (editable install). An editable install drops a .pth file in the venv that adds the source directory to sys.path. The path baked into that .pth is the builder's WORKDIR (\`/app\`). The runtime stage copies the venv (\`COPY --from=builder /opt/venv /opt/venv\`) but NOT the source at \`/app/app\` — so when uvicorn imports \`app.main\`, the .pth points to a directory that doesn't exist in the runtime image.

Fix: drop the \`-e\`. Non-editable install copies the \`app\` package into \`/opt/venv/lib/python3.11/site-packages/app/\` directly, which is then carried into the runtime via the existing venv copy. No source-tree dependency at runtime.

Editable installs are for local dev (so source edits show up live). Production images should use the non-editable form.

## Test plan

- After merge, Render rebuilds via git auto-deploy.
- Verify the new deploy reaches \`Uvicorn running on http://0.0.0.0:\$PORT\` and \`/health\` returns 200.