### PR TITLE
ci(frontend): bump Node to 22 to satisfy wrangler 4.x

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           # NOTE: npm cache disabled until frontend/package-lock.json is committed
           # (will be generated when Node is installed locally for Phase 5).
           # Re-enable with `cache: "npm"` + `cache-dependency-path` once the
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           # See note above about cache.
       - run: |
           if [ -f package-lock.json ]; then


### PR DESCRIPTION
## Summary

The Cloudflare Pages deploy step has been silently failing on every main push since wrangler 4.x landed. Logs from run 25458711793:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

The deploy job uses npx wrangler@latest, which currently resolves to 4.88.0 (Node 22+ required). The test job is on the same Node 20 too, so we bump both to keep them in sync.

Result: zero successful Pages deployments. www.soundclash.org returns CF error 522 because the project has no origin to serve.

## Fix

Bump both jobs from node-version: "20" to "22". Node 22 is the current LTS; all our deps (vite 5, vitest, react 18, @sentry/react 8, supabase-js 2) support it.

## Test plan

- After merge: next push to main runs the deploy job, succeeds, Pages gets its first deployment.
- Verify https://www.soundclash.org and https://sound-clash.pages.dev return 200.