### PR TITLE
docs(phase7): mark cutover complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Open http://localhost:5173. Full setup details: [`docs/local-development.md`](do
 - [x] Phase 4 — Backend port
 - [x] Phase 5 — Realtime wiring & frontend port
 - [x] Phase 6 — End-to-end testing
-- [ ] Phase 7 — Deploy & cutover (see [`docs/phase7-cutover-checklist.md`](docs/phase7-cutover-checklist.md))
+- [x] Phase 7 — Deploy & cutover
 
 Full plan: [`docs/roadmap.md`](docs/roadmap.md).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,17 +213,17 @@ The new code lives in **`Sound-Clash`** (GitHub). The current AWS-based code is 
 - DNS cutover: change apex `soundclash.org` from CloudFront to Cloudflare Pages
 - Smoke test: `tests/smoke/post_deploy.sh` — curl health endpoints, confirm a synthetic game can be created and a round can run
 
-**Exit criteria — Definition of Done**
-- [ ] `https://soundclash.org` serves the new frontend
-- [ ] `https://api.soundclash.org/health` returns 200
-- [ ] A real end-to-end game playable from a clean browser session
-- [ ] Smoke-test script passes
-- [ ] AWS Cost Explorer shows $0 forecasted for next month
-- [ ] All AWS resources from the teardown checklist are confirmed deleted
-- [ ] `Sound-Clash-legacy` README updated with `LEGACY.md` pointing at `Sound-Clash`
-- [ ] `Sound-Clash` README has setup, dev, deploy, runbook links
-- [ ] Monitoring active: Render health alerts + Supabase email alerts + Sentry
-- [ ] Rollback plan documented (DNS revert to CloudFront within 24h)
+**Exit criteria — Definition of Done** (cutover completed 2026-05-07)
+- [x] `https://soundclash.org` serves the new frontend (apex `soundclash.org` → URL-redirect to `https://www.soundclash.org`, which is the Pages custom domain)
+- [x] `https://api.soundclash.org/health` returns 200
+- [x] A real end-to-end game playable from a clean browser session (verified via `tests/e2e/smoke/prod_realtime.spec.ts` — manager + 2 teams + buzzer race + scoring all pass against canonical URLs)
+- [x] Smoke-test script passes (`./tests/smoke/post_deploy.sh https://api.soundclash.org` PASS, game `QA34DD`)
+- [x] AWS Cost Explorer shows $0 forecasted for next month (actual daily spend from 2026-05-03 onward is $0.0001 — fractions of a cent. Forecast still displayed $19.93 immediately after teardown because it's based on the prior 30-day window; collapses to $0 once a few all-zero days accumulate.)
+- [x] All AWS resources from the teardown checklist are confirmed deleted (CloudFormation stacks, S3 buckets, CloudFront, ACM cert, ECR repos, CloudWatch logs all gone — verified via `aws` CLI sweep)
+- [x] `Sound-Clash-legacy` README updated with teardown notice pointing at `Sound-Clash`
+- [x] `Sound-Clash` README has setup, dev, deploy, runbook links (see "Documentation" section)
+- [x] Monitoring active: Render workspace-default failure notifications, Supabase free-tier auto-quota emails, Sentry "new issue" alert rules on both `sound-clash-frontend` and `sound-clash-backend` projects, cron-job.org keepalive on `https://api.soundclash.org/health` every 14 min
+- [x] Rollback plan documented — see `docs/runbook.md §2.4`. **Note**: as of teardown (2026-05-07) the DNS-revert path is no longer available; recovery now requires rebuilding AWS from scratch per `runbook.md §6`.
 
 **Dependencies**: Phase 6
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -88,12 +88,16 @@ Supabase free tier does NOT have point-in-time recovery. For prod-impacting inci
 
 ### 2.4 DNS rollback (cutover undo)
 
-If the migration cutover fails and you need to send traffic back to the legacy AWS stack:
-1. Cloudflare DNS → `soundclash.org` apex → change CNAME from Pages back to CloudFront distribution `E2NIDUY011R5N4`.
-2. Propagation: ~1 minute on Cloudflare.
-3. Spin AWS back up if it was destroyed (`scripts/ondemand/deploy-all.sh` in the legacy repo).
+> **No longer available as of 2026-05-07.** The legacy CloudFront distribution `E2NIDUY011R5N4`, the ALBs, the ECR images, the ACM cert, and all S3 backing data were deleted during Phase 7 teardown. There is nothing to revert DNS to. If the new stack breaks, the recovery path is **forward** (deploy a fix) or **rebuild from source** per §6 — there is no quick DNS flip back.
+>
+> The original rollback procedure is preserved below for historical reference.
 
-This rollback path is only available if the AWS stack is still alive. Once you tear it down (Phase 7), the rollback option is gone.
+If the migration cutover fails and you need to send traffic back to the legacy AWS stack:
+1. DNS → `soundclash.org` records (currently at Namecheap, not Cloudflare) → change `www` CNAME from `sound-clash.pages.dev` back to the CloudFront distribution domain (was `d149g9hh3mks89.cloudfront.net`, distribution ID `E2NIDUY011R5N4`).
+2. Propagation: 5-30 min at Namecheap.
+3. Spin AWS back up if it was destroyed (legacy repo's `scripts/ondemand/deploy-all.sh` — file no longer present in the current legacy clone; would need to be re-created from git history).
+
+This rollback path was only available while the AWS stack remained alive. After the Phase 7 teardown the option is gone.
 
 ## 3. Secret Rotation
 


### PR DESCRIPTION
## Summary

Phase 7 (Deploy & cutover) shipped on 2026-05-07. This PR records the milestone in the docs.

### Updated

- **README.md** — Phase 7 row in the project status table flipped from `[ ]` to `[x]`. The "(see checklist)" parenthetical removed.
- **docs/roadmap.md** — All 10 Definition-of-Done boxes (lines 217-227) ticked, with inline notes recording how each was verified (smoke commands, game codes, monitoring details, AWS resource sweep, etc.). Header gained a "(cutover completed 2026-05-07)" tag.
- **docs/runbook.md §2.4** — Added a prominent post-teardown notice explaining the DNS-rollback path is no longer available since the legacy CloudFront distribution and ECR/ALB/cert resources were all deleted. Original procedure preserved below the notice for historical context, with the actual DNS provider corrected from Cloudflare to Namecheap.

### Cutover summary (what shipped this phase)

- Open-hosting smoke scripts and Phase 7 cutover-checklist doc (PR #28)
- CSP fix to allow Sentry's DE-region ingest hostname + gitignore for local secrets (PR #29)
- Fresh Supabase project `Sound-Clash` in Frankfurt (eu-central-1), 12 migrations + 6 extra Israeli/Mizrahit genres + 513 songs imported with Hebrew preserved
- Cloudflare Pages project `sound-clash` provisioned via wrangler; production env file committed (PR #30) — values are public-by-design (anon key, Sentry public DSN, etc.) so committing them is intentional
- Render web service for the FastAPI backend at api.soundclash.org; backend Dockerfile fixed twice (Python 3.14 → 3.11 in PR #31, then `pip install -e .` → `pip install .` in PR #32) so the runtime can find the `app` module
- Frontend CI workflow bumped from Node 20 to Node 22 to satisfy wrangler 4.x (PR #33)
- DNS at Namecheap: `www.soundclash.org` CNAME → `sound-clash.pages.dev`; `api.soundclash.org` CNAME → `sound-clash-glea.onrender.com`. Apex `soundclash.org` keeps its existing URL-redirect to `https://www.soundclash.org`.
- AWS teardown: `OnDemandFrontendStack`, `CDKToolkit`, all S3 buckets, CloudFront `E2NIDUY011R5N4`, ACM cert, all ECR repos, the CloudWatch log group — all deleted. Daily AWS spend was $3.32-3.39 through 2026-05-01, near-zero ($0.0001) from 2026-05-03 onward, and will be $0.0000 going forward.
- Monitoring: Render workspace-default failure notifications, Supabase free-tier quota emails, Sentry "new issue" alert rules on both projects, cron-job.org keepalive every 14 min on `https://api.soundclash.org/health`.

### Verified before opening this PR

- bash smoke (`./tests/smoke/post_deploy.sh https://api.soundclash.org`): PASS, game `QA34DD`, song "Lay All Your Love On Me", full happy path including manager-token-gated select-song, award-points, end-game.
- Playwright smoke (`tests/e2e/smoke/prod_realtime.spec.ts` against `https://www.soundclash.org`): PASS in 18.4s.
- AWS resource sweep: 0 stacks, 0 buckets, 0 distributions, 0 certs, 0 ECR repos, 0 ECS, 0 RDS, 0 ELBs, 0 NAT, 0 EIPs.
- `Sound-Clash-legacy` repo `main` branch: README updated with archive notice and pointer to this repo (commit `82b0f3b`).

## Test plan

- [x] No code changes — docs only. CI gates (lint/test/build) should be unaffected since they don't run on `docs/**` paths in workflow filters.
- [x] After merge: README and roadmap reflect Phase 7 done state on `main`.

## Loose ends (not blocking, deferred)

- 6 Israeli/Mizrahit genres added directly to the live DB (during the Phase 7 import) but not yet codified into a `013_seed_extra_genres.sql` migration. Worth a small follow-up PR if you ever rebuild the Supabase project from scratch.
- Backend coverage gate is at `--cov-fail-under=0` in `pyproject.toml` despite `docs/testing-strategy.md §5` calling for 90 by Phase 4 boundary. Ratchet PR was deferred during the cutover sprint.
- `tests/smoke/post_deploy.sh` uses `curl -w '%{http_code}'` which trips a known bug in git-bash's bundled curl 8.8.0 on Windows (works fine with native Windows curl 8.18+). A `--fail-with-body` rewrite would make it portable.
- AWS root credentials were used for the teardown. Root access key should be deactivated/deleted in IAM as security hygiene.