### PR TITLE
chore: seed Israeli genres and fix smoke script git-bash portability

### DIFF
--- a/db/migrations/013_seed_extra_genres.sql
+++ b/db/migrations/013_seed_extra_genres.sql
@@ -1,0 +1,15 @@
+-- 013_seed_extra_genres.sql
+-- Israeli / Mizrahit genres added live during the Phase 7 song-catalog
+-- import. Backfilled into version control so a fresh prod rebuild from
+-- migrations alone produces the same genre set. Idempotent via
+-- ON CONFLICT (slug) DO NOTHING; safe to rerun.
+--
+-- Pairs with 008_seed_genres.sql; do not delete that file's rows here.
+
+INSERT INTO genres (name, slug) VALUES
+  ('Israeli Cover',         'israeli-cover'),
+  ('Israeli Pop',           'israeli-pop'),
+  ('Israeli Rap & Hip-Hop', 'israeli-rap-hip-hop'),
+  ('Israeli Rock-Pop',      'israeli-rock-pop'),
+  ('Mizrahit',              'mizrahit')
+ON CONFLICT (slug) DO NOTHING;

--- a/tests/smoke/post_deploy.sh
+++ b/tests/smoke/post_deploy.sh
@@ -44,27 +44,23 @@ require_cmd() {
 require_cmd curl
 require_cmd jq
 
-# Wrapper that captures status code AND body. We need both: status to
-# detect failure, body to surface error detail.
+# Wrapper that asserts a 2xx and emits the body to stdout. Uses
+# --fail-with-body (curl 7.76+) so curl exits non-zero on HTTP errors
+# while still streaming the body — gives us the detail in the failure
+# message without the -w '%{http_code}' invocation that trips git-bash
+# bundled curl 8.8.0 (exits 43). Portable across git-bash, macOS, and
+# CI Ubuntu.
 http() {
   local method="$1"
   local path="$2"
-  local body_file
-  body_file=$(mktemp)
   shift 2
 
-  local status
-  status=$(curl -sS -o "$body_file" -w '%{http_code}' -X "$method" \
+  local body
+  if ! body=$(curl -sS --fail-with-body -X "$method" \
     -H 'Content-Type: application/json' \
     "$@" \
-    "${API_URL}${path}")
-
-  local body
-  body=$(cat "$body_file")
-  rm -f "$body_file"
-
-  if [[ ! "$status" =~ ^2 ]]; then
-    fail "$method $path -> $status: $body"
+    "${API_URL}${path}"); then
+    fail "$method $path failed: $body"
   fi
   printf '%s' "$body"
 }


### PR DESCRIPTION
## Summary

- Add `db/migrations/013_seed_extra_genres.sql` with the 5 Israeli/Mizrahit slugs that exist in live prod but were missing from version control. Idempotent `ON CONFLICT (slug) DO NOTHING`, mirrors the pattern in `008_seed_genres.sql`. A fresh prod rebuild from migrations alone now produces the same genre set.
- Rewrite `tests/smoke/post_deploy.sh`'s `http()` helper to use `curl --fail-with-body` instead of `-w '%{http_code}'`. The bundled curl 8.8.0 in git-bash exits 43 on the `-w` form (lessons-learned entry from 2026-05-05); `--fail-with-body` works on git-bash, macOS, and CI Ubuntu.

## Test plan

- [x] Migration is purely additive: `INSERT … ON CONFLICT (slug) DO NOTHING`. Idempotent on rerun.
- [x] Smoke script run against prod (`bash tests/smoke/post_deploy.sh https://api.soundclash.org`) — passes end-to-end with the new helper, no `/tmp/winbin/curl` shim needed.
- [ ] CI: verify `db-migrations.yml` reruns 013 idempotently, and the smoke job (if any runs in CI) still passes.