### PR TITLE
test(e2e): update scoring selectors after toggle-button revamp

### DIFF
--- a/tests/e2e/buzzer_race.spec.ts
+++ b/tests/e2e/buzzer_race.spec.ts
@@ -79,10 +79,10 @@ test("two teams race the buzzer; exactly one wins; all contexts agree", async ({
     display.page.getByRole("status").filter({ hasText: new RegExp(`${winnerName}.*buzzed in`, "i") }),
   ).toBeVisible({ timeout: 10_000 });
 
-  // 9. Manager checks Title and awards points; the winner's score should
-  //    update on display + both team scoreboards.
-  await manager.page.getByLabel(/^title$/i).check();
-  await manager.page.getByTestId("award-points").click();
+  // 9. Manager toggles "Correct Song" and ends the round; the winner's
+  //    score should update on display + both team scoreboards.
+  await manager.page.getByTestId("score-title").click();
+  await manager.page.getByTestId("end-round").click();
 
   for (const page of [team1.page, team2.page, display.page]) {
     await expect(

--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -50,14 +50,14 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
       timeout: 10_000,
     });
 
-    // Manager checks the right boxes and awards.
+    // Manager toggles the right scoring buttons and ends the round.
     if (r.title) {
-      await manager.page.getByLabel(/^title$/i).check();
+      await manager.page.getByTestId("score-title").click();
     }
     if (r.artist) {
-      await manager.page.getByLabel(/^artist$/i).check();
+      await manager.page.getByTestId("score-artist").click();
     }
-    await manager.page.getByTestId("award-points").click();
+    await manager.page.getByTestId("end-round").click();
 
     runningTotal += r.expected;
 

--- a/tests/e2e/mobile_team.spec.ts
+++ b/tests/e2e/mobile_team.spec.ts
@@ -56,8 +56,8 @@ test("mobile viewport: team can join, buzz, and score", async ({ browser }) => {
 
   // Award and confirm the score reaches the team's own scoreboard on
   // the small viewport.
-  await manager.page.getByLabel(/^title$/i).check();
-  await manager.page.getByTestId("award-points").click();
+  await manager.page.getByTestId("score-title").click();
+  await manager.page.getByTestId("end-round").click();
   await expect(
     team.page.locator('[data-team-id]:has-text("Mobile"):has-text("10")').first(),
   ).toBeVisible({ timeout: 10_000 });

--- a/tests/e2e/reconnection.spec.ts
+++ b/tests/e2e/reconnection.spec.ts
@@ -61,8 +61,8 @@ test("team identity survives a mid-game tab reload", async ({ browser }) => {
   });
 
   // Award and verify the score lands on the (reloaded) team's own scoreboard.
-  await manager.page.getByLabel(/^title$/i).check();
-  await manager.page.getByTestId("award-points").click();
+  await manager.page.getByTestId("score-title").click();
+  await manager.page.getByTestId("end-round").click();
   await expect(
     team.page.locator('[data-team-id]:has-text("Persistent"):has-text("10")').first(),
   ).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## Summary
- The scoring revamp (PR #38) replaced the manager console's title/artist checkboxes with toggle buttons (`Correct Song +10` / `Correct Artist +5` / `Wrong -3` / `Bonus +4`) and merged Skip+Award into a single `End round` button. The four e2e specs that exercised the manager scoring UI (`buzzer_race`, `full_game`, `mobile_team`, `reconnection`) were still using the old `getByLabel(/^title$/i).check()` + `getByTestId("award-points")` selectors, so the E2E workflow has been failing on `main` since PR #38 merged.
- This PR swaps each call site to the new test IDs: `score-title` / `score-artist` for the scoring buttons, `end-round` for the awards-and-end action.

## Test plan
- [ ] Add the `run-e2e` label so the E2E workflow runs against this PR.
- [ ] Confirm chromium suite turns green (was 4 failed / 3 passed before).