### PR TITLE
fix(scoring): handle PostgREST list shape in award_points response

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -144,9 +144,15 @@ def _award_blocking(
         ).execute()
     except Exception as exc:
         raise map_postgrest_error(exc) from exc
-    # award_points returns exactly one row (or raises P0001/P0002 which the
-    # except above maps to a DomainError), so .data is always a single dict.
-    return dict(rpc_resp.data)
+    # PostgREST returns a TABLE-shaped function as a list of row-dicts (a
+    # length-1 list here, since award_points always RETURN QUERY one row).
+    # Some test mocks pass a bare dict, so accept both shapes.
+    data = rpc_resp.data
+    if isinstance(data, list):
+        if not data:
+            raise NotFoundError("award_points returned no row")
+        data = data[0]
+    return dict(data)
 
 
 def _bonus_blocking(

--- a/tests/backend/_fake_supabase.py
+++ b/tests/backend/_fake_supabase.py
@@ -399,9 +399,13 @@ class _Rpc:
                 # scalar-returning function — unwrap single column
                 data = _normalize(list(rows[0].values())[0])
             else:
+                # Real PostgREST always returns TABLE-shaped functions as a
+                # list of row-dicts, even for single-row results — never
+                # auto-unwraps. Match that. (Earlier this fake unwrapped a
+                # length-1 list into a bare dict; that masked the regression
+                # in d49cb6f where _award_blocking dropped its list-defensive
+                # handling.)
                 data = [_record_to_dict(r) for r in rows]
-                if len(data) == 1:
-                    data = data[0]
             return FakeResponse(data)
         finally:
             self._fake._close_conn(conn)

--- a/tests/backend/test_services_unit.py
+++ b/tests/backend/test_services_unit.py
@@ -9,7 +9,6 @@ import pytest
 from app.db.errors import ConflictError, InternalError, ValidationError
 from app.services import codes, csv_import, scoring
 
-
 # ----- scoring -----------------------------------------------------------
 
 
@@ -122,9 +121,7 @@ def _bytes(rows: list[str]) -> bytes:
 
 
 def test_parse_csv_happy_path() -> None:
-    rows = csv_import.parse_csv(
-        _bytes(["Hello,Adele,YQHsXMglC9A,0,false,,rock"])
-    )
+    rows = csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,false,,rock"]))
     assert len(rows) == 1
     assert rows[0].title == "Hello"
     assert rows[0].is_soundtrack is False
@@ -195,3 +192,85 @@ def test_parse_csv_strips_bom() -> None:
     raw = b"\xef\xbb\xbf" + _bytes(["Hi,Adele,YQHsXMglC9A,0,false,,rock"])
     rows = csv_import.parse_csv(raw)
     assert rows[0].title == "Hi"
+
+
+# ----- _award_blocking shape handling -----------------------------------
+
+
+class _StubExecuteResponse:
+    def __init__(self, data: object) -> None:
+        self.data = data
+
+
+class _StubRpc:
+    def __init__(self, data: object) -> None:
+        self._data = data
+
+    def execute(self) -> _StubExecuteResponse:
+        return _StubExecuteResponse(self._data)
+
+
+class _StubSupabaseClient:
+    def __init__(self, rpc_data: object) -> None:
+        self._rpc_data = rpc_data
+
+    def rpc(self, name: str, params: dict[str, object]) -> _StubRpc:
+        del name, params
+        return _StubRpc(self._rpc_data)
+
+
+def _award_body() -> object:
+    from uuid import UUID
+
+    from app.models.games import AwardPointsRequest
+
+    return AwardPointsRequest(
+        round_id=UUID("00000000-0000-0000-0000-000000000001"),
+        title_correct=True,
+        artist_correct=False,
+        wrong_buzz=False,
+        timeout=False,
+    )
+
+
+def test_award_blocking_handles_postgrest_list_shape() -> None:
+    """Real PostgREST returns TABLE-shaped functions as a list of row-dicts."""
+    from app.routers.games import _award_blocking
+
+    client = _StubSupabaseClient(
+        rpc_data=[
+            {
+                "team_id": "11111111-1111-1111-1111-111111111111",
+                "points_awarded": 10,
+                "team_total_score": 10,
+            }
+        ],
+    )
+    out = _award_blocking(client, "ABCDEF", _award_body())
+    assert out["points_awarded"] == 10
+    assert out["team_total_score"] == 10
+
+
+def test_award_blocking_accepts_legacy_dict_shape() -> None:
+    """Older test mocks pass a bare dict — keep working with both shapes."""
+    from app.routers.games import _award_blocking
+
+    client = _StubSupabaseClient(
+        rpc_data={
+            "team_id": "11111111-1111-1111-1111-111111111111",
+            "points_awarded": 5,
+            "team_total_score": 5,
+        },
+    )
+    out = _award_blocking(client, "ABCDEF", _award_body())
+    assert out["points_awarded"] == 5
+
+
+def test_award_blocking_empty_list_raises_not_found() -> None:
+    """Defensive: an unexpected empty list response surfaces as 404, not 500."""
+    from app.db.errors import NotFoundError
+    from app.routers.games import _award_blocking
+
+    client = _StubSupabaseClient(rpc_data=[])
+    with pytest.raises(NotFoundError):
+        _award_blocking(client, "ABCDEF", _award_body())

--- a/tests/smoke/post_deploy.sh
+++ b/tests/smoke/post_deploy.sh
@@ -157,7 +157,7 @@ log "      round_id=$ROUND_ID song=\"$SONG_TITLE\""
 log "5/6 POST /games/$GAME_CODE/award-points"
 AWARD_BODY=$(jq -n \
   --arg rid "$ROUND_ID" \
-  '{round_id: $rid, title_correct: true, artist_correct: false, source_correct: false, timeout: false}')
+  '{round_id: $rid, title_correct: true, artist_correct: false, wrong_buzz: false, timeout: false}')
 AWARD=$(http POST "/games/$GAME_CODE/award-points" \
   -H "X-Manager-Token: $TOKEN" \
   --data "$AWARD_BODY")


### PR DESCRIPTION
## Summary
Prod regression: every `POST /games/{code}/award-points` 500s with `dictionary update sequence element #0 has length 3; 2 is required`. Live game scoring is broken — discovered while running `tests/smoke/post_deploy.sh` against `https://api.soundclash.org`.

Root cause: commit `d49cb6f` (fix(scoring): drop unreachable list-defensive in _award_blocking) replaced `_award_blocking`'s shape-tolerant data extraction with a bare `dict(rpc_resp.data)`. Real PostgREST returns a TABLE-shaped function (`award_points` returns `TABLE(team_id uuid, points_awarded integer, team_total_score integer)`) as a list of row-dicts — never auto-unwrapped. `dict([{...3 keys...}])` then explodes because `dict()` tries to interpret each list element as a 2-tuple key/value pair.

Why CI was green: `tests/backend/_fake_supabase.py` auto-unwrapped any single-row TABLE response into a bare dict, so the integration tests in `test_games_award_points.py` never saw the real shape. The fake was lying.

Fix:
- `backend/app/routers/games.py:_award_blocking` — restore the list-defensive handling. Accepts both shapes (real prod + any test mock that still passes a dict).
- `tests/backend/_fake_supabase.py` — stop auto-unwrapping single-row TABLE results. Now matches real PostgREST behaviour, so `test_games_award_points.py` (which goes through this code path) actually exercises the production shape going forward. Comment notes the masking history so the next person doesn't re-introduce the bug.
- `tests/smoke/post_deploy.sh` — drive-by: was still posting `source_correct` (extra-forbidden field after migration 014). Switched to `wrong_buzz`. Without this the smoke can't reach the award-points step at all.

## Test plan
- [ ] CI backend.yml green — confirms the now-faithful fake still passes the existing `test_games_award_points.py` and `test_games_bonus.py` integration tests.
- [ ] After merge: Render redeploys the backend; run `tests/smoke/post_deploy.sh https://api.soundclash.org` — should exit 0 with `PASS` end-to-end (it failed at step 5 before this PR).