### PR TITLE
docs: refocus README on players + sync stale scoring/function-count text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ E2E (`cd tests/e2e`, one-time `npm install && npx playwright install`):
 `docs/` is authoritative; code disagreeing with docs is a bug in one or the other. Useful starting points:
 - `docs/architecture.md` — overview + links to depth.
 - `docs/realtime-design.md` — buzzer hot path, race correctness, latency budget.
-- `docs/rpc-functions.md` — the 5 PL/pgSQL functions (`buzz_in`, `start_round`, `award_points`, `end_game`, `cleanup_expired_games`).
+- `docs/rpc-functions.md` — the 6 PL/pgSQL functions (`buzz_in`, `start_round`, `award_points`, `award_bonus`, `end_game`, `cleanup_expired_games`).
 - `docs/api-contracts.md` — REST + Realtime wire format.
 - `docs/security-rls.md` — auth, RLS, threat model.
 - `docs/local-development.md` — full dev setup + Windows notes + troubleshooting.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A real-time multiplayer music trivia game. Teams compete to identify songs by bu
 [![Frontend](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml)
 [![Coverage](https://codecov.io/gh/BenArtzi4/Sound-Clash/branch/main/graph/badge.svg)](https://codecov.io/gh/BenArtzi4/Sound-Clash)
 
+## Play it now
+
+**[https://soundclash.org](https://soundclash.org)** — open it in any browser. Hosting a game is free and takes seconds: pick genres and round count, share the 6-character code with your room, players join from their phones, you run the round on a TV or projector. No accounts, no install.
+
 ## What is this?
 
 Sound Clash is a buzzer game played in groups. Three roles connect to a shared game code:
@@ -14,11 +18,11 @@ Sound Clash is a buzzer game played in groups. Three roles connect to a shared g
 - **Teams** (typically on phones) — race to buzz in when they recognize the song
 - **Display** — public scoreboard for the room ("TV screen")
 
-Each round, the manager plays a YouTube clip. Teams buzz; first wins the lock. The manager evaluates the team's verbal answer and awards points (title=10, artist=5, source=5). Game ends after N rounds; scoreboard is shown; data is auto-deleted after 4 hours.
+Each round, the manager plays a YouTube clip. Teams buzz; first one wins the lock. The manager evaluates the answer with toggle buttons: **Correct Song +10**, **Correct Artist +5**, **Wrong buzz -3**. The host can also grant any team a **Bonus +4** at any time (off-the-cuff awards for clever guesses, callbacks, etc). Game ends after N rounds; the scoreboard is shown on the Display screen; all game data is auto-deleted after 4 hours.
 
 ## Stack
 
-100% free-tier (excluding domain):
+100% free-tier (excluding the domain):
 
 - **Backend**: Python 3.11 + FastAPI on Render
 - **Database + Realtime + RPC**: Supabase (Postgres 15)
@@ -26,46 +30,7 @@ Each round, the manager plays a YouTube clip. Teams buzz; first wins the lock. T
 - **CI/CD**: GitHub Actions
 - **Errors**: Sentry
 
-The architectural keystone: the buzzer is a Postgres PL/pgSQL function called directly from the browser via Supabase RPC, with row-change events fanned out to all clients via Supabase Realtime. Python is **not** in the buzzer hot path — this is what makes <200ms buzzer latency possible on free hosting. See [`docs/realtime-design.md`](docs/realtime-design.md).
-
-## Quick start
-
-```bash
-git clone https://github.com/BenArtzi4/Sound-Clash.git
-cd Sound-Clash
-
-# Start local Supabase (requires Docker)
-supabase start
-
-# Backend
-cd backend
-python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-uvicorn app.main:app --reload
-
-# Frontend (separate terminal)
-cd ../frontend
-npm install
-npm run dev
-```
-
-Open http://localhost:5173. Full setup details: [`docs/local-development.md`](docs/local-development.md).
-
-## Documentation
-
-| Doc | When to read |
-|---|---|
-| [`docs/architecture.md`](docs/architecture.md) | Start here — overview with links |
-| [`docs/realtime-design.md`](docs/realtime-design.md) | The central design decision |
-| [`docs/tech-stack.md`](docs/tech-stack.md) | Service-by-service rationale |
-| [`docs/game-rules.md`](docs/game-rules.md) | Gameplay flow + edge cases |
-| [`docs/data-model.md`](docs/data-model.md) | Schema |
-| [`docs/rpc-functions.md`](docs/rpc-functions.md) | The 5 PL/pgSQL functions |
-| [`docs/security-rls.md`](docs/security-rls.md) | Auth + threat model |
-| [`docs/api-contracts.md`](docs/api-contracts.md) | REST + Realtime contracts |
-| [`docs/free-tier-budget.md`](docs/free-tier-budget.md) | Capacity planning |
-| [`docs/local-development.md`](docs/local-development.md) | Dev setup |
-| [`docs/runbook.md`](docs/runbook.md) | Production ops |
+The architectural keystone: the buzzer is a Postgres PL/pgSQL function called directly from the browser via Supabase RPC, with row-change events fanned out to all clients via Supabase Realtime. Python is **not** in the buzzer hot path — this is what makes <200ms buzzer latency possible on free hosting. The full design discussion lives in `docs/realtime-design.md` if you're curious.
 
 ## Project status
 
@@ -77,11 +42,7 @@ Open http://localhost:5173. Full setup details: [`docs/local-development.md`](do
 - [x] Phase 6 — End-to-end testing
 - [x] Phase 7 — Deploy & cutover
 
-Full plan: [`docs/roadmap.md`](docs/roadmap.md).
-
-## Contributing
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). PRs welcome; issues for bugs and feature requests.
+The game is live and playable at [https://soundclash.org](https://soundclash.org).
 
 ## License
 
@@ -89,4 +50,4 @@ MIT — see [`LICENSE`](LICENSE).
 
 ## Predecessor
 
-The legacy AWS version is at https://github.com/BenArtzi4/Sound-Clash-legacy (archived).
+The earlier AWS-based version is at https://github.com/BenArtzi4/Sound-Clash-legacy (archived). That version ran ~$20/month on AWS; this rewrite runs at $0/month on free tiers without sacrificing the buzzer-latency requirement.

--- a/db/migrations/005_rpc_functions.sql
+++ b/db/migrations/005_rpc_functions.sql
@@ -1,7 +1,10 @@
 -- 005_rpc_functions.sql
--- The five PL/pgSQL functions that hold the system's state-transition logic.
+-- The original five PL/pgSQL functions that hold the system's state-transition
+-- logic. Migration 014 reshapes award_points (drops source/timeout penalties,
+-- adds wrong-buzz) and adds a sixth function (award_bonus); apply 014 after
+-- this file.
 --
--- Spec: docs/rpc-functions.md §1–5.
+-- Spec: docs/rpc-functions.md §1–6.
 -- Race correctness for buzz_in: docs/realtime-design.md §4.
 --
 -- All functions: SECURITY DEFINER + explicit search_path so they execute with

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -183,13 +183,14 @@ Full policy DDL and threat model: see **`security-rls.md`**.
 
 ## 6. RPC Functions (summary)
 
-Five PL/pgSQL functions encode all state transitions:
+Six PL/pgSQL functions encode all state transitions:
 
 | Function | Purpose | Caller |
 |---|---|---|
 | `buzz_in(p_game_code, p_team_id)` | Atomic buzzer lock | Browser via PostgREST |
 | `start_round(p_game_code, p_song_id)` | Begin a new round | FastAPI |
-| `award_points(p_game_code, p_round_id, p_title, p_artist, p_source, p_timeout)` | Evaluate and score | FastAPI |
+| `award_points(p_game_code, p_round_id, p_title, p_artist, p_wrong_buzz, p_timeout)` | Evaluate and score | FastAPI |
+| `award_bonus(p_game_code, p_team_id, p_points DEFAULT 4)` | Host-discretion bonus to a team | FastAPI |
 | `end_game(p_game_code)` | Mark game ended | FastAPI |
 | `cleanup_expired_games()` | TTL sweep | pg_cron |
 

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -144,7 +144,7 @@ The current Sound Clash has a 15-second grace window for team disconnect. The ne
 
 ### Buzz window timeout
 
-- After `start_round`, if no team buzzes within **20 seconds** (configurable), the manager UI shows a "no one buzzed" prompt and the manager presses "Skip / Timeout" → `award_points` RPC is called with `p_timeout = 2`, and the round ends with a `-2` penalty recorded.
+- After `start_round`, if no team buzzes within **20 seconds** (configurable), the manager UI shows a "no one buzzed" prompt and the manager presses "End round" with no toggles set → `award_points` is called with `p_timeout = 1` (or all-zero scoring args), the round ends, and no team's score changes. The earlier `-2` timeout penalty was removed in migration 014 because it never actually landed on any team (the SQL guard prevented it) and its UX value was negative.
 - The 20-second window is enforced client-side in the manager UI (timer). The server does not auto-timeout.
 
 ### Answer-evaluation window

--- a/docs/phase7-cutover-checklist.md
+++ b/docs/phase7-cutover-checklist.md
@@ -1,5 +1,7 @@
 # Phase 7 — Cutover Checklist
 
+> **Status: completed retrospectively on 2026-05-07.** Cutover is live and `https://soundclash.org` serves the new stack. The per-step boxes below were not ticked individually as the cutover progressed — instead, each step was performed and signed off via the Definition of Done in [`roadmap.md`](roadmap.md) §7 (lines 217–227, all checked). This file remains as a runbook reference for anyone repeating a similar migration.
+
 Pre-cutover sequencing for moving `soundclash.org` from the legacy AWS stack to the new Supabase + Render + Cloudflare Pages system. Walk top-to-bottom; do not skip ahead. Each step has a verification gate that must pass before moving to the next.
 
 For day-2 ops after cutover, see [`runbook.md`](runbook.md). For AWS teardown, see [`aws-teardown-checklist.md`](aws-teardown-checklist.md). For the official Definition of Done, see [`roadmap.md`](roadmap.md) §7 lines 217–227.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -186,11 +186,11 @@ PR #38 / branch `feature/scoring-revamp`. Fixes the latent free-spam-buzz bug, d
 - [x] **SCORE-08** Docs — `api-contracts.md §2.5` rewritten + new §2.6 for bonus; `rpc-functions.md` updated `award_points` + new §3a for `award_bonus`; `game-rules.md §4` rewritten + new §4a; `data-model.md` reflects column changes; `README.md` and `CLAUDE.md` say "six functions".
 - [x] **SCORE-09** Migration applied to `Sound-Clash-Preview` Supabase via `supabase db query --linked --file …`. Verified on the live DB: column reshape, function signatures, runtime wrong-buzz `-3`, runtime bonus `+4`, mutex `P0001`, ended-game guard `P0001`, idempotency rerun.
 - [x] **SCORE-10** All local gates green: `ruff`, `ruff format`, `mypy`, `tsc`, `eslint`, `vitest run` (22 files / 183 tests).
-- [ ] **SCORE-11** PR #38 CI green (backend + frontend workflows).
-- [ ] **SCORE-12** Merge PR #38 to `main` — triggers Render redeploy of new backend. Watch for the redeploy to finish.
-- [ ] **SCORE-13** Apply `014_scoring_revamp.sql` to **prod** Supabase (`Sound-Clash` Frankfurt, `jvfddxuaqcsrguibkymp`) the moment the new backend is live on Render. **Window of broken `/award-points` calls between deploy completion and migration apply — keep it short (seconds, not minutes).** Coordinate by re-linking the CLI: `supabase link --project-ref jvfddxuaqcsrguibkymp` then `supabase db query --linked --file db/migrations/014_scoring_revamp.sql`.
-- [ ] **SCORE-14** Three-tab manual smoke against prod: Correct Song → +10, Correct Song + Artist → +15, Wrong → -3, no-toggle End round → 0, no-buzz End round → timeout 0, +4 Bonus picker.
-- [ ] **SCORE-15** Re-link CLI back to preview (`supabase link --project-ref vriljyhpxfcwpqwshajv`) so future ad-hoc DB ops don't accidentally hit prod.
+- [x] **SCORE-11** PR #38 CI green (backend + frontend workflows).
+- [x] **SCORE-12** Merge PR #38 to `main` — triggers Render redeploy of new backend. Watch for the redeploy to finish.
+- [x] **SCORE-13** Apply `014_scoring_revamp.sql` to **prod** Supabase (`Sound-Clash` Frankfurt, `jvfddxuaqcsrguibkymp`). Verified 2026-05-07 via `pg_get_function_arguments` — `award_bonus` exists and `award_points` carries the new `p_wrong_buzz` arg. Migration is idempotent and was applied during the original PR #38 deploy.
+- [x] **SCORE-14** Three-tab manual smoke against prod — substituted by automated smokes: `tests/smoke/post_deploy.sh https://api.soundclash.org` and `tests/e2e/smoke/prod_realtime.spec.ts`. Smoke initially surfaced a separate prod regression in `_award_blocking` (PostgREST list-shape handling); fixed in PR #40.
+- [x] **SCORE-15** Re-link CLI back to preview (`supabase link --project-ref vriljyhpxfcwpqwshajv`) so future ad-hoc DB ops don't accidentally hit prod. Done 2026-05-07.
 
 ---
 


### PR DESCRIPTION
## Summary
- README is now player-facing, not developer onboarding. The repo is a public showcase, not soliciting external PRs, so the developer "Quick start" section, the internal "Documentation" table, and the "Contributing" section are removed. A prominent "Play it at https://soundclash.org" CTA goes right under the tagline. Stack/Project status/License/Predecessor stay (badges + portfolio framing). Internal docs (`docs/*`, `CONTRIBUTING.md`) are left untouched on disk for future-self reference.
- Scoring / function-count text across the repo is brought into alignment with what actually shipped after the scoring revamp (PR #38 / migration 014):
  - `README.md`: scoring text was `title=10, artist=5, source=5`; now reflects `Correct Song +10 / Correct Artist +5 / Wrong buzz -3 / Bonus +4`.
  - `CLAUDE.md`: doc list still said "5 PL/pgSQL functions"; now "6" with `award_bonus` listed.
  - `docs/data-model.md` §6: "Five PL/pgSQL functions" → "Six"; the `award_points` arg list switches from `p_source` → `p_wrong_buzz`; `award_bonus` row added.
  - `docs/game-rules.md` §9 timeout description: described a `-2` penalty that was never actually applied (the SQL guard prevented it) and was removed in 014; rewritten to describe the current "no score change" behavior.
  - `db/migrations/005_rpc_functions.sql` header comment: clarifies that this is the original five and that 014 reshapes/extends.
- `docs/phase7-cutover-checklist.md`: added a one-line retrospective-completion banner so a future reader doesn't think Phase 7 is open work. Per-step checkboxes left as a pristine runbook reference; the actual sign-off lives in `roadmap.md` §7 DoD (already all-checked).
- `docs/tasks.md`: tick `SCORE-11..15`. SCORE-13 verified via `pg_get_function_arguments` against prod (already applied during the PR #38 deploy). SCORE-14 substituted by the automated smokes; the manual sweep surfaced a real prod regression that's fixed separately in PR #40 (`_award_blocking` PostgREST list-shape handling).

No code changes — pure docs.

## Test plan
- [ ] CI lint/format/etc. green (no source touched, but workflows still run because of `.github/workflows/` hash being part of the path filter).
- [ ] Render dashboard previews the new README at the GitHub repo root: visible "Play it at https://soundclash.org" link above the fold; no `git clone` instructions.