### PR TITLE
docs: architecture diagrams + tooling guide (closes DOC-06)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ Design and operational documentation for Sound Clash. Each file has a single, di
 13. **[roadmap.md](roadmap.md)** — eight-phase migration plan with exit criteria.
 14. **[tasks.md](tasks.md)** — granular checkboxed task list grouped by area.
 15. **[aws-teardown-checklist.md](aws-teardown-checklist.md)** — step-by-step Phase 7 cutover script for tearing down the legacy AWS stack.
+16. **[tooling.md](tooling.md)** — every tool that touches the repo: GitHub Actions workflows, CodeQL, Dependabot, Codecov, pre-commit, deploy automation, monitoring.
+17. **[diagrams/](diagrams/)** — visual architecture diagrams (Mermaid in Markdown + standalone HTML mirrors). [`internal.md`](diagrams/internal.md) for what's inside the game; [`external.md`](diagrams/external.md) for the third-party services around it.
 
 ## Suggested reading paths
 
@@ -95,3 +97,5 @@ Out-of-date docs are worse than missing ones.
 | `roadmap.md` | 8-phase migration plan |
 | `tasks.md` | Granular task checklist |
 | `aws-teardown-checklist.md` | Phase 7 step-by-step cutover script |
+| `tooling.md` | Dev/CI tooling reference — workflows, bots, deploy automation |
+| `diagrams/` | Architecture diagrams (Mermaid `.md` + standalone `.html`) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,8 @@ This is the executive summary of the system. It points to the deeper docs rather
 - For operational procedures, see **`runbook.md`**.
 - For local dev, see **`local-development.md`**.
 - For free-tier capacity planning, see **`free-tier-budget.md`**.
+- For visual diagrams (component map + service map + sequences), see **`diagrams/internal.md`** and **`diagrams/external.md`**.
+- For dev/CI tooling reference (workflows, CodeQL, Dependabot, Codecov, …), see **`tooling.md`**.
 
 ## 1. Goals
 

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -148,7 +148,8 @@
       utility
     );
 
-    host.className = "topnav";
+    // .topnav class is set in HTML so the bar has stable height from first
+    // paint; here we just populate the inner content.
     host.replaceChildren(inner);
   }
 
@@ -172,7 +173,7 @@
       );
     };
 
-    host.className = "page-nav";
+    // .page-nav class is set in HTML; here we just populate prev/next cards.
     host.replaceChildren(
       prev ? card(prev, "prev") : el("span", { class: "page-nav-spacer" }),
       next ? card(next, "next") : el("span", { class: "page-nav-spacer" })

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -1,0 +1,116 @@
+/* Sound Clash docs — shared script
+ * - Theme toggle (light / dark / system) persisted in localStorage
+ * - Mermaid initialization (consistent config across all pages)
+ * - TOC active-link highlighting on scroll (only if .toc exists)
+ */
+
+(function () {
+  "use strict";
+
+  // ---------- Theme ----------
+  const STORAGE_KEY = "sc-theme";
+  const root = document.documentElement;
+
+  function applyTheme(theme) {
+    if (theme === "light" || theme === "dark") {
+      root.setAttribute("data-theme", theme);
+    } else {
+      root.removeAttribute("data-theme");
+    }
+  }
+
+  function currentTheme() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+
+  // Apply persisted theme as early as possible (script is in <head> with defer)
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") applyTheme(stored);
+
+  function setupThemeToggle() {
+    const btn = document.getElementById("theme-toggle");
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      const next = currentTheme() === "dark" ? "light" : "dark";
+      localStorage.setItem(STORAGE_KEY, next);
+      applyTheme(next);
+    });
+  }
+
+  // ---------- Mermaid ----------
+  function initMermaid() {
+    if (!document.querySelector(".mermaid")) return;
+    import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs")
+      .then((mod) => {
+        const mermaid = mod.default;
+        mermaid.initialize({
+          startOnLoad: true,
+          theme: "default", // diagrams render on white background regardless of page theme
+          securityLevel: "loose",
+          flowchart: { htmlLabels: true, curve: "basis" },
+          sequence: { mirrorActors: false, showSequenceNumbers: true },
+        });
+      })
+      .catch((err) => {
+        console.error("Mermaid failed to load:", err);
+      });
+  }
+
+  // ---------- TOC active-link on scroll ----------
+  function setupTOC() {
+    const toc = document.querySelector(".toc");
+    if (!toc) return;
+    const links = Array.from(toc.querySelectorAll("a[href^='#']"));
+    if (!links.length) return;
+
+    const targets = links
+      .map((a) => {
+        const id = decodeURIComponent(a.getAttribute("href").slice(1));
+        return { id, link: a, el: document.getElementById(id) };
+      })
+      .filter((t) => t.el);
+
+    function setActive() {
+      const offset = 100; // sticky nav height + buffer
+      let active = targets[0];
+      for (const t of targets) {
+        if (t.el.getBoundingClientRect().top - offset <= 0) {
+          active = t;
+        } else {
+          break;
+        }
+      }
+      links.forEach((l) => l.classList.remove("active"));
+      if (active && active.link) active.link.classList.add("active");
+    }
+
+    let ticking = false;
+    window.addEventListener("scroll", () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setActive();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    }, { passive: true });
+    setActive();
+  }
+
+  // ---------- Bootstrap ----------
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      setupThemeToggle();
+      initMermaid();
+      setupTOC();
+    });
+  } else {
+    setupThemeToggle();
+    initMermaid();
+    setupTOC();
+  }
+})();

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -1,16 +1,48 @@
 /* Sound Clash docs — shared script
- * - Theme toggle (light / dark / system) persisted in localStorage
- * - Mermaid initialization (consistent config across all pages)
- * - TOC active-link highlighting on scroll (only if .toc exists)
+ *
+ * Single source of truth for navigation. Each HTML page declares its identity
+ * via <html data-page="..."> and includes <header id="topnav"></header> +
+ * <footer id="page-nav"></footer> placeholders. This script renders both from
+ * the PAGES list below, so adding a new HTML page = one entry here.
+ *
+ * Also handles: theme toggle (light/dark/system, persisted), Mermaid init,
+ * TOC scroll-spy active-link highlighting.
  */
 
 (function () {
   "use strict";
 
-  // ---------- Theme ----------
+  // ---------- Single source of truth: every HTML page in /docs ----------
+  const PAGES = [
+    { id: "home",     title: "Home",     short: "Home",      path: "index.html",          desc: "Documentation index" },
+    { id: "internal", title: "Internal architecture", short: "Internal", path: "diagrams/internal.html", desc: "Browser ↔ FastAPI ↔ Supabase, buzz race" },
+    { id: "external", title: "External services",     short: "External", path: "diagrams/external.html", desc: "Hosting, CI/CD, monitoring, deploy flow" },
+  ];
+
+  const EXTERNAL = {
+    repo: "https://github.com/BenArtzi4/Sound-Clash",
+    live: "https://soundclash.org",
+  };
+
   const STORAGE_KEY = "sc-theme";
   const root = document.documentElement;
 
+  // ---------- Path helpers ----------
+  function basePath() {
+    // Pages live at: /docs/index.html, /docs/diagrams/internal.html, etc.
+    // Detect depth from the current location.
+    const path = window.location.pathname;
+    if (/\/diagrams\//.test(path)) return "..";
+    return ".";
+  }
+  function hrefTo(page) {
+    return basePath() + "/" + page.path;
+  }
+  function currentPageId() {
+    return root.dataset.page || "home";
+  }
+
+  // ---------- Theme ----------
   function applyTheme(theme) {
     if (theme === "light" || theme === "dark") {
       root.setAttribute("data-theme", theme);
@@ -31,6 +63,123 @@
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === "light" || stored === "dark") applyTheme(stored);
 
+  // ---------- Render: top navigation ----------
+  // Icons inlined as SVG paths so we don't need an icon font.
+  const ICONS = {
+    github: '<svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>',
+    external: '<svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V8a.5.5 0 0 0-1 0v4.5a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5H8a.5.5 0 0 0 0-1z"/><path d="M9.146.146A.5.5 0 0 1 9.5 0h5a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-1 0V1.707L6.354 9.354a.5.5 0 1 1-.708-.708L13.293 1H9.5a.5.5 0 0 1-.354-.854"/></svg>',
+    moon: '<svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>',
+    sun: '<svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>',
+    arrowLeft: '<svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8"/></svg>',
+    arrowRight: '<svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8"/></svg>',
+  };
+
+  function el(tag, attrs, ...children) {
+    const e = document.createElement(tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (v == null || v === false) continue;
+        if (k === "class") e.className = v;
+        else if (k === "html") e.innerHTML = v;
+        else if (k.startsWith("on") && typeof v === "function") {
+          e.addEventListener(k.slice(2).toLowerCase(), v);
+        } else e.setAttribute(k, v);
+      }
+    }
+    for (const c of children.flat()) {
+      if (c == null || c === false) continue;
+      e.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    }
+    return e;
+  }
+
+  function renderTopnav() {
+    const host = document.getElementById("topnav");
+    if (!host) return;
+    const here = currentPageId();
+    const home = PAGES.find((p) => p.id === "home");
+
+    const tabs = el("nav", { class: "topnav-tabs", "aria-label": "Documentation pages" },
+      ...PAGES.map((p) => {
+        const isActive = p.id === here;
+        return el("a", {
+          class: "topnav-tab" + (isActive ? " active" : ""),
+          href: hrefTo(p),
+          "aria-current": isActive ? "page" : null,
+          title: p.desc,
+        }, p.short);
+      })
+    );
+
+    const utility = el("div", { class: "topnav-utility" },
+      el("a", {
+        class: "topnav-link",
+        href: EXTERNAL.live,
+        target: "_blank",
+        rel: "noopener",
+        title: "Open the live game",
+      }, el("span", { class: "label" }, "Live"), el("span", { html: ICONS.external })),
+      el("a", {
+        class: "topnav-link",
+        href: EXTERNAL.repo,
+        target: "_blank",
+        rel: "noopener",
+        title: "View source on GitHub",
+      }, el("span", { class: "label" }, "GitHub"), el("span", { html: ICONS.github })),
+      el("button", {
+        id: "theme-toggle",
+        class: "topnav-link icon-only",
+        type: "button",
+        "aria-label": "Toggle dark mode",
+        title: "Toggle dark mode",
+      },
+        el("span", { html: ICONS.moon }),
+        el("span", { html: ICONS.sun })
+      )
+    );
+
+    const inner = el("div", { class: "topnav-inner" },
+      el("a", { class: "topnav-brand", href: hrefTo(home), "aria-label": "Sound Clash docs home" },
+        el("span", { class: "dot", "aria-hidden": "true" }),
+        document.createTextNode("Sound Clash"),
+        el("span", { class: "muted small" }, "docs")
+      ),
+      tabs,
+      utility
+    );
+
+    host.className = "topnav";
+    host.replaceChildren(inner);
+  }
+
+  function renderPageNav() {
+    const host = document.getElementById("page-nav");
+    if (!host) return;
+    const here = currentPageId();
+    const idx = PAGES.findIndex((p) => p.id === here);
+    if (idx === -1) return;
+    const prev = PAGES[idx - 1];
+    const next = PAGES[idx + 1];
+    if (!prev && !next) return;
+
+    const card = (page, dir) => {
+      const arrow = dir === "prev" ? ICONS.arrowLeft : ICONS.arrowRight;
+      const labelText = dir === "prev" ? "Previous" : "Next";
+      return el("a", { class: `page-nav-card page-nav-${dir}`, href: hrefTo(page) },
+        el("span", { class: "page-nav-dir" }, el("span", { html: arrow }), document.createTextNode(labelText)),
+        el("span", { class: "page-nav-title" }, page.title),
+        el("span", { class: "page-nav-desc" }, page.desc)
+      );
+    };
+
+    host.className = "page-nav";
+    host.replaceChildren(
+      prev ? card(prev, "prev") : el("span", { class: "page-nav-spacer" }),
+      next ? card(next, "next") : el("span", { class: "page-nav-spacer" })
+    );
+  }
+
+  // ---------- Theme toggle wiring (after nav renders) ----------
   function setupThemeToggle() {
     const btn = document.getElementById("theme-toggle");
     if (!btn) return;
@@ -75,7 +224,7 @@
       .filter((t) => t.el);
 
     function setActive() {
-      const offset = 100; // sticky nav height + buffer
+      const offset = 100;
       let active = targets[0];
       for (const t of targets) {
         if (t.el.getBoundingClientRect().top - offset <= 0) {
@@ -102,15 +251,17 @@
   }
 
   // ---------- Bootstrap ----------
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => {
-      setupThemeToggle();
-      initMermaid();
-      setupTOC();
-    });
-  } else {
+  function boot() {
+    renderTopnav();
+    renderPageNav();
     setupThemeToggle();
     initMermaid();
     setupTOC();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
   }
 })();

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -127,14 +127,22 @@ body {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(250, 250, 247, 0.85);
+  /* min-height so the bar reserves space BEFORE script.js populates it.
+     Prevents the content below from briefly rendering at the top of the
+     viewport and being overlapped when the nav renders in. */
+  min-height: var(--nav-h);
+  background: rgba(250, 250, 247, 0.92);
   border-bottom: 1px solid var(--rule);
   backdrop-filter: saturate(180%) blur(10px);
   -webkit-backdrop-filter: saturate(180%) blur(10px);
 }
-[data-theme="dark"] .topnav { background: rgba(13, 17, 23, 0.85); }
+/* Fallback for browsers without backdrop-filter — opaque background */
+@supports not (backdrop-filter: blur(1px)) {
+  .topnav { background: var(--bg-elevated); }
+}
+[data-theme="dark"] .topnav { background: rgba(13, 17, 23, 0.92); }
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .topnav { background: rgba(13, 17, 23, 0.85); }
+  :root:not([data-theme="light"]) .topnav { background: rgba(13, 17, 23, 0.92); }
 }
 
 .topnav-inner {
@@ -200,7 +208,16 @@ body {
 .topnav-tab.active {
   color: var(--accent);
   background: var(--bg-elevated);
-  box-shadow: var(--shadow-sm);
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 0 0 1px var(--rule);
+}
+[data-theme="dark"] .topnav-tab.active {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--rule-strong);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .topnav-tab.active {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--rule-strong);
+  }
 }
 
 .topnav-utility {
@@ -657,6 +674,7 @@ details ul { padding-left: 2.4rem; }
   .topnav-tabs { padding: 0.18rem; }
   .topnav-tab { padding: 0.35rem 0.6rem; font-size: 0.85rem; }
   .topnav-utility { gap: 0.15rem; }
+  .topnav-link { padding: 0.4rem 0.5rem; gap: 0; }
   .topnav-link .label { display: none; }
 }
 
@@ -675,4 +693,21 @@ details ul { padding-left: 2.4rem; }
   .page-nav-next { text-align: left; align-items: flex-start; }
   .page-nav-next .page-nav-dir { flex-direction: row; }
   .topnav-brand { font-size: 0.9rem; }
+  .topnav-tab { padding: 0.3rem 0.5rem; font-size: 0.82rem; }
+  .topnav-inner { gap: 0.5rem; padding: 0 0.7rem; }
+}
+
+/* Very small phones: hide GitHub link to keep nav from overflowing. */
+@media (max-width: 420px) {
+  .topnav-utility a[href*="github"] { display: none; }
+  .topnav-brand { font-size: 0.85rem; }
+}
+
+/* Reduce motion respect */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,549 @@
+/* Sound Clash docs — shared stylesheet
+ * Used by docs/index.html and docs/diagrams/*.html
+ */
+
+:root {
+  /* Light theme (default) */
+  --bg: #fafaf7;
+  --bg-elevated: #ffffff;
+  --bg-subtle: #f1f3f5;
+  --fg: #1a1a1a;
+  --fg-muted: #555;
+  --fg-subtle: #888;
+  --rule: #e3e3e0;
+  --rule-strong: #c9c9c4;
+  --accent: #d97706;          /* amber-600 */
+  --accent-hover: #b45309;     /* amber-700 */
+  --accent-soft: #fef3c7;      /* amber-100 */
+  --link: #1d4ed8;             /* blue-700 */
+  --link-hover: #1e3a8a;       /* blue-900 */
+  --code-bg: #f1f3f5;
+  --code-fg: #1a1a1a;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --radius: 8px;
+  --max-content: 880px;
+  --max-wide: 1180px;
+}
+
+[data-theme="dark"] {
+  --bg: #0e1116;
+  --bg-elevated: #161b22;
+  --bg-subtle: #1c2128;
+  --fg: #e6edf3;
+  --fg-muted: #9da7b3;
+  --fg-subtle: #6e7681;
+  --rule: #30363d;
+  --rule-strong: #484f58;
+  --accent: #fbbf24;          /* amber-400 */
+  --accent-hover: #fcd34d;     /* amber-300 */
+  --accent-soft: rgba(251, 191, 36, 0.15);
+  --link: #79c0ff;
+  --link-hover: #a5d6ff;
+  --code-bg: #1c2128;
+  --code-fg: #e6edf3;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0e1116;
+    --bg-elevated: #161b22;
+    --bg-subtle: #1c2128;
+    --fg: #e6edf3;
+    --fg-muted: #9da7b3;
+    --fg-subtle: #6e7681;
+    --rule: #30363d;
+    --rule-strong: #484f58;
+    --accent: #fbbf24;
+    --accent-hover: #fcd34d;
+    --accent-soft: rgba(251, 191, 36, 0.15);
+    --link: #79c0ff;
+    --link-hover: #a5d6ff;
+    --code-bg: #1c2128;
+    --code-fg: #e6edf3;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; scroll-padding-top: 4.5rem; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+/* ---------- Top nav ---------- */
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--rule);
+  backdrop-filter: saturate(150%) blur(8px);
+  -webkit-backdrop-filter: saturate(150%) blur(8px);
+}
+.topnav-inner {
+  max-width: var(--max-wide);
+  margin: 0 auto;
+  padding: 0.7rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+.topnav-brand {
+  font-weight: 600;
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 0.98rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.topnav-brand .dot {
+  width: 9px;
+  height: 9px;
+  background: var(--accent);
+  border-radius: 50%;
+  display: inline-block;
+}
+.topnav-crumbs {
+  color: var(--fg-subtle);
+  font-size: 0.92rem;
+  flex: 1;
+  min-width: 0;
+}
+.topnav-crumbs a {
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+.topnav-crumbs a:hover { color: var(--accent); }
+.topnav-crumbs .sep { margin: 0 0.4rem; color: var(--fg-subtle); }
+
+.topnav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.topnav-links a, .topnav-links button {
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.12s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.topnav-links a:hover, .topnav-links button:hover {
+  color: var(--fg);
+  background: var(--bg-subtle);
+  border-color: var(--rule);
+}
+.topnav-links .icon {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  vertical-align: -3px;
+}
+#theme-toggle .icon-sun { display: none; }
+#theme-toggle .icon-moon { display: inline-block; }
+[data-theme="dark"] #theme-toggle .icon-sun { display: inline-block; }
+[data-theme="dark"] #theme-toggle .icon-moon { display: none; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) #theme-toggle .icon-sun { display: inline-block; }
+  :root:not([data-theme="light"]) #theme-toggle .icon-moon { display: none; }
+}
+
+/* ---------- Layout ---------- */
+.container {
+  max-width: var(--max-content);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+}
+.container-wide {
+  max-width: var(--max-wide);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+}
+
+/* Two-column layout: content + sticky TOC */
+.layout-with-toc {
+  max-width: var(--max-wide);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 3rem;
+}
+.layout-with-toc .toc {
+  position: sticky;
+  top: 5rem;
+  align-self: start;
+  font-size: 0.9rem;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+}
+.toc-title {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-subtle);
+  margin: 0 0 0.7rem;
+  font-weight: 600;
+}
+.toc ul { list-style: none; padding: 0; margin: 0; border-left: 1px solid var(--rule); }
+.toc li { margin: 0; }
+.toc a {
+  display: block;
+  padding: 0.3rem 0 0.3rem 0.9rem;
+  margin-left: -1px;
+  border-left: 2px solid transparent;
+  color: var(--fg-muted);
+  text-decoration: none;
+  line-height: 1.4;
+  transition: all 0.1s ease;
+}
+.toc a:hover { color: var(--accent); }
+.toc a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  font-weight: 500;
+}
+
+@media (max-width: 1000px) {
+  .layout-with-toc {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  .layout-with-toc .toc { display: none; }
+}
+
+/* ---------- Typography ---------- */
+h1, h2, h3, h4 {
+  line-height: 1.25;
+  font-weight: 600;
+  margin: 0 0 0.6rem;
+  letter-spacing: -0.01em;
+}
+h1 { font-size: 2.1rem; margin-bottom: 1rem; }
+h2 {
+  font-size: 1.5rem;
+  margin-top: 3rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--rule);
+}
+h3 { font-size: 1.15rem; margin-top: 2rem; }
+h4 { font-size: 1rem; margin-top: 1.5rem; color: var(--fg-muted); }
+
+.lead {
+  font-size: 1.15rem;
+  color: var(--fg-muted);
+  line-height: 1.55;
+  margin: 0 0 1.5rem;
+}
+
+p { margin: 0 0 1rem; }
+
+a { color: var(--link); text-decoration: none; transition: color 0.12s ease; }
+a:hover { color: var(--link-hover); text-decoration: underline; }
+
+code {
+  font-family: "SF Mono", "Cascadia Code", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.12em 0.4em;
+  border-radius: 4px;
+  border: 1px solid var(--rule);
+}
+
+ul, ol { padding-left: 1.4rem; }
+li { margin: 0.35rem 0; }
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.8rem 1.2rem;
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--fg);
+}
+blockquote p:last-child { margin-bottom: 0; }
+blockquote strong { color: var(--accent-hover); }
+[data-theme="dark"] blockquote strong { color: var(--accent); }
+
+hr {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 2.5rem 0;
+}
+
+/* ---------- Tables ---------- */
+.table-wrap { overflow-x: auto; margin: 1.2rem 0; }
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.93rem;
+  background: var(--bg-elevated);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--rule);
+}
+th, td {
+  padding: 0.6rem 0.85rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--rule);
+}
+th {
+  background: var(--bg-subtle);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+}
+tr:last-child td { border-bottom: none; }
+td.center, th.center { text-align: center; }
+
+/* ---------- Hero ---------- */
+.hero {
+  padding: 3rem 0 2rem;
+  text-align: left;
+}
+.hero h1 {
+  font-size: 2.6rem;
+  margin-bottom: 0.6rem;
+}
+.hero .lead { font-size: 1.2rem; max-width: 640px; }
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.6rem;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: all 0.12s ease;
+  cursor: pointer;
+  font-family: inherit;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #1a1a1a;
+  border-color: var(--accent);
+}
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #1a1a1a;
+  text-decoration: none;
+}
+.btn-secondary {
+  background: var(--bg-elevated);
+  color: var(--fg);
+  border-color: var(--rule-strong);
+}
+.btn-secondary:hover {
+  background: var(--bg-subtle);
+  text-decoration: none;
+  color: var(--fg);
+}
+
+/* ---------- Cards ---------- */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  gap: 1.2rem;
+  margin: 1.5rem 0;
+}
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1.4rem 1.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  display: flex;
+  flex-direction: column;
+}
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--accent);
+}
+.card-tag {
+  display: inline-block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+.card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+.card h3 a {
+  color: var(--fg);
+  text-decoration: none;
+}
+.card h3 a:hover { color: var(--accent); }
+.card p {
+  color: var(--fg-muted);
+  margin: 0;
+  font-size: 0.94rem;
+  flex: 1;
+}
+.card-arrow {
+  color: var(--accent);
+  margin-left: 0.3rem;
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+.card:hover .card-arrow { transform: translateX(3px); }
+
+/* ---------- Mermaid containers ---------- */
+.diagram {
+  background: #ffffff;        /* always white for Mermaid contrast */
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+  overflow-x: auto;
+  box-shadow: var(--shadow-sm);
+}
+.diagram .mermaid { text-align: center; }
+.diagram .mermaid svg { max-width: 100%; height: auto !important; }
+
+/* Force light text on white diagram even in dark mode */
+.diagram, .diagram * { color-scheme: light; }
+
+/* Caption under a diagram */
+.caption {
+  font-size: 0.88rem;
+  color: var(--fg-subtle);
+  text-align: center;
+  margin: 0.5rem 0 1.5rem;
+  font-style: italic;
+}
+
+/* ---------- Legend ---------- */
+.legend {
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 1rem 1.4rem;
+  margin: 1rem 0 1.5rem;
+}
+.legend-title {
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: var(--fg);
+}
+.legend ul { margin: 0; padding-left: 1.2rem; }
+.legend li { font-size: 0.93rem; margin: 0.3rem 0; color: var(--fg-muted); }
+
+/* ---------- Details / collapsible ---------- */
+details {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 0;
+  margin: 0.7rem 0;
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+details summary {
+  cursor: pointer;
+  padding: 0.8rem 1.2rem;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: background 0.12s ease;
+  user-select: none;
+}
+details summary:hover { background: var(--bg-subtle); }
+details summary::-webkit-details-marker { display: none; }
+details summary::after {
+  content: "+";
+  color: var(--fg-subtle);
+  font-size: 1.3rem;
+  font-weight: 300;
+  transition: transform 0.2s ease;
+  margin-left: 0.5rem;
+}
+details[open] summary::after { content: "−"; }
+details > :not(summary) {
+  padding: 0 1.2rem 1rem;
+  margin: 0;
+}
+details ul { padding-left: 2.4rem; }
+
+/* ---------- Footer ---------- */
+.footer {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  color: var(--fg-subtle);
+  font-size: 0.88rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+.footer a { color: var(--fg-muted); }
+.footer a:hover { color: var(--accent); }
+
+/* ---------- Utility ---------- */
+.muted { color: var(--fg-muted); }
+.small { font-size: 0.88rem; }
+
+@media (max-width: 600px) {
+  body { font-size: 15px; }
+  .hero h1 { font-size: 2rem; }
+  .hero .lead { font-size: 1.05rem; }
+  .container, .container-wide, .layout-with-toc {
+    padding: 1.5rem 1rem 3rem;
+  }
+  .topnav-inner { padding: 0.6rem 1rem; gap: 0.7rem; }
+  .topnav-crumbs { font-size: 0.82rem; }
+  .topnav-links a, .topnav-links button {
+    padding: 0.35rem 0.55rem;
+    font-size: 0.85rem;
+  }
+  .topnav-links .label { display: none; }
+  h2 { font-size: 1.3rem; }
+  table { font-size: 0.85rem; }
+  th, td { padding: 0.5rem 0.6rem; }
+}

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,5 +1,9 @@
 /* Sound Clash docs — shared stylesheet
  * Used by docs/index.html and docs/diagrams/*.html
+ *
+ * Page-tab navigation, prev/next footer, and theme toggle are rendered by
+ * assets/script.js from the PAGES list — adding a 4th HTML page = one entry
+ * there, no edits here.
  */
 
 :root {
@@ -7,6 +11,7 @@
   --bg: #fafaf7;
   --bg-elevated: #ffffff;
   --bg-subtle: #f1f3f5;
+  --bg-hover: #e9ecef;
   --fg: #1a1a1a;
   --fg-muted: #555;
   --fg-subtle: #888;
@@ -16,41 +21,48 @@
   --accent-hover: #b45309;     /* amber-700 */
   --accent-soft: #fef3c7;      /* amber-100 */
   --link: #1d4ed8;             /* blue-700 */
-  --link-hover: #1e3a8a;       /* blue-900 */
+  --link-hover: #1e3a8a;
   --code-bg: #f1f3f5;
   --code-fg: #1a1a1a;
+  --focus-ring: #1d4ed8;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
   --radius: 8px;
   --max-content: 880px;
   --max-wide: 1180px;
+  --nav-h: 56px;
 }
 
 [data-theme="dark"] {
-  --bg: #0e1116;
+  --bg: #0d1117;
   --bg-elevated: #161b22;
   --bg-subtle: #1c2128;
+  --bg-hover: #21262d;
   --fg: #e6edf3;
   --fg-muted: #9da7b3;
   --fg-subtle: #6e7681;
   --rule: #30363d;
   --rule-strong: #484f58;
   --accent: #fbbf24;          /* amber-400 */
-  --accent-hover: #fcd34d;     /* amber-300 */
+  --accent-hover: #fcd34d;
   --accent-soft: rgba(251, 191, 36, 0.15);
   --link: #79c0ff;
   --link-hover: #a5d6ff;
   --code-bg: #1c2128;
   --code-fg: #e6edf3;
+  --focus-ring: #79c0ff;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    --bg: #0e1116;
+    --bg: #0d1117;
     --bg-elevated: #161b22;
     --bg-subtle: #1c2128;
+    --bg-hover: #21262d;
     --fg: #e6edf3;
     --fg-muted: #9da7b3;
     --fg-subtle: #6e7681;
@@ -63,14 +75,16 @@
     --link-hover: #a5d6ff;
     --code-bg: #1c2128;
     --code-fg: #e6edf3;
+    --focus-ring: #79c0ff;
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
   }
 }
 
 * { box-sizing: border-box; }
 
-html { scroll-behavior: smooth; scroll-padding-top: 4.5rem; }
+html { scroll-behavior: smooth; scroll-padding-top: calc(var(--nav-h) + 1rem); }
 
 body {
   margin: 0;
@@ -84,33 +98,66 @@ body {
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-/* ---------- Top nav ---------- */
+/* ---------- Focus ring (a11y) ---------- */
+:focus { outline: none; }
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ---------- Skip link (a11y) ---------- */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0.5rem;
+  background: var(--accent);
+  color: #1a1a1a;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 600;
+  z-index: 200;
+  transition: top 0.15s ease;
+  text-decoration: none;
+}
+.skip-link:focus { top: 0.5rem; text-decoration: none; }
+
+/* ---------- Top nav (rendered by script.js) ---------- */
 .topnav {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: var(--bg-elevated);
+  background: rgba(250, 250, 247, 0.85);
   border-bottom: 1px solid var(--rule);
-  backdrop-filter: saturate(150%) blur(8px);
-  -webkit-backdrop-filter: saturate(150%) blur(8px);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
 }
+[data-theme="dark"] .topnav { background: rgba(13, 17, 23, 0.85); }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .topnav { background: rgba(13, 17, 23, 0.85); }
+}
+
 .topnav-inner {
   max-width: var(--max-wide);
   margin: 0 auto;
-  padding: 0.7rem 1.5rem;
+  padding: 0 1.5rem;
+  height: var(--nav-h);
   display: flex;
   align-items: center;
-  gap: 1.2rem;
+  gap: 1.5rem;
 }
+
 .topnav-brand {
-  font-weight: 600;
-  color: var(--fg);
-  text-decoration: none;
-  font-size: 0.98rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.98rem;
+  color: var(--fg);
+  text-decoration: none;
+  white-space: nowrap;
 }
+.topnav-brand:hover { color: var(--accent); text-decoration: none; }
 .topnav-brand .dot {
   width: 9px;
   height: 9px;
@@ -118,51 +165,79 @@ body {
   border-radius: 50%;
   display: inline-block;
 }
-.topnav-crumbs {
+.topnav-brand .small {
+  font-size: 0.78rem;
+  font-weight: 400;
   color: var(--fg-subtle);
-  font-size: 0.92rem;
-  flex: 1;
-  min-width: 0;
+  margin-left: 0.1rem;
 }
-.topnav-crumbs a {
-  color: var(--fg-muted);
-  text-decoration: none;
-}
-.topnav-crumbs a:hover { color: var(--accent); }
-.topnav-crumbs .sep { margin: 0 0.4rem; color: var(--fg-subtle); }
 
-.topnav-links {
+/* Tab group: Home / Internal / External */
+.topnav-tabs {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.15rem;
+  padding: 0.25rem;
+  background: var(--bg-subtle);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
 }
-.topnav-links a, .topnav-links button {
+.topnav-tab {
+  padding: 0.4rem 0.85rem;
+  border-radius: 5px;
   color: var(--fg-muted);
   text-decoration: none;
-  padding: 0.4rem 0.7rem;
-  border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 500;
+  white-space: nowrap;
+  transition: all 0.12s ease;
+}
+.topnav-tab:hover {
+  color: var(--fg);
+  background: var(--bg-hover);
+  text-decoration: none;
+}
+.topnav-tab.active {
+  color: var(--accent);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-sm);
+}
+
+.topnav-utility {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.topnav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--fg-muted);
+  text-decoration: none;
   background: transparent;
   border: 1px solid transparent;
   cursor: pointer;
   font-family: inherit;
   transition: all 0.12s ease;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
 }
-.topnav-links a:hover, .topnav-links button:hover {
+.topnav-link:hover {
   color: var(--fg);
   background: var(--bg-subtle);
   border-color: var(--rule);
+  text-decoration: none;
 }
-.topnav-links .icon {
+.topnav-link.icon-only { padding: 0.4rem 0.55rem; }
+.topnav-link .icon {
   width: 16px;
   height: 16px;
   display: inline-block;
-  vertical-align: -3px;
 }
+/* sun/moon swap based on current theme */
 #theme-toggle .icon-sun { display: none; }
 #theme-toggle .icon-moon { display: inline-block; }
 [data-theme="dark"] #theme-toggle .icon-sun { display: inline-block; }
@@ -172,37 +247,37 @@ body {
   :root:not([data-theme="light"]) #theme-toggle .icon-moon { display: none; }
 }
 
-/* ---------- Layout ---------- */
+/* ---------- Layouts ---------- */
 .container {
   max-width: var(--max-content);
   margin: 0 auto;
-  padding: 2.5rem 1.5rem 5rem;
+  padding: 2.5rem 1.5rem 4rem;
 }
 .container-wide {
   max-width: var(--max-wide);
   margin: 0 auto;
-  padding: 2.5rem 1.5rem 5rem;
+  padding: 2.5rem 1.5rem 4rem;
 }
 
 /* Two-column layout: content + sticky TOC */
 .layout-with-toc {
   max-width: var(--max-wide);
   margin: 0 auto;
-  padding: 2.5rem 1.5rem 5rem;
+  padding: 2.5rem 1.5rem 4rem;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 220px;
   gap: 3rem;
 }
 .layout-with-toc .toc {
   position: sticky;
-  top: 5rem;
+  top: calc(var(--nav-h) + 1rem);
   align-self: start;
   font-size: 0.9rem;
-  max-height: calc(100vh - 6rem);
+  max-height: calc(100vh - var(--nav-h) - 2rem);
   overflow-y: auto;
 }
 .toc-title {
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--fg-subtle);
@@ -221,7 +296,7 @@ body {
   line-height: 1.4;
   transition: all 0.1s ease;
 }
-.toc a:hover { color: var(--accent); }
+.toc a:hover { color: var(--accent); text-decoration: none; }
 .toc a.active {
   color: var(--accent);
   border-left-color: var(--accent);
@@ -241,20 +316,20 @@ h1, h2, h3, h4 {
   line-height: 1.25;
   font-weight: 600;
   margin: 0 0 0.6rem;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
 }
 h1 { font-size: 2.1rem; margin-bottom: 1rem; }
 h2 {
-  font-size: 1.5rem;
+  font-size: 1.45rem;
   margin-top: 3rem;
   padding-bottom: 0.4rem;
   border-bottom: 1px solid var(--rule);
 }
-h3 { font-size: 1.15rem; margin-top: 2rem; }
+h3 { font-size: 1.12rem; margin-top: 2rem; }
 h4 { font-size: 1rem; margin-top: 1.5rem; color: var(--fg-muted); }
 
 .lead {
-  font-size: 1.15rem;
+  font-size: 1.12rem;
   color: var(--fg-muted);
   line-height: 1.55;
   margin: 0 0 1.5rem;
@@ -317,7 +392,7 @@ th, td {
 th {
   background: var(--bg-subtle);
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--fg-muted);
@@ -328,13 +403,12 @@ td.center, th.center { text-align: center; }
 /* ---------- Hero ---------- */
 .hero {
   padding: 3rem 0 2rem;
-  text-align: left;
 }
 .hero h1 {
   font-size: 2.6rem;
   margin-bottom: 0.6rem;
 }
-.hero .lead { font-size: 1.2rem; max-width: 640px; }
+.hero .lead { font-size: 1.18rem; max-width: 640px; }
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -409,12 +483,9 @@ td.center, th.center { text-align: center; }
 }
 .card h3 {
   margin: 0 0 0.5rem;
-  font-size: 1.15rem;
+  font-size: 1.12rem;
 }
-.card h3 a {
-  color: var(--fg);
-  text-decoration: none;
-}
+.card h3 a { color: var(--fg); text-decoration: none; }
 .card h3 a:hover { color: var(--accent); }
 .card p {
   color: var(--fg-muted);
@@ -442,11 +513,8 @@ td.center, th.center { text-align: center; }
 }
 .diagram .mermaid { text-align: center; }
 .diagram .mermaid svg { max-width: 100%; height: auto !important; }
-
-/* Force light text on white diagram even in dark mode */
 .diagram, .diagram * { color-scheme: light; }
 
-/* Caption under a diagram */
 .caption {
   font-size: 0.88rem;
   color: var(--fg-subtle);
@@ -466,31 +534,32 @@ td.center, th.center { text-align: center; }
 .legend-title {
   font-weight: 600;
   margin: 0 0 0.5rem;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   color: var(--fg);
 }
 .legend ul { margin: 0; padding-left: 1.2rem; }
-.legend li { font-size: 0.93rem; margin: 0.3rem 0; color: var(--fg-muted); }
+.legend li { font-size: 0.92rem; margin: 0.3rem 0; color: var(--fg-muted); }
 
 /* ---------- Details / collapsible ---------- */
 details {
   border: 1px solid var(--rule);
   border-radius: var(--radius);
-  padding: 0;
   margin: 0.7rem 0;
   background: var(--bg-elevated);
   overflow: hidden;
+  transition: border-color 0.12s ease;
 }
+details:hover { border-color: var(--rule-strong); }
 details summary {
   cursor: pointer;
-  padding: 0.8rem 1.2rem;
+  padding: 0.85rem 1.2rem;
   font-weight: 500;
   list-style: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  transition: background 0.12s ease;
   user-select: none;
+  transition: background 0.12s ease;
 }
 details summary:hover { background: var(--bg-subtle); }
 details summary::-webkit-details-marker { display: none; }
@@ -509,13 +578,65 @@ details > :not(summary) {
 }
 details ul { padding-left: 2.4rem; }
 
+/* ---------- Page nav (prev/next, rendered by script.js) ---------- */
+.page-nav {
+  margin-top: 3.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.page-nav-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1rem 1.2rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  color: var(--fg);
+  text-decoration: none;
+  transition: all 0.12s ease;
+  min-width: 0;
+}
+.page-nav-card:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+  color: var(--fg);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+.page-nav-next { text-align: right; align-items: flex-end; }
+.page-nav-dir {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  font-weight: 600;
+}
+.page-nav-next .page-nav-dir { flex-direction: row-reverse; }
+.page-nav-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+.page-nav-desc {
+  font-size: 0.86rem;
+  color: var(--fg-muted);
+}
+.page-nav-spacer { display: block; }
+
 /* ---------- Footer ---------- */
 .footer {
-  margin-top: 4rem;
-  padding-top: 1.5rem;
+  margin-top: 2rem;
+  padding-top: 1.2rem;
   border-top: 1px solid var(--rule);
   color: var(--fg-subtle);
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
@@ -527,23 +648,31 @@ details ul { padding-left: 2.4rem; }
 
 /* ---------- Utility ---------- */
 .muted { color: var(--fg-muted); }
-.small { font-size: 0.88rem; }
+.small { font-size: 0.86rem; }
 
-@media (max-width: 600px) {
+/* ---------- Responsive ---------- */
+@media (max-width: 820px) {
+  .topnav-inner { padding: 0 1rem; gap: 0.7rem; }
+  .topnav-brand .small { display: none; }
+  .topnav-tabs { padding: 0.18rem; }
+  .topnav-tab { padding: 0.35rem 0.6rem; font-size: 0.85rem; }
+  .topnav-utility { gap: 0.15rem; }
+  .topnav-link .label { display: none; }
+}
+
+@media (max-width: 560px) {
   body { font-size: 15px; }
-  .hero h1 { font-size: 2rem; }
-  .hero .lead { font-size: 1.05rem; }
+  .hero { padding: 2rem 0 1.5rem; }
+  .hero h1 { font-size: 1.85rem; }
+  .hero .lead { font-size: 1rem; }
   .container, .container-wide, .layout-with-toc {
     padding: 1.5rem 1rem 3rem;
   }
-  .topnav-inner { padding: 0.6rem 1rem; gap: 0.7rem; }
-  .topnav-crumbs { font-size: 0.82rem; }
-  .topnav-links a, .topnav-links button {
-    padding: 0.35rem 0.55rem;
-    font-size: 0.85rem;
-  }
-  .topnav-links .label { display: none; }
-  h2 { font-size: 1.3rem; }
-  table { font-size: 0.85rem; }
+  h2 { font-size: 1.25rem; }
+  table { font-size: 0.84rem; }
   th, td { padding: 0.5rem 0.6rem; }
+  .page-nav { grid-template-columns: 1fr; }
+  .page-nav-next { text-align: left; align-items: flex-start; }
+  .page-nav-next .page-nav-dir { flex-direction: row; }
+  .topnav-brand { font-size: 0.9rem; }
 }

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,26 @@
+# Sound Clash — Diagrams
+
+Visual companions to the architecture docs. Each diagram exists in two forms:
+
+- **`*.md`** — Mermaid source embedded in Markdown. Renders inline on GitHub, in VSCode (Markdown Preview Mermaid plugin), and on most static-site renderers. Use this in code reviews and PRs.
+- **`*.html`** — standalone HTML that loads Mermaid from a CDN. Open in a browser when you want a full-screen view, or send the file to someone who can't open the GitHub UI.
+
+| File | Shows |
+|---|---|
+| [`internal.md`](internal.md) / [`internal.html`](internal.html) | What's inside the running game: browser ↔ FastAPI ↔ Supabase, the buzzer hot path, the auth split |
+| [`external.md`](external.md) / [`external.html`](external.html) | The third-party services that surround the game: hosting, CI/CD, error tracking, dependency bots, DNS |
+
+## Why two formats
+
+The `.md` files are the source of truth — they're text, version-controlled, and edits land in the same PR as the code change that motivated them. The `.html` files are conveniences for situations where Mermaid-in-Markdown isn't an option (sharing with non-developers, presenting on a projector, opening offline). Both files render the **same** Mermaid source — keep them in sync when editing.
+
+## Updating a diagram
+
+1. Edit the `mermaid` block in the `.md` file.
+2. Open the corresponding `.html` file and copy the same Mermaid source into the `<pre class="mermaid">` block.
+3. Open the `.html` locally in a browser to verify the diagram renders.
+4. Commit both files in the same change.
+
+## Why not GitHub Pages
+
+The `.md` versions render natively at `https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md`. The `.html` versions render fully when opened locally. Hosting a separate docs site would add a maintenance surface (and a second public URL alongside `https://soundclash.org`) for negligible benefit on a solo project. If that calculus changes, flipping on Pages is a single repo-Settings toggle.

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sound Clash — External Services</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --accent: #1a73e8;
+    --rule: #e5e5e5;
+    --code-bg: #f3f3f3;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; }
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.55;
+  }
+  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.4rem; }
+  h2 { margin-top: 2.4rem; }
+  blockquote {
+    border-left: 3px solid var(--accent);
+    padding: 0.4rem 1rem;
+    color: var(--muted);
+    background: var(--code-bg);
+    margin: 1.2rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  table { border-collapse: collapse; margin: 1rem 0; width: 100%; font-size: 0.95em; }
+  th, td { border: 1px solid var(--rule); padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }
+  th { background: var(--code-bg); }
+  td.center { text-align: center; }
+  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
+  .mermaid {
+    background: #fff;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+  .nav { font-size: 0.9em; color: var(--muted); margin-bottom: 1rem; }
+  .nav a { color: inherit; }
+</style>
+</head>
+<body>
+
+<div class="nav">
+  <a href="./README.md">← diagrams index</a> &middot;
+  <a href="../README.md">docs index</a>
+</div>
+
+<h1>External Services</h1>
+
+<p>The third-party services Sound Clash depends on, and how they're glued together. Internal architecture (browser ↔ FastAPI ↔ Postgres) lives in <a href="./internal.html">internal.html</a>; this file covers everything <em>around</em> the running game: hosting, CI/CD, error tracking, dependency bots, DNS.</p>
+
+<blockquote>
+  <strong>Total recurring cost</strong>: $12/yr for the domain. Everything else is on a free tier. See <code>tech-stack.md</code> for the full quota table and <code>free-tier-budget.md</code> for capacity analysis.
+</blockquote>
+
+<h2>Service map</h2>
+
+<pre class="mermaid">
+flowchart LR
+    User((Player /<br/>Host /<br/>Display))
+    YT[YouTube IFrame<br/>Player API]
+
+    subgraph DNS["DNS &amp; domain"]
+        Namecheap[("Namecheap<br/>$12/yr")]
+        Cloudflare[Cloudflare DNS<br/>soundclash.org]
+    end
+
+    subgraph Frontend["Frontend hosting"]
+        Pages[Cloudflare Pages<br/>www.soundclash.org]
+    end
+
+    subgraph Backend["Backend hosting"]
+        Render[Render web service<br/>api.soundclash.org]
+    end
+
+    subgraph Data["Database &amp; realtime"]
+        SupaProd[Supabase<br/>Sound-Clash<br/>Frankfurt, prod]
+        SupaPreview[Supabase<br/>Sound-Clash-Preview<br/>for E2E]
+    end
+
+    subgraph Ops["Ops &amp; observability"]
+        Sentry[Sentry<br/>frontend + backend]
+        CronJob[cron-job.org<br/>14-min keepalive]
+    end
+
+    subgraph Repo["GitHub repo"]
+        GH[github.com/<br/>BenArtzi4/Sound-Clash]
+        Actions[GitHub Actions<br/>backend / frontend /<br/>e2e / db-migrate]
+        CodeQL[CodeQL<br/>Default Setup]
+        Dependabot[Dependabot<br/>weekly bumps]
+        Codecov[Codecov<br/>coverage badge]
+    end
+
+    User -->|HTTPS| Pages
+    User -.->|YouTube embed| YT
+    Pages -->|REST| Render
+    Pages -->|"Realtime WSS<br/>+ PostgREST"| SupaProd
+    Render -->|"service-role key"| SupaProd
+    CronJob -->|GET /health<br/>every 14 min| Render
+
+    Namecheap -.->|nameservers| Cloudflare
+    Cloudflare -.->|"apex 301 → www"| Pages
+    Cloudflare -.->|"CNAME api"| Render
+
+    GH -->|webhook on push| Actions
+    Actions -->|Render deploy hook| Render
+    Actions -->|wrangler pages deploy| Pages
+    Actions -.->|coverage.xml| Codecov
+    Actions -.->|psql migrate.sh<br/>(manual dispatch)| SupaProd
+    Actions -->|Playwright E2E| SupaPreview
+    GH -.->|on push / PR| CodeQL
+    Dependabot -.->|opens PRs| GH
+
+    Pages -.->|JS errors| Sentry
+    Render -.->|Python errors| Sentry
+
+    classDef paid fill:#ffe0e0,stroke:#cc0000,color:#000
+    classDef free fill:#e8f5e9,stroke:#2e7d32,color:#000
+    classDef ci fill:#e3f2fd,stroke:#1565c0,color:#000
+    class Namecheap paid
+    class Pages,Render,SupaProd,SupaPreview,Sentry,CronJob,YT free
+    class GH,Actions,CodeQL,Dependabot,Codecov ci
+</pre>
+
+<p><strong>Legend</strong>: red = paid (just the domain), green = free-tier services in the request path, blue = developer/CI infrastructure that doesn't sit on the request path.</p>
+
+<h2>Service inventory</h2>
+
+<table>
+<thead><tr><th>Service</th><th>Used for</th><th>Plan</th><th>Auth surface</th></tr></thead>
+<tbody>
+<tr><td><strong>Namecheap</strong></td><td>Domain registration of <code>soundclash.org</code></td><td>$12/yr</td><td>Account login</td></tr>
+<tr><td><strong>Cloudflare DNS</strong></td><td>Authoritative DNS, apex redirect, CNAME for <code>api.soundclash.org</code></td><td>Free</td><td>API token (<code>CF_API_TOKEN</code>)</td></tr>
+<tr><td><strong>Cloudflare Pages</strong></td><td>Static hosting of the React SPA at <code>www.soundclash.org</code></td><td>Free (unlimited bandwidth, 500 builds/mo)</td><td>API token + account ID</td></tr>
+<tr><td><strong>Render</strong></td><td>FastAPI Docker service at <code>api.soundclash.org</code></td><td>Free (750 hr/mo, 512 MB, 15-min idle sleep)</td><td>Deploy webhook (<code>RENDER_DEPLOY_HOOK</code>)</td></tr>
+<tr><td><strong>Supabase (prod)</strong></td><td>Postgres + Realtime + PostgREST</td><td>Free (500 MB DB, 200 concurrent peers, 2M msgs/mo)</td><td>anon key (browser), service-role key (server)</td></tr>
+<tr><td><strong>Supabase (preview)</strong></td><td>Isolated project for Playwright E2E</td><td>Free</td><td>Separate anon + service-role secrets</td></tr>
+<tr><td><strong>GitHub Actions</strong></td><td>CI/CD for all four workflows</td><td>Free for public repos</td><td><code>GITHUB_TOKEN</code> per run</td></tr>
+<tr><td><strong>CodeQL</strong></td><td>Security static analysis</td><td>Free for public repos (Default Setup)</td><td>none (runs as a check)</td></tr>
+<tr><td><strong>Dependabot</strong></td><td>Weekly dependency PRs</td><td>Free</td><td>none (built into GitHub)</td></tr>
+<tr><td><strong>Codecov</strong></td><td>Coverage delta comments + badge</td><td>Free for public repos</td><td><code>CODECOV_TOKEN</code> upload secret</td></tr>
+<tr><td><strong>Sentry</strong></td><td>Error tracking (<code>sound-clash-frontend</code> + <code>sound-clash-backend</code>)</td><td>Free (5k errors/mo, 10k perf events)</td><td>DSN per project</td></tr>
+<tr><td><strong>cron-job.org</strong></td><td>Pings <code>/health</code> every 14 min so Render doesn't sleep</td><td>Free</td><td>Account login</td></tr>
+<tr><td><strong>YouTube IFrame Player API</strong></td><td>Audio playback (browser-direct)</td><td>Free, terms apply</td><td>none (public CDN)</td></tr>
+</tbody>
+</table>
+
+<h2>Deploy flow: what happens on <code>git push main</code></h2>
+
+<pre class="mermaid">
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as GitHub Actions
+    participant CodeQL as CodeQL
+    participant Codecov as Codecov
+    participant Render as Render
+    participant CF as Cloudflare Pages
+    participant API as api.soundclash.org
+    participant Web as www.soundclash.org
+
+    Dev->>GH: git push origin main
+    par
+        GH->>CI: trigger backend.yml
+        and
+        GH->>CI: trigger frontend.yml
+        and
+        GH->>CodeQL: scan changed files
+    end
+
+    Note over CI: ruff + mypy + pytest<br/>(backend.yml)<br/>eslint + tsc + vitest + build<br/>(frontend.yml)
+
+    CI->>Codecov: upload coverage.xml / lcov.info
+    Codecov-->>GH: PR comment / badge update
+
+    alt backend tests pass
+        CI->>Render: POST $RENDER_DEPLOY_HOOK
+        Render->>Render: docker build + health-check
+        Render-->>API: traffic swap (~30s cold start)
+    end
+
+    alt frontend tests pass
+        CI->>CF: wrangler pages deploy dist
+        CF-->>Web: new build live (~10s)
+    end
+
+    Note over CI: e2e.yml only runs on main pushes,<br/>or PRs labeled `run-e2e`.<br/>db-migrate.yml is manual-dispatch only<br/>(never auto-applied).
+</pre>
+
+<h2>What goes into which secret store</h2>
+
+<p>Every credential lives in <strong>exactly one</strong> of these places (no duplication, no committed <code>.env</code>):</p>
+
+<table>
+<thead><tr><th>Secret</th><th>GitHub Actions</th><th>Render env</th><th>Cloudflare Pages env</th><th>Local <code>.env</code></th></tr></thead>
+<tbody>
+<tr><td><code>SUPABASE_URL</code></td><td class="center">✅</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>SUPABASE_ANON_KEY</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>SUPABASE_SERVICE_ROLE_KEY</code></td><td class="center">✅</td><td class="center">✅</td><td class="center"><strong>never</strong></td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>SUPABASE_PREVIEW_*</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+<tr><td><code>ADMIN_PASSWORD</code></td><td class="center">✅ (preview)</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>RENDER_DEPLOY_HOOK</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+<tr><td><code>CF_API_TOKEN</code> / <code>CF_ACCOUNT_ID</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+<tr><td><code>SENTRY_DSN_BACKEND</code></td><td class="center">–</td><td class="center">✅</td><td class="center">–</td><td class="center">optional</td></tr>
+<tr><td><code>SENTRY_DSN_FRONTEND</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">optional</td></tr>
+<tr><td><code>CODECOV_TOKEN</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+<tr><td><code>VITE_SUPABASE_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>VITE_SUPABASE_ANON_KEY</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+<tr><td><code>VITE_API_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+</tbody>
+</table>
+
+<p>The full secret rotation procedure is in <code>runbook.md</code> §3.</p>
+
+<h2>What is <em>not</em> in this diagram</h2>
+
+<ul>
+  <li><strong>AWS</strong> — torn down 2026-05-07. The legacy stack lives in <code>Sound-Clash-legacy</code> for reference only; nothing in the new system depends on AWS resources.</li>
+  <li><strong>CDN for YouTube</strong> — YouTube IFrame Player loads its own JS from <code>youtube.com</code>; there's no separate CDN dependency we manage.</li>
+  <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
+</ul>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true, theme: "default", securityLevel: "loose" });
+</script>
+
+</body>
+</html>

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-page="external">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -10,32 +10,13 @@
 </head>
 <body>
 
-<header class="topnav">
-  <div class="topnav-inner">
-    <a class="topnav-brand" href="../"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
-    <nav class="topnav-crumbs">
-      <a href="../">Docs</a><span class="sep">/</span>
-      <a href="./README.md">Diagrams</a><span class="sep">/</span>
-      <span>External services</span>
-    </nav>
-    <div class="topnav-links">
-      <a href="./internal.html">
-        <span class="label">← Internal</span>
-      </a>
-      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
-        <span class="label">GitHub</span>
-        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
-      </a>
-      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
-        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
-      </button>
-    </div>
-  </div>
-</header>
+<a class="skip-link" href="#content">Skip to content</a>
+
+<!-- Top nav rendered by assets/script.js -->
+<header id="topnav"></header>
 
 <div class="layout-with-toc">
-  <main>
+  <main id="content">
     <h1>External services</h1>
     <p class="lead">The third-party services Sound Clash depends on, and how they're glued together. <a href="./internal.html">Internal architecture</a> covers what's <em>inside</em> the game.</p>
 
@@ -224,9 +205,12 @@ sequenceDiagram
       <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
     </ul>
 
+    <!-- Prev/next nav rendered by assets/script.js -->
+    <nav id="page-nav" aria-label="Page navigation"></nav>
+
     <footer class="footer">
-      <span>Previous: <a href="./internal.html">← Internal architecture</a></span>
       <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/external.md">View Markdown source</a></span>
+      <span><a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a></span>
     </footer>
 
   </main>

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -3,73 +3,50 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Sound Clash — External Services</title>
-<style>
-  :root {
-    --bg: #fafafa;
-    --fg: #1a1a1a;
-    --muted: #666;
-    --accent: #1a73e8;
-    --rule: #e5e5e5;
-    --code-bg: #f3f3f3;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; }
-  }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
-    background: var(--bg);
-    color: var(--fg);
-    line-height: 1.55;
-  }
-  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.4rem; }
-  h2 { margin-top: 2.4rem; }
-  blockquote {
-    border-left: 3px solid var(--accent);
-    padding: 0.4rem 1rem;
-    color: var(--muted);
-    background: var(--code-bg);
-    margin: 1.2rem 0;
-    border-radius: 0 4px 4px 0;
-  }
-  table { border-collapse: collapse; margin: 1rem 0; width: 100%; font-size: 0.95em; }
-  th, td { border: 1px solid var(--rule); padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }
-  th { background: var(--code-bg); }
-  td.center { text-align: center; }
-  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
-  .mermaid {
-    background: #fff;
-    border: 1px solid var(--rule);
-    border-radius: 6px;
-    padding: 1rem;
-    overflow-x: auto;
-    margin: 1.5rem 0;
-  }
-  .nav { font-size: 0.9em; color: var(--muted); margin-bottom: 1rem; }
-  .nav a { color: inherit; }
-</style>
+<title>External Services — Sound Clash</title>
+<meta name="description" content="The third-party services Sound Clash depends on, and how they're glued together." />
+<link rel="stylesheet" href="../assets/style.css" />
+<script defer src="../assets/script.js"></script>
 </head>
 <body>
 
-<div class="nav">
-  <a href="./README.md">← diagrams index</a> &middot;
-  <a href="../README.md">docs index</a>
-</div>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="topnav-brand" href="../"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
+    <nav class="topnav-crumbs">
+      <a href="../">Docs</a><span class="sep">/</span>
+      <a href="./README.md">Diagrams</a><span class="sep">/</span>
+      <span>External services</span>
+    </nav>
+    <div class="topnav-links">
+      <a href="./internal.html">
+        <span class="label">← Internal</span>
+      </a>
+      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
+        <span class="label">GitHub</span>
+        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
+      </a>
+      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
+        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
+      </button>
+    </div>
+  </div>
+</header>
 
-<h1>External Services</h1>
+<div class="layout-with-toc">
+  <main>
+    <h1>External services</h1>
+    <p class="lead">The third-party services Sound Clash depends on, and how they're glued together. <a href="./internal.html">Internal architecture</a> covers what's <em>inside</em> the game.</p>
 
-<p>The third-party services Sound Clash depends on, and how they're glued together. Internal architecture (browser ↔ FastAPI ↔ Postgres) lives in <a href="./internal.html">internal.html</a>; this file covers everything <em>around</em> the running game: hosting, CI/CD, error tracking, dependency bots, DNS.</p>
+    <blockquote>
+      <strong>Total recurring cost:</strong> $12/yr for the domain. Everything else is on a free tier. See <code>tech-stack.md</code> for the full quota table and <code>free-tier-budget.md</code> for capacity analysis.
+    </blockquote>
 
-<blockquote>
-  <strong>Total recurring cost</strong>: $12/yr for the domain. Everything else is on a free tier. See <code>tech-stack.md</code> for the full quota table and <code>free-tier-budget.md</code> for capacity analysis.
-</blockquote>
+    <h2 id="service-map">Service map</h2>
 
-<h2>Service map</h2>
-
-<pre class="mermaid">
+    <div class="diagram">
+      <pre class="mermaid">
 flowchart LR
     User((Player /<br/>Host /<br/>Display))
     YT[YouTube IFrame<br/>Player API]
@@ -134,34 +111,45 @@ flowchart LR
     class Namecheap paid
     class Pages,Render,SupaProd,SupaPreview,Sentry,CronJob,YT free
     class GH,Actions,CodeQL,Dependabot,Codecov ci
-</pre>
+      </pre>
+    </div>
 
-<p><strong>Legend</strong>: red = paid (just the domain), green = free-tier services in the request path, blue = developer/CI infrastructure that doesn't sit on the request path.</p>
+    <div class="legend">
+      <p class="legend-title">Legend</p>
+      <ul>
+        <li><strong>Red</strong> — paid (just the domain)</li>
+        <li><strong>Green</strong> — free-tier services in the request path</li>
+        <li><strong>Blue</strong> — developer / CI infrastructure that doesn't sit on the request path</li>
+      </ul>
+    </div>
 
-<h2>Service inventory</h2>
+    <h2 id="inventory">Service inventory</h2>
 
-<table>
-<thead><tr><th>Service</th><th>Used for</th><th>Plan</th><th>Auth surface</th></tr></thead>
-<tbody>
-<tr><td><strong>Namecheap</strong></td><td>Domain registration of <code>soundclash.org</code></td><td>$12/yr</td><td>Account login</td></tr>
-<tr><td><strong>Cloudflare DNS</strong></td><td>Authoritative DNS, apex redirect, CNAME for <code>api.soundclash.org</code></td><td>Free</td><td>API token (<code>CF_API_TOKEN</code>)</td></tr>
-<tr><td><strong>Cloudflare Pages</strong></td><td>Static hosting of the React SPA at <code>www.soundclash.org</code></td><td>Free (unlimited bandwidth, 500 builds/mo)</td><td>API token + account ID</td></tr>
-<tr><td><strong>Render</strong></td><td>FastAPI Docker service at <code>api.soundclash.org</code></td><td>Free (750 hr/mo, 512 MB, 15-min idle sleep)</td><td>Deploy webhook (<code>RENDER_DEPLOY_HOOK</code>)</td></tr>
-<tr><td><strong>Supabase (prod)</strong></td><td>Postgres + Realtime + PostgREST</td><td>Free (500 MB DB, 200 concurrent peers, 2M msgs/mo)</td><td>anon key (browser), service-role key (server)</td></tr>
-<tr><td><strong>Supabase (preview)</strong></td><td>Isolated project for Playwright E2E</td><td>Free</td><td>Separate anon + service-role secrets</td></tr>
-<tr><td><strong>GitHub Actions</strong></td><td>CI/CD for all four workflows</td><td>Free for public repos</td><td><code>GITHUB_TOKEN</code> per run</td></tr>
-<tr><td><strong>CodeQL</strong></td><td>Security static analysis</td><td>Free for public repos (Default Setup)</td><td>none (runs as a check)</td></tr>
-<tr><td><strong>Dependabot</strong></td><td>Weekly dependency PRs</td><td>Free</td><td>none (built into GitHub)</td></tr>
-<tr><td><strong>Codecov</strong></td><td>Coverage delta comments + badge</td><td>Free for public repos</td><td><code>CODECOV_TOKEN</code> upload secret</td></tr>
-<tr><td><strong>Sentry</strong></td><td>Error tracking (<code>sound-clash-frontend</code> + <code>sound-clash-backend</code>)</td><td>Free (5k errors/mo, 10k perf events)</td><td>DSN per project</td></tr>
-<tr><td><strong>cron-job.org</strong></td><td>Pings <code>/health</code> every 14 min so Render doesn't sleep</td><td>Free</td><td>Account login</td></tr>
-<tr><td><strong>YouTube IFrame Player API</strong></td><td>Audio playback (browser-direct)</td><td>Free, terms apply</td><td>none (public CDN)</td></tr>
-</tbody>
-</table>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Service</th><th>Used for</th><th>Plan</th><th>Auth surface</th></tr></thead>
+        <tbody>
+          <tr><td><strong>Namecheap</strong></td><td>Domain registration of <code>soundclash.org</code></td><td>$12/yr</td><td>Account login</td></tr>
+          <tr><td><strong>Cloudflare DNS</strong></td><td>Authoritative DNS, apex redirect, CNAME for <code>api.soundclash.org</code></td><td>Free</td><td>API token</td></tr>
+          <tr><td><strong>Cloudflare Pages</strong></td><td>Static hosting of the React SPA at <code>www.soundclash.org</code></td><td>Free (unlimited bandwidth, 500 builds/mo)</td><td>API token + account ID</td></tr>
+          <tr><td><strong>Render</strong></td><td>FastAPI Docker service at <code>api.soundclash.org</code></td><td>Free (750 hr/mo, 512 MB, 15-min idle sleep)</td><td>Deploy webhook</td></tr>
+          <tr><td><strong>Supabase (prod)</strong></td><td>Postgres + Realtime + PostgREST</td><td>Free (500 MB DB, 200 concurrent peers, 2M msgs/mo)</td><td>anon key (browser), service-role key (server)</td></tr>
+          <tr><td><strong>Supabase (preview)</strong></td><td>Isolated project for Playwright E2E</td><td>Free</td><td>Separate anon + service-role secrets</td></tr>
+          <tr><td><strong>GitHub Actions</strong></td><td>CI/CD for all four workflows</td><td>Free for public repos</td><td><code>GITHUB_TOKEN</code> per run</td></tr>
+          <tr><td><strong>CodeQL</strong></td><td>Security static analysis</td><td>Free (Default Setup)</td><td>none (runs as a check)</td></tr>
+          <tr><td><strong>Dependabot</strong></td><td>Weekly dependency PRs</td><td>Free</td><td>none (built into GitHub)</td></tr>
+          <tr><td><strong>Codecov</strong></td><td>Coverage delta comments + badge</td><td>Free for public repos</td><td><code>CODECOV_TOKEN</code> upload secret</td></tr>
+          <tr><td><strong>Sentry</strong></td><td>Error tracking (frontend + backend)</td><td>Free (5k errors/mo, 10k perf events)</td><td>DSN per project</td></tr>
+          <tr><td><strong>cron-job.org</strong></td><td>Pings <code>/health</code> every 14 min so Render doesn't sleep</td><td>Free</td><td>Account login</td></tr>
+          <tr><td><strong>YouTube IFrame Player</strong></td><td>Audio playback (browser-direct)</td><td>Free, terms apply</td><td>none</td></tr>
+        </tbody>
+      </table>
+    </div>
 
-<h2>Deploy flow: what happens on <code>git push main</code></h2>
+    <h2 id="deploy-flow">Deploy flow: <code>git push main</code></h2>
 
-<pre class="mermaid">
+    <div class="diagram">
+      <pre class="mermaid">
 sequenceDiagram
     autonumber
     participant Dev as Developer
@@ -200,45 +188,60 @@ sequenceDiagram
     end
 
     Note over CI: e2e.yml only runs on main pushes,<br/>or PRs labeled `run-e2e`.<br/>db-migrate.yml is manual-dispatch only<br/>(never auto-applied).
-</pre>
+      </pre>
+    </div>
 
-<h2>What goes into which secret store</h2>
+    <h2 id="secrets">Secret-store matrix</h2>
+    <p>Every credential lives in <strong>exactly one</strong> of these places (no duplication, no committed <code>.env</code>):</p>
 
-<p>Every credential lives in <strong>exactly one</strong> of these places (no duplication, no committed <code>.env</code>):</p>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Secret</th><th class="center">GitHub Actions</th><th class="center">Render env</th><th class="center">Cloudflare Pages env</th><th class="center">Local <code>.env</code></th></tr></thead>
+        <tbody>
+          <tr><td><code>SUPABASE_URL</code></td><td class="center">✅</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>SUPABASE_ANON_KEY</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>SUPABASE_SERVICE_ROLE_KEY</code></td><td class="center">✅</td><td class="center">✅</td><td class="center"><strong>never</strong></td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>SUPABASE_PREVIEW_*</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+          <tr><td><code>ADMIN_PASSWORD</code></td><td class="center">✅ (preview)</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>RENDER_DEPLOY_HOOK</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+          <tr><td><code>CF_API_TOKEN</code> / <code>CF_ACCOUNT_ID</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+          <tr><td><code>SENTRY_DSN_BACKEND</code></td><td class="center">–</td><td class="center">✅</td><td class="center">–</td><td class="center">optional</td></tr>
+          <tr><td><code>SENTRY_DSN_FRONTEND</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">optional</td></tr>
+          <tr><td><code>CODECOV_TOKEN</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
+          <tr><td><code>VITE_SUPABASE_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>VITE_SUPABASE_ANON_KEY</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+          <tr><td><code>VITE_API_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
+        </tbody>
+      </table>
+    </div>
 
-<table>
-<thead><tr><th>Secret</th><th>GitHub Actions</th><th>Render env</th><th>Cloudflare Pages env</th><th>Local <code>.env</code></th></tr></thead>
-<tbody>
-<tr><td><code>SUPABASE_URL</code></td><td class="center">✅</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>SUPABASE_ANON_KEY</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>SUPABASE_SERVICE_ROLE_KEY</code></td><td class="center">✅</td><td class="center">✅</td><td class="center"><strong>never</strong></td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>SUPABASE_PREVIEW_*</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
-<tr><td><code>ADMIN_PASSWORD</code></td><td class="center">✅ (preview)</td><td class="center">✅</td><td class="center">–</td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>RENDER_DEPLOY_HOOK</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
-<tr><td><code>CF_API_TOKEN</code> / <code>CF_ACCOUNT_ID</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
-<tr><td><code>SENTRY_DSN_BACKEND</code></td><td class="center">–</td><td class="center">✅</td><td class="center">–</td><td class="center">optional</td></tr>
-<tr><td><code>SENTRY_DSN_FRONTEND</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">optional</td></tr>
-<tr><td><code>CODECOV_TOKEN</code></td><td class="center">✅</td><td class="center">–</td><td class="center">–</td><td class="center">–</td></tr>
-<tr><td><code>VITE_SUPABASE_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>VITE_SUPABASE_ANON_KEY</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
-<tr><td><code>VITE_API_URL</code></td><td class="center">–</td><td class="center">–</td><td class="center">✅</td><td class="center">✅ (dev)</td></tr>
-</tbody>
-</table>
+    <p class="muted small">The full secret rotation procedure is in <code>runbook.md</code> §3.</p>
 
-<p>The full secret rotation procedure is in <code>runbook.md</code> §3.</p>
+    <h2 id="not-here">What is <em>not</em> in this diagram</h2>
+    <ul>
+      <li><strong>AWS</strong> — torn down 2026-05-07. The legacy stack lives in <code>Sound-Clash-legacy</code> for reference only; nothing in the new system depends on AWS resources.</li>
+      <li><strong>CDN for YouTube</strong> — YouTube IFrame Player loads its own JS from <code>youtube.com</code>; there's no separate CDN dependency we manage.</li>
+      <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
+    </ul>
 
-<h2>What is <em>not</em> in this diagram</h2>
+    <footer class="footer">
+      <span>Previous: <a href="./internal.html">← Internal architecture</a></span>
+      <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/external.md">View Markdown source</a></span>
+    </footer>
 
-<ul>
-  <li><strong>AWS</strong> — torn down 2026-05-07. The legacy stack lives in <code>Sound-Clash-legacy</code> for reference only; nothing in the new system depends on AWS resources.</li>
-  <li><strong>CDN for YouTube</strong> — YouTube IFrame Player loads its own JS from <code>youtube.com</code>; there's no separate CDN dependency we manage.</li>
-  <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
-</ul>
+  </main>
 
-<script type="module">
-  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
-  mermaid.initialize({ startOnLoad: true, theme: "default", securityLevel: "loose" });
-</script>
+  <aside class="toc">
+    <p class="toc-title">On this page</p>
+    <ul>
+      <li><a href="#service-map">Service map</a></li>
+      <li><a href="#inventory">Service inventory</a></li>
+      <li><a href="#deploy-flow">Deploy flow</a></li>
+      <li><a href="#secrets">Secret-store matrix</a></li>
+      <li><a href="#not-here">What's not here</a></li>
+    </ul>
+  </aside>
+</div>
 
 </body>
 </html>

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -12,8 +12,9 @@
 
 <a class="skip-link" href="#content">Skip to content</a>
 
-<!-- Top nav rendered by assets/script.js -->
-<header id="topnav"></header>
+<!-- Top nav: CSS class applied here so the bar has stable height from
+     first paint; assets/script.js populates the inner content. -->
+<header id="topnav" class="topnav"></header>
 
 <div class="layout-with-toc">
   <main id="content">
@@ -205,8 +206,8 @@ sequenceDiagram
       <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
     </ul>
 
-    <!-- Prev/next nav rendered by assets/script.js -->
-    <nav id="page-nav" aria-label="Page navigation"></nav>
+    <!-- Prev/next nav populated by assets/script.js -->
+    <nav id="page-nav" class="page-nav" aria-label="Page navigation"></nav>
 
     <footer class="footer">
       <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/external.md">View Markdown source</a></span>

--- a/docs/diagrams/external.md
+++ b/docs/diagrams/external.md
@@ -1,0 +1,165 @@
+# External Services
+
+The third-party services Sound Clash depends on, and how they're glued together. Internal architecture (browser ↔ FastAPI ↔ Postgres) lives in [`internal.md`](internal.md); this file covers everything *around* the running game: hosting, CI/CD, error tracking, dependency bots, DNS.
+
+> **Total recurring cost**: $12/yr for the domain. Everything else is on a free tier. See `tech-stack.md` for the full quota table and `free-tier-budget.md` for capacity analysis.
+
+## Service map
+
+```mermaid
+flowchart LR
+    User((Player /<br/>Host /<br/>Display))
+    YT[YouTube IFrame<br/>Player API]
+
+    subgraph DNS["DNS &amp; domain"]
+        Namecheap[("Namecheap<br/>$12/yr")]
+        Cloudflare[Cloudflare DNS<br/>soundclash.org]
+    end
+
+    subgraph Frontend["Frontend hosting"]
+        Pages[Cloudflare Pages<br/>www.soundclash.org]
+    end
+
+    subgraph Backend["Backend hosting"]
+        Render[Render web service<br/>api.soundclash.org]
+    end
+
+    subgraph Data["Database &amp; realtime"]
+        SupaProd[Supabase<br/>Sound-Clash<br/>Frankfurt, prod]
+        SupaPreview[Supabase<br/>Sound-Clash-Preview<br/>for E2E]
+    end
+
+    subgraph Ops["Ops &amp; observability"]
+        Sentry[Sentry<br/>frontend + backend]
+        CronJob[cron-job.org<br/>14-min keepalive]
+    end
+
+    subgraph Repo["GitHub repo"]
+        GH[github.com/<br/>BenArtzi4/Sound-Clash]
+        Actions[GitHub Actions<br/>backend / frontend /<br/>e2e / db-migrate]
+        CodeQL[CodeQL<br/>Default Setup]
+        Dependabot[Dependabot<br/>weekly bumps]
+        Codecov[Codecov<br/>coverage badge]
+    end
+
+    User -->|HTTPS| Pages
+    User -.->|YouTube embed| YT
+    Pages -->|REST| Render
+    Pages -->|"Realtime WSS<br/>+ PostgREST"| SupaProd
+    Render -->|"service-role key"| SupaProd
+    CronJob -->|GET /health<br/>every 14 min| Render
+
+    Namecheap -.->|nameservers| Cloudflare
+    Cloudflare -.->|"apex 301 → www"| Pages
+    Cloudflare -.->|"CNAME api"| Render
+
+    GH -->|webhook on push| Actions
+    Actions -->|Render deploy hook| Render
+    Actions -->|wrangler pages deploy| Pages
+    Actions -.->|coverage.xml| Codecov
+    Actions -.->|psql migrate.sh<br/>(manual dispatch)| SupaProd
+    Actions -->|Playwright E2E| SupaPreview
+    GH -.->|on push / PR| CodeQL
+    Dependabot -.->|opens PRs| GH
+
+    Pages -.->|JS errors| Sentry
+    Render -.->|Python errors| Sentry
+
+    classDef paid fill:#ffe0e0,stroke:#cc0000,color:#000
+    classDef free fill:#e8f5e9,stroke:#2e7d32,color:#000
+    classDef ci fill:#e3f2fd,stroke:#1565c0,color:#000
+    class Namecheap paid
+    class Pages,Render,SupaProd,SupaPreview,Sentry,CronJob,YT free
+    class GH,Actions,CodeQL,Dependabot,Codecov ci
+```
+
+**Legend**: red = paid (just the domain), green = free-tier services in the request path, blue = developer/CI infrastructure that doesn't sit on the request path.
+
+## Service inventory
+
+| Service | Used for | Plan | Auth surface |
+|---|---|---|---|
+| **Namecheap** | Domain registration of `soundclash.org` | $12/yr | Account login |
+| **Cloudflare DNS** | Authoritative DNS, apex redirect, CNAME for `api.soundclash.org` | Free | API token (`CF_API_TOKEN`) |
+| **Cloudflare Pages** | Static hosting of the React SPA at `www.soundclash.org` | Free (unlimited bandwidth, 500 builds/mo) | API token + account ID |
+| **Render** | FastAPI Docker service at `api.soundclash.org` | Free (750 hr/mo, 512 MB, 15-min idle sleep) | Deploy webhook (`RENDER_DEPLOY_HOOK`) |
+| **Supabase (prod)** | Postgres + Realtime + PostgREST | Free (500 MB DB, 200 concurrent peers, 2M msgs/mo) | anon key (browser), service-role key (server) |
+| **Supabase (preview)** | Isolated project for Playwright E2E | Free | Separate anon + service-role secrets |
+| **GitHub Actions** | CI/CD for all four workflows | Free for public repos | `GITHUB_TOKEN` per run |
+| **CodeQL** | Security static analysis | Free for public repos (Default Setup) | none (runs as a check) |
+| **Dependabot** | Weekly dependency PRs | Free | none (built into GitHub) |
+| **Codecov** | Coverage delta comments + badge | Free for public repos | `CODECOV_TOKEN` upload secret |
+| **Sentry** | Error tracking (`sound-clash-frontend` + `sound-clash-backend`) | Free (5k errors/mo, 10k perf events) | DSN per project |
+| **cron-job.org** | Pings `/health` every 14 min so Render doesn't sleep | Free | Account login |
+| **YouTube IFrame Player API** | Audio playback (browser-direct) | Free, terms apply | none (public CDN) |
+
+## Deploy flow: what happens on `git push main`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as GitHub Actions
+    participant CodeQL as CodeQL
+    participant Codecov as Codecov
+    participant Render as Render
+    participant CF as Cloudflare Pages
+    participant API as api.soundclash.org
+    participant Web as www.soundclash.org
+
+    Dev->>GH: git push origin main
+    par
+        GH->>CI: trigger backend.yml
+        and
+        GH->>CI: trigger frontend.yml
+        and
+        GH->>CodeQL: scan changed files
+    end
+
+    Note over CI: ruff + mypy + pytest<br/>(backend.yml)<br/>eslint + tsc + vitest + build<br/>(frontend.yml)
+
+    CI->>Codecov: upload coverage.xml / lcov.info
+    Codecov-->>GH: PR comment / badge update
+
+    alt backend tests pass
+        CI->>Render: POST $RENDER_DEPLOY_HOOK
+        Render->>Render: docker build + health-check
+        Render-->>API: traffic swap (~30s cold start)
+    end
+
+    alt frontend tests pass
+        CI->>CF: wrangler pages deploy dist
+        CF-->>Web: new build live (~10s)
+    end
+
+    Note over CI: e2e.yml only runs on main pushes,<br/>or PRs labeled `run-e2e`.<br/>db-migrate.yml is manual-dispatch only<br/>(never auto-applied).
+```
+
+## What goes into which secret store
+
+Every credential lives in **exactly one** of these places (no duplication, no committed `.env`):
+
+| Secret | GitHub Actions | Render env | Cloudflare Pages env | Local `.env` |
+|---|:-:|:-:|:-:|:-:|
+| `SUPABASE_URL` | ✅ | ✅ | – | ✅ (dev) |
+| `SUPABASE_ANON_KEY` | ✅ | – | – | ✅ (dev) |
+| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | ✅ | **never** | ✅ (dev) |
+| `SUPABASE_PREVIEW_*` | ✅ | – | – | – |
+| `ADMIN_PASSWORD` | ✅ (preview) | ✅ | – | ✅ (dev) |
+| `RENDER_DEPLOY_HOOK` | ✅ | – | – | – |
+| `CF_API_TOKEN` / `CF_ACCOUNT_ID` | ✅ | – | – | – |
+| `SENTRY_DSN_BACKEND` | – | ✅ | – | optional |
+| `SENTRY_DSN_FRONTEND` | – | – | ✅ | optional |
+| `CODECOV_TOKEN` | ✅ | – | – | – |
+| `VITE_SUPABASE_URL` | – | – | ✅ | ✅ (dev) |
+| `VITE_SUPABASE_ANON_KEY` | – | – | ✅ | ✅ (dev) |
+| `VITE_API_URL` | – | – | ✅ | ✅ (dev) |
+
+The full secret rotation procedure is in `runbook.md` §3.
+
+## What is **not** in this diagram
+
+- **AWS** — torn down 2026-05-07. The legacy stack lives in `Sound-Clash-legacy` for reference only; nothing in the new system depends on AWS resources.
+- **CDN for YouTube** — YouTube IFrame Player loads its own JS from `youtube.com`; there's no separate CDN dependency we manage.
+- **Email** — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.

--- a/docs/diagrams/internal.html
+++ b/docs/diagrams/internal.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sound Clash — Internal Architecture</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --accent: #cc6600;
+    --rule: #e5e5e5;
+    --code-bg: #f3f3f3;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; }
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.55;
+  }
+  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.4rem; }
+  h2 { margin-top: 2.4rem; }
+  blockquote {
+    border-left: 3px solid var(--accent);
+    padding: 0.4rem 1rem;
+    color: var(--muted);
+    background: var(--code-bg);
+    margin: 1.2rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  table { border-collapse: collapse; margin: 1rem 0; width: 100%; }
+  th, td { border: 1px solid var(--rule); padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }
+  th { background: var(--code-bg); }
+  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
+  .mermaid {
+    background: #fff;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 1.5rem 0;
+  }
+  .legend { font-size: 0.94em; }
+  .legend li { margin: 0.3rem 0; }
+  .nav { font-size: 0.9em; color: var(--muted); margin-bottom: 1rem; }
+  .nav a { color: inherit; }
+</style>
+</head>
+<body>
+
+<div class="nav">
+  <a href="./README.md">← diagrams index</a> &middot;
+  <a href="../README.md">docs index</a>
+</div>
+
+<h1>Internal Architecture</h1>
+
+<p>What lives inside the running game: how the React frontend, FastAPI backend, and Supabase Postgres talk to each other, and what travels over each edge.</p>
+
+<blockquote>
+  <strong>The single most important detail</strong>: the buzzer (<code>buzz_in</code>) goes browser → Supabase <strong>directly</strong>, bypassing FastAPI entirely. That's how a &lt;200ms hot path coexists with free-tier Python hosting that has 2–30s cold starts. See <code>realtime-design.md</code> for the full reasoning.
+</blockquote>
+
+<h2>Component map</h2>
+
+<pre class="mermaid">
+flowchart TB
+    subgraph BROWSER["Browser (React + Vite SPA)"]
+        direction LR
+        Mgr["Manager<br/>console"]
+        Tm["Team<br/>buzzer"]
+        Disp["Display<br/>screen"]
+    end
+
+    subgraph RENDER["FastAPI on Render"]
+        direction TB
+        Health["/health"]
+        Games["/games/*<br/>create / join / select-song /<br/>award-points / bonus / end / kick"]
+        Admin["/admin/songs<br/>CRUD + bulk-import"]
+        Genres["/genres"]
+    end
+
+    subgraph SUPA["Supabase"]
+        direction TB
+        PostgREST["PostgREST<br/>HTTP → SQL"]
+        Realtime["Realtime<br/>WebSocket"]
+        subgraph PG["Postgres 15"]
+            direction TB
+            Tephem[("Ephemeral<br/>active_games /<br/>game_teams /<br/>game_rounds<br/>(4h TTL)")]
+            Tdurable[("Durable<br/>songs /<br/>genres /<br/>song_genres")]
+            RPC{{"PL/pgSQL<br/>buzz_in / start_round /<br/>award_points / award_bonus /<br/>end_game / cleanup_expired_games"}}
+            Cron[/"pg_cron<br/>cleanup every hour"/]
+            RLS[/"RLS policies<br/>anon SELECT only"/]
+        end
+    end
+
+    Mgr -.->|"REST<br/>X-Manager-Token (per-game uuid)"| Games
+    Mgr -.->|"REST<br/>X-Admin-Password"| Admin
+    BROWSER -.->|"REST (open)"| Genres
+    Tm ==>|"PostgREST RPC<br/>anon key<br/>buzz_in &lt;200ms"| PostgREST
+    BROWSER ==>|"WSS subscribe<br/>active_games / game_teams /<br/>game_rounds for game_code"| Realtime
+
+    Games -->|"service-role key"| Tephem
+    Admin -->|"service-role key"| Tdurable
+    Genres -->|"service-role key"| Tdurable
+    PostgREST --> RPC
+    RPC --> Tephem
+    RPC --> Tdurable
+    Cron --> Tephem
+    Realtime -.->|"logical replication"| Tephem
+    RLS -.- Tephem
+    RLS -.- Tdurable
+
+    classDef hot fill:#fff3cd,stroke:#cc6600,stroke-width:3px,color:#000
+    classDef cold fill:#e8f0fe,stroke:#1a73e8,color:#000
+    classDef store fill:#f1f8e9,stroke:#558b2f,color:#000
+    class Tm,PostgREST,RPC hot
+    class Games,Admin,Genres,Health cold
+    class Tephem,Tdurable store
+</pre>
+
+<p class="legend"><strong>Legend</strong></p>
+<ul class="legend">
+  <li><strong>Yellow / thick edges</strong> = the buzzer hot path. Browser fires <code>supabase.rpc('buzz_in', ...)</code> over PostgREST; Postgres does an atomic conditional <code>UPDATE</code>; Realtime fans the row change to all subscribers. No Python in the loop.</li>
+  <li><strong>Blue / dashed edges</strong> = REST traffic to FastAPI. Cold-start tolerant: game creation, song selection, scoring, admin CRUD. Always uses the service-role key server-side.</li>
+  <li><strong>Solid arrows</strong> = synchronous request/response. <strong>Dashed arrows</strong> = subscription / pub-sub.</li>
+</ul>
+
+<h2>Auth surfaces (who can hit what)</h2>
+
+<table>
+<thead><tr><th>Caller</th><th>Path</th><th>Header / key</th><th>Why</th></tr></thead>
+<tbody>
+<tr><td>Anonymous browser</td><td><code>POST /games</code></td><td>none</td><td>Open hosting; returns the per-game <code>manager_token</code></td></tr>
+<tr><td>Anonymous browser</td><td><code>POST /games/{code}/teams</code></td><td>none</td><td>Players just need to know the code</td></tr>
+<tr><td>Anonymous browser</td><td><code>supabase.rpc('buzz_in')</code></td><td>anon JWT (RLS)</td><td>Hot path; the only RPC <code>anon</code> is <code>GRANT EXECUTE</code>'d on</td></tr>
+<tr><td>Anonymous browser</td><td><code>SELECT</code> on game-scoped rows</td><td>anon JWT (RLS)</td><td>RLS allows SELECT, denies all writes</td></tr>
+<tr><td>Manager browser</td><td><code>POST /games/{code}/{select-song,award-points,bonus,end}</code></td><td><code>X-Manager-Token</code></td><td>Per-game uuid stored on <code>active_games</code>, mirrored in localStorage</td></tr>
+<tr><td>Manager browser</td><td><code>DELETE /games/{code}/teams/{team_id}</code></td><td><code>X-Manager-Token</code></td><td>Same</td></tr>
+<tr><td>Admin browser</td><td><code>/admin/songs/*</code></td><td><code>X-Admin-Password</code></td><td>Single env-var password, constant-time compared</td></tr>
+<tr><td>FastAPI itself</td><td>Anything via <code>supabase-py</code></td><td>service-role key</td><td>Server-side only; never reaches the browser bundle</td></tr>
+</tbody>
+</table>
+
+<p>The <code>manager_token</code> was added in 2026-05-06 (<code>migrations/012_manager_token.sql</code>) when the global manager-password gate was retired in favour of open hosting.</p>
+
+<h2>Hot-path sequence: a buzz race</h2>
+
+<p>Two teams click the buzzer within ~50ms of each other. Postgres serializes them and exactly one wins. The other clients learn the result over Realtime.</p>
+
+<pre class="mermaid">
+sequenceDiagram
+    autonumber
+    participant T1 as Team 1 (browser)
+    participant T2 as Team 2 (browser)
+    participant PR as PostgREST
+    participant PG as Postgres (buzz_in)
+    participant RT as Realtime
+    participant Mgr as Manager / Display
+
+    par Concurrent buzzes
+        T1->>PR: POST /rest/v1/rpc/buzz_in
+        PR->>PG: SELECT buzz_in('A1B2C3', team1_uuid)
+    and
+        T2->>PR: POST /rest/v1/rpc/buzz_in
+        PR->>PG: SELECT buzz_in('A1B2C3', team2_uuid)
+    end
+
+    Note over PG: UPDATE active_games<br/>SET buzzed_team_id = $2<br/>WHERE buzzed_team_id IS NULL<br/>RETURNING ...
+
+    PG-->>PR: T1 result: locked=true
+    PG-->>PR: T2 result: locked=false
+    PR-->>T1: { locked: true, team_id: t1 }
+    PR-->>T2: { locked: false, team_id: t1 }
+
+    PG-)RT: WAL change on active_games
+    RT-)Mgr: row update {buzzed_team_id: t1}
+    RT-)T1: row update
+    RT-)T2: row update
+
+    Note over T1,Mgr: All four contexts agree on the winner<br/>within ~80–180ms total
+</pre>
+
+<p>Why this works: Postgres' <code>UPDATE ... WHERE buzzed_team_id IS NULL</code> is atomic at row level. The first call to land sets the field; the second sees zero rows affected and returns <code>locked=false</code>. There is no separate read-then-write that could lose to a race.</p>
+
+<h2>What's deliberately <em>not</em> here</h2>
+
+<ul>
+  <li>No object storage. Audio is YouTube IFrame Player only — the catalog stores <code>youtube_id</code> + <code>start_time</code>.</li>
+  <li>No state-management library. React local state + Supabase Realtime is the entire client model.</li>
+  <li>No user accounts or JWT identity. The two credentials in the system (<code>X-Manager-Token</code>, <code>X-Admin-Password</code>) are scoped to specific surfaces; there is no profile, no login, no session.</li>
+  <li>No WebSocket service in FastAPI. Supabase Realtime is the broadcast plane.</li>
+</ul>
+
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+  mermaid.initialize({ startOnLoad: true, theme: "default", securityLevel: "loose" });
+</script>
+
+</body>
+</html>

--- a/docs/diagrams/internal.html
+++ b/docs/diagrams/internal.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-page="internal">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -10,32 +10,13 @@
 </head>
 <body>
 
-<header class="topnav">
-  <div class="topnav-inner">
-    <a class="topnav-brand" href="../"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
-    <nav class="topnav-crumbs">
-      <a href="../">Docs</a><span class="sep">/</span>
-      <a href="./README.md">Diagrams</a><span class="sep">/</span>
-      <span>Internal architecture</span>
-    </nav>
-    <div class="topnav-links">
-      <a href="./external.html">
-        <span class="label">External →</span>
-      </a>
-      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
-        <span class="label">GitHub</span>
-        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
-      </a>
-      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
-        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
-      </button>
-    </div>
-  </div>
-</header>
+<a class="skip-link" href="#content">Skip to content</a>
+
+<!-- Top nav rendered by assets/script.js -->
+<header id="topnav"></header>
 
 <div class="layout-with-toc">
-  <main>
+  <main id="content">
     <h1>Internal architecture</h1>
     <p class="lead">What lives inside the running game: how the React frontend, FastAPI backend, and Supabase Postgres talk to each other, and what travels over each edge.</p>
 
@@ -181,9 +162,12 @@ sequenceDiagram
       <li><strong>No WebSocket service in FastAPI.</strong> Supabase Realtime is the broadcast plane.</li>
     </ul>
 
+    <!-- Prev/next nav rendered by assets/script.js -->
+    <nav id="page-nav" aria-label="Page navigation"></nav>
+
     <footer class="footer">
-      <span>Next: <a href="./external.html">External services →</a></span>
       <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md">View Markdown source</a></span>
+      <span><a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a></span>
     </footer>
 
   </main>

--- a/docs/diagrams/internal.html
+++ b/docs/diagrams/internal.html
@@ -12,8 +12,9 @@
 
 <a class="skip-link" href="#content">Skip to content</a>
 
-<!-- Top nav rendered by assets/script.js -->
-<header id="topnav"></header>
+<!-- Top nav: CSS class applied here so the bar has stable height from
+     first paint; assets/script.js populates the inner content. -->
+<header id="topnav" class="topnav"></header>
 
 <div class="layout-with-toc">
   <main id="content">
@@ -162,8 +163,8 @@ sequenceDiagram
       <li><strong>No WebSocket service in FastAPI.</strong> Supabase Realtime is the broadcast plane.</li>
     </ul>
 
-    <!-- Prev/next nav rendered by assets/script.js -->
-    <nav id="page-nav" aria-label="Page navigation"></nav>
+    <!-- Prev/next nav populated by assets/script.js -->
+    <nav id="page-nav" class="page-nav" aria-label="Page navigation"></nav>
 
     <footer class="footer">
       <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md">View Markdown source</a></span>

--- a/docs/diagrams/internal.html
+++ b/docs/diagrams/internal.html
@@ -3,74 +3,50 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Sound Clash — Internal Architecture</title>
-<style>
-  :root {
-    --bg: #fafafa;
-    --fg: #1a1a1a;
-    --muted: #666;
-    --accent: #cc6600;
-    --rule: #e5e5e5;
-    --code-bg: #f3f3f3;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; }
-  }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
-    background: var(--bg);
-    color: var(--fg);
-    line-height: 1.55;
-  }
-  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.4rem; }
-  h2 { margin-top: 2.4rem; }
-  blockquote {
-    border-left: 3px solid var(--accent);
-    padding: 0.4rem 1rem;
-    color: var(--muted);
-    background: var(--code-bg);
-    margin: 1.2rem 0;
-    border-radius: 0 4px 4px 0;
-  }
-  table { border-collapse: collapse; margin: 1rem 0; width: 100%; }
-  th, td { border: 1px solid var(--rule); padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }
-  th { background: var(--code-bg); }
-  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
-  .mermaid {
-    background: #fff;
-    border: 1px solid var(--rule);
-    border-radius: 6px;
-    padding: 1rem;
-    overflow-x: auto;
-    margin: 1.5rem 0;
-  }
-  .legend { font-size: 0.94em; }
-  .legend li { margin: 0.3rem 0; }
-  .nav { font-size: 0.9em; color: var(--muted); margin-bottom: 1rem; }
-  .nav a { color: inherit; }
-</style>
+<title>Internal Architecture — Sound Clash</title>
+<meta name="description" content="Component map of the Sound Clash backend: browser ↔ FastAPI ↔ Supabase, plus the buzzer hot path." />
+<link rel="stylesheet" href="../assets/style.css" />
+<script defer src="../assets/script.js"></script>
 </head>
 <body>
 
-<div class="nav">
-  <a href="./README.md">← diagrams index</a> &middot;
-  <a href="../README.md">docs index</a>
-</div>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="topnav-brand" href="../"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
+    <nav class="topnav-crumbs">
+      <a href="../">Docs</a><span class="sep">/</span>
+      <a href="./README.md">Diagrams</a><span class="sep">/</span>
+      <span>Internal architecture</span>
+    </nav>
+    <div class="topnav-links">
+      <a href="./external.html">
+        <span class="label">External →</span>
+      </a>
+      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
+        <span class="label">GitHub</span>
+        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
+      </a>
+      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
+        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
+      </button>
+    </div>
+  </div>
+</header>
 
-<h1>Internal Architecture</h1>
+<div class="layout-with-toc">
+  <main>
+    <h1>Internal architecture</h1>
+    <p class="lead">What lives inside the running game: how the React frontend, FastAPI backend, and Supabase Postgres talk to each other, and what travels over each edge.</p>
 
-<p>What lives inside the running game: how the React frontend, FastAPI backend, and Supabase Postgres talk to each other, and what travels over each edge.</p>
+    <blockquote>
+      <strong>The single most important detail:</strong> the buzzer (<code>buzz_in</code>) goes browser → Supabase <strong>directly</strong>, bypassing FastAPI entirely. That's how a &lt;200ms hot path coexists with free-tier Python hosting that has 2–30s cold starts. See <code>realtime-design.md</code> for the full reasoning.
+    </blockquote>
 
-<blockquote>
-  <strong>The single most important detail</strong>: the buzzer (<code>buzz_in</code>) goes browser → Supabase <strong>directly</strong>, bypassing FastAPI entirely. That's how a &lt;200ms hot path coexists with free-tier Python hosting that has 2–30s cold starts. See <code>realtime-design.md</code> for the full reasoning.
-</blockquote>
+    <h2 id="component-map">Component map</h2>
 
-<h2>Component map</h2>
-
-<pre class="mermaid">
+    <div class="diagram">
+      <pre class="mermaid">
 flowchart TB
     subgraph BROWSER["Browser (React + Vite SPA)"]
         direction LR
@@ -124,38 +100,44 @@ flowchart TB
     class Tm,PostgREST,RPC hot
     class Games,Admin,Genres,Health cold
     class Tephem,Tdurable store
-</pre>
+      </pre>
+    </div>
 
-<p class="legend"><strong>Legend</strong></p>
-<ul class="legend">
-  <li><strong>Yellow / thick edges</strong> = the buzzer hot path. Browser fires <code>supabase.rpc('buzz_in', ...)</code> over PostgREST; Postgres does an atomic conditional <code>UPDATE</code>; Realtime fans the row change to all subscribers. No Python in the loop.</li>
-  <li><strong>Blue / dashed edges</strong> = REST traffic to FastAPI. Cold-start tolerant: game creation, song selection, scoring, admin CRUD. Always uses the service-role key server-side.</li>
-  <li><strong>Solid arrows</strong> = synchronous request/response. <strong>Dashed arrows</strong> = subscription / pub-sub.</li>
-</ul>
+    <div class="legend">
+      <p class="legend-title">Legend</p>
+      <ul>
+        <li><strong>Yellow / thick edges</strong> — the buzzer hot path. Browser fires <code>supabase.rpc('buzz_in', ...)</code> over PostgREST; Postgres does an atomic conditional <code>UPDATE</code>; Realtime fans the row change to all subscribers. No Python in the loop.</li>
+        <li><strong>Blue / dashed edges</strong> — REST traffic to FastAPI. Cold-start tolerant: game creation, song selection, scoring, admin CRUD. Always uses the service-role key server-side.</li>
+        <li><strong>Solid arrows</strong> — synchronous request/response. <strong>Dashed arrows</strong> — subscription / pub-sub.</li>
+      </ul>
+    </div>
 
-<h2>Auth surfaces (who can hit what)</h2>
+    <h2 id="auth-surfaces">Auth surfaces</h2>
+    <p>Who can hit what, and with which credential:</p>
 
-<table>
-<thead><tr><th>Caller</th><th>Path</th><th>Header / key</th><th>Why</th></tr></thead>
-<tbody>
-<tr><td>Anonymous browser</td><td><code>POST /games</code></td><td>none</td><td>Open hosting; returns the per-game <code>manager_token</code></td></tr>
-<tr><td>Anonymous browser</td><td><code>POST /games/{code}/teams</code></td><td>none</td><td>Players just need to know the code</td></tr>
-<tr><td>Anonymous browser</td><td><code>supabase.rpc('buzz_in')</code></td><td>anon JWT (RLS)</td><td>Hot path; the only RPC <code>anon</code> is <code>GRANT EXECUTE</code>'d on</td></tr>
-<tr><td>Anonymous browser</td><td><code>SELECT</code> on game-scoped rows</td><td>anon JWT (RLS)</td><td>RLS allows SELECT, denies all writes</td></tr>
-<tr><td>Manager browser</td><td><code>POST /games/{code}/{select-song,award-points,bonus,end}</code></td><td><code>X-Manager-Token</code></td><td>Per-game uuid stored on <code>active_games</code>, mirrored in localStorage</td></tr>
-<tr><td>Manager browser</td><td><code>DELETE /games/{code}/teams/{team_id}</code></td><td><code>X-Manager-Token</code></td><td>Same</td></tr>
-<tr><td>Admin browser</td><td><code>/admin/songs/*</code></td><td><code>X-Admin-Password</code></td><td>Single env-var password, constant-time compared</td></tr>
-<tr><td>FastAPI itself</td><td>Anything via <code>supabase-py</code></td><td>service-role key</td><td>Server-side only; never reaches the browser bundle</td></tr>
-</tbody>
-</table>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Caller</th><th>Path</th><th>Header / key</th><th>Why</th></tr></thead>
+        <tbody>
+          <tr><td>Anonymous browser</td><td><code>POST /games</code></td><td>none</td><td>Open hosting; returns the per-game <code>manager_token</code></td></tr>
+          <tr><td>Anonymous browser</td><td><code>POST /games/{code}/teams</code></td><td>none</td><td>Players just need to know the code</td></tr>
+          <tr><td>Anonymous browser</td><td><code>supabase.rpc('buzz_in')</code></td><td>anon JWT (RLS)</td><td>Hot path; the only RPC <code>anon</code> is <code>GRANT EXECUTE</code>'d on</td></tr>
+          <tr><td>Anonymous browser</td><td><code>SELECT</code> on game-scoped rows</td><td>anon JWT (RLS)</td><td>RLS allows SELECT, denies all writes</td></tr>
+          <tr><td>Manager browser</td><td><code>POST /games/{code}/{select-song,award-points,bonus,end}</code></td><td><code>X-Manager-Token</code></td><td>Per-game uuid stored on <code>active_games</code>, mirrored in localStorage</td></tr>
+          <tr><td>Manager browser</td><td><code>DELETE /games/{code}/teams/{team_id}</code></td><td><code>X-Manager-Token</code></td><td>Same</td></tr>
+          <tr><td>Admin browser</td><td><code>/admin/songs/*</code></td><td><code>X-Admin-Password</code></td><td>Single env-var password, constant-time compared</td></tr>
+          <tr><td>FastAPI itself</td><td>Anything via <code>supabase-py</code></td><td>service-role key</td><td>Server-side only; never reaches the browser bundle</td></tr>
+        </tbody>
+      </table>
+    </div>
 
-<p>The <code>manager_token</code> was added in 2026-05-06 (<code>migrations/012_manager_token.sql</code>) when the global manager-password gate was retired in favour of open hosting.</p>
+    <p class="muted small">The <code>manager_token</code> was added in 2026-05-06 (<code>migrations/012_manager_token.sql</code>) when the global manager-password gate was retired in favour of open hosting.</p>
 
-<h2>Hot-path sequence: a buzz race</h2>
+    <h2 id="buzz-race">Hot-path sequence: a buzz race</h2>
+    <p>Two teams click the buzzer within ~50ms of each other. Postgres serializes them and exactly one wins. The other clients learn the result over Realtime.</p>
 
-<p>Two teams click the buzzer within ~50ms of each other. Postgres serializes them and exactly one wins. The other clients learn the result over Realtime.</p>
-
-<pre class="mermaid">
+    <div class="diagram">
+      <pre class="mermaid">
 sequenceDiagram
     autonumber
     participant T1 as Team 1 (browser)
@@ -186,23 +168,36 @@ sequenceDiagram
     RT-)T2: row update
 
     Note over T1,Mgr: All four contexts agree on the winner<br/>within ~80–180ms total
-</pre>
+      </pre>
+    </div>
 
-<p>Why this works: Postgres' <code>UPDATE ... WHERE buzzed_team_id IS NULL</code> is atomic at row level. The first call to land sets the field; the second sees zero rows affected and returns <code>locked=false</code>. There is no separate read-then-write that could lose to a race.</p>
+    <p>Why this works: Postgres' <code>UPDATE ... WHERE buzzed_team_id IS NULL</code> is atomic at row level. The first call to land sets the field; the second sees zero rows affected and returns <code>locked=false</code>. There is no separate read-then-write that could lose to a race.</p>
 
-<h2>What's deliberately <em>not</em> here</h2>
+    <h2 id="not-here">What's deliberately <em>not</em> here</h2>
+    <ul>
+      <li><strong>No object storage.</strong> Audio is YouTube IFrame Player only — the catalog stores <code>youtube_id</code> + <code>start_time</code>.</li>
+      <li><strong>No state-management library.</strong> React local state + Supabase Realtime is the entire client model.</li>
+      <li><strong>No user accounts or JWT identity.</strong> The two credentials in the system (<code>X-Manager-Token</code>, <code>X-Admin-Password</code>) are scoped to specific surfaces; there is no profile, no login, no session.</li>
+      <li><strong>No WebSocket service in FastAPI.</strong> Supabase Realtime is the broadcast plane.</li>
+    </ul>
 
-<ul>
-  <li>No object storage. Audio is YouTube IFrame Player only — the catalog stores <code>youtube_id</code> + <code>start_time</code>.</li>
-  <li>No state-management library. React local state + Supabase Realtime is the entire client model.</li>
-  <li>No user accounts or JWT identity. The two credentials in the system (<code>X-Manager-Token</code>, <code>X-Admin-Password</code>) are scoped to specific surfaces; there is no profile, no login, no session.</li>
-  <li>No WebSocket service in FastAPI. Supabase Realtime is the broadcast plane.</li>
-</ul>
+    <footer class="footer">
+      <span>Next: <a href="./external.html">External services →</a></span>
+      <span><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md">View Markdown source</a></span>
+    </footer>
 
-<script type="module">
-  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
-  mermaid.initialize({ startOnLoad: true, theme: "default", securityLevel: "loose" });
-</script>
+  </main>
+
+  <aside class="toc">
+    <p class="toc-title">On this page</p>
+    <ul>
+      <li><a href="#component-map">Component map</a></li>
+      <li><a href="#auth-surfaces">Auth surfaces</a></li>
+      <li><a href="#buzz-race">Buzz race sequence</a></li>
+      <li><a href="#not-here">What's not here</a></li>
+    </ul>
+  </aside>
+</div>
 
 </body>
 </html>

--- a/docs/diagrams/internal.md
+++ b/docs/diagrams/internal.md
@@ -1,0 +1,130 @@
+# Internal Architecture
+
+What lives inside the running game: how the React frontend, FastAPI backend, and Supabase Postgres talk to each other, and what travels over each edge.
+
+> **The single most important detail**: the buzzer (`buzz_in`) goes browser → Supabase **directly**, bypassing FastAPI entirely. That's how a <200ms hot path coexists with free-tier Python hosting that has 2–30s cold starts. See `realtime-design.md` for the full reasoning.
+
+## Component map
+
+```mermaid
+flowchart TB
+    subgraph BROWSER["Browser (React + Vite SPA)"]
+        direction LR
+        Mgr["Manager<br/>console"]
+        Tm["Team<br/>buzzer"]
+        Disp["Display<br/>screen"]
+    end
+
+    subgraph RENDER["FastAPI on Render"]
+        direction TB
+        Health["/health"]
+        Games["/games/*<br/>create / join / select-song /<br/>award-points / bonus / end / kick"]
+        Admin["/admin/songs<br/>CRUD + bulk-import"]
+        Genres["/genres"]
+    end
+
+    subgraph SUPA["Supabase"]
+        direction TB
+        PostgREST["PostgREST<br/>HTTP → SQL"]
+        Realtime["Realtime<br/>WebSocket"]
+        subgraph PG["Postgres 15"]
+            direction TB
+            Tephem[("Ephemeral<br/>active_games /<br/>game_teams /<br/>game_rounds<br/>(4h TTL)")]
+            Tdurable[("Durable<br/>songs /<br/>genres /<br/>song_genres")]
+            RPC{{"PL/pgSQL<br/>buzz_in / start_round /<br/>award_points / award_bonus /<br/>end_game / cleanup_expired_games"}}
+            Cron[/"pg_cron<br/>cleanup every hour"/]
+            RLS[/"RLS policies<br/>anon SELECT only"/]
+        end
+    end
+
+    Mgr -.->|"REST<br/>X-Manager-Token (per-game uuid)"| Games
+    Mgr -.->|"REST<br/>X-Admin-Password"| Admin
+    BROWSER -.->|"REST (open)"| Genres
+    Tm ==>|"PostgREST RPC<br/>anon key<br/>buzz_in &lt;200ms"| PostgREST
+    BROWSER ==>|"WSS subscribe<br/>active_games / game_teams /<br/>game_rounds for game_code"| Realtime
+
+    Games -->|"service-role key"| Tephem
+    Admin -->|"service-role key"| Tdurable
+    Genres -->|"service-role key"| Tdurable
+    PostgREST --> RPC
+    RPC --> Tephem
+    RPC --> Tdurable
+    Cron --> Tephem
+    Realtime -.->|"logical replication"| Tephem
+    RLS -.- Tephem
+    RLS -.- Tdurable
+
+    classDef hot fill:#fff3cd,stroke:#cc6600,stroke-width:3px,color:#000
+    classDef cold fill:#e8f0fe,stroke:#1a73e8,color:#000
+    classDef store fill:#f1f8e9,stroke:#558b2f,color:#000
+    class Tm,PostgREST,RPC hot
+    class Games,Admin,Genres,Health cold
+    class Tephem,Tdurable store
+```
+
+**Legend**
+
+- **Yellow / thick edges** = the buzzer hot path. Browser fires `supabase.rpc('buzz_in', ...)` over PostgREST; Postgres does an atomic conditional `UPDATE`; Realtime fans the row change to all subscribers. No Python in the loop.
+- **Blue / dashed edges** = REST traffic to FastAPI. Cold-start tolerant: game creation, song selection, scoring, admin CRUD. Always uses the service-role key server-side.
+- **Solid arrows** = synchronous request/response. **Dashed arrows** = subscription / pub-sub.
+
+## Auth surfaces (who can hit what)
+
+| Caller | Path | Header / key | Why |
+|---|---|---|---|
+| Anonymous browser | `POST /games` | none | Open hosting; returns the per-game `manager_token` |
+| Anonymous browser | `POST /games/{code}/teams` | none | Players just need to know the code |
+| Anonymous browser | `supabase.rpc('buzz_in')` | anon JWT (RLS) | Hot path; the only RPC `anon` is `GRANT EXECUTE`d on |
+| Anonymous browser | `SELECT` on game-scoped rows | anon JWT (RLS) | RLS allows SELECT, denies all writes |
+| Manager browser | `POST /games/{code}/{select-song,award-points,bonus,end}` | `X-Manager-Token` | Per-game uuid stored on `active_games`, mirrored in localStorage |
+| Manager browser | `DELETE /games/{code}/teams/{team_id}` | `X-Manager-Token` | Same |
+| Admin browser | `/admin/songs/*` | `X-Admin-Password` | Single env-var password, constant-time compared |
+| FastAPI itself | Anything via `supabase-py` | service-role key | Server-side only; never reaches the browser bundle |
+
+The `manager_token` was added in 2026-05-06 (`migrations/012_manager_token.sql`) when the global manager-password gate was retired in favour of open hosting.
+
+## Hot-path sequence: a buzz race
+
+Two teams click the buzzer within ~50ms of each other. Postgres serializes them and exactly one wins. The other clients learn the result over Realtime.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T1 as Team 1 (browser)
+    participant T2 as Team 2 (browser)
+    participant PR as PostgREST
+    participant PG as Postgres (buzz_in)
+    participant RT as Realtime
+    participant Mgr as Manager / Display
+
+    par Concurrent buzzes
+        T1->>PR: POST /rest/v1/rpc/buzz_in
+        PR->>PG: SELECT buzz_in('A1B2C3', team1_uuid)
+    and
+        T2->>PR: POST /rest/v1/rpc/buzz_in
+        PR->>PG: SELECT buzz_in('A1B2C3', team2_uuid)
+    end
+
+    Note over PG: UPDATE active_games<br/>SET buzzed_team_id = $2<br/>WHERE buzzed_team_id IS NULL<br/>RETURNING ...
+
+    PG-->>PR: T1 result: locked=true
+    PG-->>PR: T2 result: locked=false
+    PR-->>T1: { locked: true, team_id: t1 }
+    PR-->>T2: { locked: false, team_id: t1 }
+
+    PG-)RT: WAL change on active_games
+    RT-)Mgr: row update {buzzed_team_id: t1}
+    RT-)T1: row update
+    RT-)T2: row update
+
+    Note over T1,Mgr: All four contexts agree on the winner<br/>within ~80–180ms total
+```
+
+Why this works: Postgres' `UPDATE ... WHERE buzzed_team_id IS NULL` is atomic at row level. The first call to land sets the field; the second sees zero rows affected and returns `locked=false`. There is no separate read-then-write that could lose to a race.
+
+## What's deliberately **not** here
+
+- No object storage. Audio is YouTube IFrame Player only — the catalog stores `youtube_id` + `start_time`.
+- No state-management library. React local state + Supabase Realtime is the entire client model.
+- No user accounts or JWT identity. The two credentials in the system (`X-Manager-Token`, `X-Admin-Password`) are scoped to specific surfaces; there is no profile, no login, no session.
+- No WebSocket service in FastAPI. Supabase Realtime is the broadcast plane.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-page="home">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -10,28 +10,12 @@
 </head>
 <body>
 
-<header class="topnav">
-  <div class="topnav-inner">
-    <a class="topnav-brand" href="./"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
-    <nav class="topnav-crumbs"></nav>
-    <div class="topnav-links">
-      <a href="https://soundclash.org" target="_blank" rel="noopener">
-        <span class="label">Live game</span>
-        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V8a.5.5 0 0 0-1 0v4.5a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5H8a.5.5 0 0 0 0-1z"/><path d="M9.146.146A.5.5 0 0 1 9.5 0h5a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-1 0V1.707L6.354 9.354a.5.5 0 1 1-.708-.708L13.293 1H9.5a.5.5 0 0 1-.354-.854"/></svg>
-      </a>
-      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
-        <span class="label">GitHub</span>
-        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
-      </a>
-      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
-        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
-        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
-      </button>
-    </div>
-  </div>
-</header>
+<a class="skip-link" href="#content">Skip to content</a>
 
-<div class="container">
+<!-- Top nav rendered by assets/script.js -->
+<header id="topnav"></header>
+
+<main id="content" class="container">
 
   <section class="hero">
     <h1>Sound Clash <span class="muted">documentation</span></h1>
@@ -114,12 +98,15 @@
     </ul>
   </details>
 
+  <!-- Prev/next nav rendered by assets/script.js -->
+  <nav id="page-nav" aria-label="Page navigation"></nav>
+
   <footer class="footer">
     <span>Sound Clash — free-tier multiplayer music trivia</span>
     <span><a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a></span>
   </footer>
 
-</div>
+</main>
 
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,9 @@
 
 <a class="skip-link" href="#content">Skip to content</a>
 
-<!-- Top nav rendered by assets/script.js -->
-<header id="topnav"></header>
+<!-- Top nav: CSS class applied here so the bar has stable height from
+     first paint; assets/script.js populates the inner content. -->
+<header id="topnav" class="topnav"></header>
 
 <main id="content" class="container">
 
@@ -98,8 +99,8 @@
     </ul>
   </details>
 
-  <!-- Prev/next nav rendered by assets/script.js -->
-  <nav id="page-nav" aria-label="Page navigation"></nav>
+  <!-- Prev/next nav populated by assets/script.js -->
+  <nav id="page-nav" class="page-nav" aria-label="Page navigation"></nav>
 
   <footer class="footer">
     <span>Sound Clash — free-tier multiplayer music trivia</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sound Clash — Documentation</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --accent: #cc6600;
+    --rule: #e5e5e5;
+    --code-bg: #f3f3f3;
+    --link: #1a73e8;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; --link: #8ab4f8; }
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.6;
+  }
+  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.5rem; margin-top: 0; }
+  h2 { margin-top: 2.4rem; border-bottom: 1px solid var(--rule); padding-bottom: 0.3rem; }
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
+  ul { padding-left: 1.4rem; }
+  li { margin: 0.45rem 0; }
+  .muted { color: var(--muted); font-size: 0.92em; }
+  .lead { font-size: 1.05em; }
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+    margin: 1.2rem 0 0;
+  }
+  .card {
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 1rem 1.2rem;
+    background: var(--code-bg);
+  }
+  .card h3 { margin: 0 0 0.4rem; font-size: 1.05em; }
+  .card p { margin: 0.4rem 0 0; color: var(--muted); font-size: 0.92em; }
+  .card a.title { color: var(--fg); }
+  .footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.9em; }
+</style>
+</head>
+<body>
+
+<h1>Sound Clash — Documentation</h1>
+
+<p class="lead">Real-time multiplayer music-trivia buzzer game. Play it at <a href="https://soundclash.org">soundclash.org</a>.</p>
+<p class="muted">This site hosts the rendered architecture diagrams. The full text documentation lives in the <a href="https://github.com/BenArtzi4/Sound-Clash/tree/main/docs"><code>docs/</code> folder on GitHub</a>, where Markdown renders inline.</p>
+
+<h2>Diagrams</h2>
+
+<div class="card-grid">
+  <div class="card">
+    <h3><a class="title" href="diagrams/internal.html">Internal architecture →</a></h3>
+    <p>What lives inside the running game: browser ↔ FastAPI ↔ Supabase. Component map, buzz-race sequence diagram, auth surface table.</p>
+  </div>
+  <div class="card">
+    <h3><a class="title" href="diagrams/external.html">External services →</a></h3>
+    <p>The third-party services around the game: Cloudflare, Render, Supabase, Sentry, GitHub Actions, CodeQL, Dependabot, Codecov. Service map, deploy sequence, secret-store matrix.</p>
+  </div>
+</div>
+
+<h2>Text documentation</h2>
+
+<p class="muted">These render as Markdown on GitHub. Start with <code>architecture.md</code> for the executive overview.</p>
+
+<h3>Read in this order</h3>
+<ul>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/architecture.md">architecture.md</a> — executive summary; one-page overview</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/realtime-design.md">realtime-design.md</a> — the central design decision: why no Python in the buzzer path</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tech-stack.md">tech-stack.md</a> — concrete services with free-tier limits</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/game-rules.md">game-rules.md</a> — gameplay flow, state machine, scoring</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/data-model.md">data-model.md</a> — schema, indexes, ER diagram</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/rpc-functions.md">rpc-functions.md</a> — the six PL/pgSQL functions</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/security-rls.md">security-rls.md</a> — auth, RLS, threat model, CSP</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/api-contracts.md">api-contracts.md</a> — REST + Realtime wire format</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/testing-strategy.md">testing-strategy.md</a> — test types, coverage gates</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/free-tier-budget.md">free-tier-budget.md</a> — quota analysis</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/local-development.md">local-development.md</a> — dev setup + Windows notes</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/runbook.md">runbook.md</a> — day-2+ operations</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/roadmap.md">roadmap.md</a> — phase boundaries and exit criteria</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tooling.md">tooling.md</a> — CI/CD, bots, monitoring (workflows, CodeQL, Dependabot, Codecov, …)</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tasks.md">tasks.md</a> — granular checkboxed task list</li>
+  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/aws-teardown-checklist.md">aws-teardown-checklist.md</a> — Phase 7 cutover script (historical)</li>
+</ul>
+
+<div class="footer">
+  Source: <a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a> &middot;
+  Live game: <a href="https://soundclash.org">soundclash.org</a>
+</div>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,102 +4,121 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Sound Clash — Documentation</title>
-<style>
-  :root {
-    --bg: #fafafa;
-    --fg: #1a1a1a;
-    --muted: #666;
-    --accent: #cc6600;
-    --rule: #e5e5e5;
-    --code-bg: #f3f3f3;
-    --link: #1a73e8;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root { --bg: #1a1a1a; --fg: #e8e8e8; --muted: #aaa; --rule: #333; --code-bg: #2a2a2a; --link: #8ab4f8; }
-  }
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-    max-width: 880px;
-    margin: 0 auto;
-    padding: 2.5rem 1.5rem 4rem;
-    background: var(--bg);
-    color: var(--fg);
-    line-height: 1.6;
-  }
-  h1 { border-bottom: 1px solid var(--rule); padding-bottom: 0.5rem; margin-top: 0; }
-  h2 { margin-top: 2.4rem; border-bottom: 1px solid var(--rule); padding-bottom: 0.3rem; }
-  a { color: var(--link); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.92em; }
-  ul { padding-left: 1.4rem; }
-  li { margin: 0.45rem 0; }
-  .muted { color: var(--muted); font-size: 0.92em; }
-  .lead { font-size: 1.05em; }
-  .card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1rem;
-    margin: 1.2rem 0 0;
-  }
-  .card {
-    border: 1px solid var(--rule);
-    border-radius: 6px;
-    padding: 1rem 1.2rem;
-    background: var(--code-bg);
-  }
-  .card h3 { margin: 0 0 0.4rem; font-size: 1.05em; }
-  .card p { margin: 0.4rem 0 0; color: var(--muted); font-size: 0.92em; }
-  .card a.title { color: var(--fg); }
-  .footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.9em; }
-</style>
+<meta name="description" content="Documentation and architecture diagrams for Sound Clash, a real-time multiplayer music-trivia buzzer game." />
+<link rel="stylesheet" href="assets/style.css" />
+<script defer src="assets/script.js"></script>
 </head>
 <body>
 
-<h1>Sound Clash — Documentation</h1>
-
-<p class="lead">Real-time multiplayer music-trivia buzzer game. Play it at <a href="https://soundclash.org">soundclash.org</a>.</p>
-<p class="muted">This site hosts the rendered architecture diagrams. The full text documentation lives in the <a href="https://github.com/BenArtzi4/Sound-Clash/tree/main/docs"><code>docs/</code> folder on GitHub</a>, where Markdown renders inline.</p>
-
-<h2>Diagrams</h2>
-
-<div class="card-grid">
-  <div class="card">
-    <h3><a class="title" href="diagrams/internal.html">Internal architecture →</a></h3>
-    <p>What lives inside the running game: browser ↔ FastAPI ↔ Supabase. Component map, buzz-race sequence diagram, auth surface table.</p>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="topnav-brand" href="./"><span class="dot"></span>Sound Clash <span class="muted small">docs</span></a>
+    <nav class="topnav-crumbs"></nav>
+    <div class="topnav-links">
+      <a href="https://soundclash.org" target="_blank" rel="noopener">
+        <span class="label">Live game</span>
+        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M3.5 2A1.5 1.5 0 0 0 2 3.5v9A1.5 1.5 0 0 0 3.5 14h9a1.5 1.5 0 0 0 1.5-1.5V8a.5.5 0 0 0-1 0v4.5a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5H8a.5.5 0 0 0 0-1z"/><path d="M9.146.146A.5.5 0 0 1 9.5 0h5a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-1 0V1.707L6.354 9.354a.5.5 0 1 1-.708-.708L13.293 1H9.5a.5.5 0 0 1-.354-.854"/></svg>
+      </a>
+      <a href="https://github.com/BenArtzi4/Sound-Clash" target="_blank" rel="noopener">
+        <span class="label">GitHub</span>
+        <svg class="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
+      </a>
+      <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <svg class="icon icon-moon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277q.792-.001 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278"/></svg>
+        <svg class="icon icon-sun" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/></svg>
+      </button>
+    </div>
   </div>
-  <div class="card">
-    <h3><a class="title" href="diagrams/external.html">External services →</a></h3>
-    <p>The third-party services around the game: Cloudflare, Render, Supabase, Sentry, GitHub Actions, CodeQL, Dependabot, Codecov. Service map, deploy sequence, secret-store matrix.</p>
+</header>
+
+<div class="container">
+
+  <section class="hero">
+    <h1>Sound Clash <span class="muted">documentation</span></h1>
+    <p class="lead">Real-time multiplayer music-trivia buzzer game. The buzzer is a Postgres function called directly from the browser — that's how a sub-200ms hot path coexists with free-tier hosting.</p>
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="diagrams/internal.html">View architecture diagrams →</a>
+      <a class="btn btn-secondary" href="https://soundclash.org" target="_blank" rel="noopener">Play the game</a>
+    </div>
+  </section>
+
+  <h2 id="diagrams">Diagrams</h2>
+  <p class="muted">Two visual maps of the system. Click through to see the rendered flowcharts and sequence diagrams.</p>
+
+  <div class="card-grid">
+    <div class="card">
+      <span class="card-tag">Inside the game</span>
+      <h3><a href="diagrams/internal.html">Internal architecture <span class="card-arrow">→</span></a></h3>
+      <p>How the React frontend, FastAPI backend, and Supabase Postgres talk to each other. Component map, buzz-race sequence, auth surface table.</p>
+    </div>
+    <div class="card">
+      <span class="card-tag">Outside the game</span>
+      <h3><a href="diagrams/external.html">External services <span class="card-arrow">→</span></a></h3>
+      <p>The third-party services that surround the running game: Cloudflare, Render, Supabase, Sentry, GitHub Actions, CodeQL, Dependabot, Codecov.</p>
+    </div>
   </div>
-</div>
 
-<h2>Text documentation</h2>
+  <h2 id="docs">Text documentation</h2>
+  <p class="muted">All written documentation lives as Markdown in <a href="https://github.com/BenArtzi4/Sound-Clash/tree/main/docs"><code>docs/</code> on GitHub</a>, where it renders inline. Pick a reading path:</p>
 
-<p class="muted">These render as Markdown on GitHub. Start with <code>architecture.md</code> for the executive overview.</p>
+  <details open>
+    <summary>I'm reviewing the design</summary>
+    <ul>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/architecture.md">architecture.md</a> — executive overview</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/realtime-design.md">realtime-design.md</a> — central design decision: no Python in the buzzer path</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/security-rls.md">security-rls.md</a> — auth model, RLS, threat model</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/free-tier-budget.md">free-tier-budget.md</a> — sanity-check capacity claims</li>
+    </ul>
+  </details>
 
-<h3>Read in this order</h3>
-<ul>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/architecture.md">architecture.md</a> — executive summary; one-page overview</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/realtime-design.md">realtime-design.md</a> — the central design decision: why no Python in the buzzer path</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tech-stack.md">tech-stack.md</a> — concrete services with free-tier limits</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/game-rules.md">game-rules.md</a> — gameplay flow, state machine, scoring</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/data-model.md">data-model.md</a> — schema, indexes, ER diagram</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/rpc-functions.md">rpc-functions.md</a> — the six PL/pgSQL functions</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/security-rls.md">security-rls.md</a> — auth, RLS, threat model, CSP</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/api-contracts.md">api-contracts.md</a> — REST + Realtime wire format</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/testing-strategy.md">testing-strategy.md</a> — test types, coverage gates</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/free-tier-budget.md">free-tier-budget.md</a> — quota analysis</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/local-development.md">local-development.md</a> — dev setup + Windows notes</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/runbook.md">runbook.md</a> — day-2+ operations</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/roadmap.md">roadmap.md</a> — phase boundaries and exit criteria</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tooling.md">tooling.md</a> — CI/CD, bots, monitoring (workflows, CodeQL, Dependabot, Codecov, …)</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tasks.md">tasks.md</a> — granular checkboxed task list</li>
-  <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/aws-teardown-checklist.md">aws-teardown-checklist.md</a> — Phase 7 cutover script (historical)</li>
-</ul>
+  <details>
+    <summary>I'm about to start implementing</summary>
+    <ul>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/architecture.md">architecture.md</a></li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/roadmap.md">roadmap.md</a> — phase boundaries and exit criteria</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/local-development.md">local-development.md</a> — dev setup + Windows notes</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tasks.md">tasks.md</a> — granular task list</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/rpc-functions.md">rpc-functions.md</a>, <a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/api-contracts.md">api-contracts.md</a></li>
+    </ul>
+  </details>
 
-<div class="footer">
-  Source: <a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a> &middot;
-  Live game: <a href="https://soundclash.org">soundclash.org</a>
+  <details>
+    <summary>I need to operate it in production</summary>
+    <ul>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/runbook.md">runbook.md</a> — day-2 operations</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tooling.md">tooling.md</a> — every tool that touches the repo</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/free-tier-budget.md">free-tier-budget.md</a> — alert thresholds</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/security-rls.md">security-rls.md</a> §3 (secrets), §10 (auth failures)</li>
+    </ul>
+  </details>
+
+  <details>
+    <summary>Full file index</summary>
+    <ul>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/architecture.md">architecture.md</a> — executive overview</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/realtime-design.md">realtime-design.md</a> — buzzer hot path</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tech-stack.md">tech-stack.md</a> — services + free-tier limits</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/game-rules.md">game-rules.md</a> — gameplay flow</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/data-model.md">data-model.md</a> — schema + indexes</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/rpc-functions.md">rpc-functions.md</a> — the six PL/pgSQL functions</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/security-rls.md">security-rls.md</a> — auth + RLS</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/api-contracts.md">api-contracts.md</a> — REST + Realtime contracts</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/testing-strategy.md">testing-strategy.md</a> — test types + CI gates</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/free-tier-budget.md">free-tier-budget.md</a> — quota analysis</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/local-development.md">local-development.md</a> — dev setup</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/runbook.md">runbook.md</a> — operational procedures</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/roadmap.md">roadmap.md</a> — phases</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tooling.md">tooling.md</a> — dev/CI tooling reference</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/tasks.md">tasks.md</a> — granular checkboxed tasks</li>
+      <li><a href="https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/aws-teardown-checklist.md">aws-teardown-checklist.md</a> — Phase 7 cutover (historical)</li>
+    </ul>
+  </details>
+
+  <footer class="footer">
+    <span>Sound Clash — free-tier multiplayer music trivia</span>
+    <span><a href="https://github.com/BenArtzi4/Sound-Clash">github.com/BenArtzi4/Sound-Clash</a></span>
+  </footer>
+
 </div>
 
 </body>

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -290,7 +290,7 @@ The system is designed to be **rebuildable from source** — if everything excep
 
 ## 8. Emergency Contacts
 
-- **You**: benartzi4@gmail.com
+- **You**: see your password manager (intentionally not in public docs)
 - **Supabase support** (free tier): community Discord + GitHub issues; no SLA
 - **Render support**: support@render.com (no free-tier SLA)
 - **Cloudflare**: dashboard support tab

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -193,9 +193,9 @@ PR #38 / branch `feature/scoring-revamp`. Fixes the latent free-spam-buzz bug, d
 - [x] **SCORE-10** All local gates green: `ruff`, `ruff format`, `mypy`, `tsc`, `eslint`, `vitest run` (22 files / 183 tests).
 - [x] **SCORE-11** PR #38 CI green (backend + frontend workflows).
 - [x] **SCORE-12** Merge PR #38 to `main` — triggers Render redeploy of new backend. Watch for the redeploy to finish.
-- [x] **SCORE-13** Apply `014_scoring_revamp.sql` to **prod** Supabase (`Sound-Clash` Frankfurt, `jvfddxuaqcsrguibkymp`). Verified 2026-05-07 via `pg_get_function_arguments` — `award_bonus` exists and `award_points` carries the new `p_wrong_buzz` arg. Migration is idempotent and was applied during the original PR #38 deploy.
+- [x] **SCORE-13** Apply `014_scoring_revamp.sql` to **prod** Supabase (`Sound-Clash` Frankfurt; project ref kept out of public docs — look it up in the Supabase dashboard). Verified 2026-05-07 via `pg_get_function_arguments` — `award_bonus` exists and `award_points` carries the new `p_wrong_buzz` arg. Migration is idempotent and was applied during the original PR #38 deploy.
 - [x] **SCORE-14** Three-tab manual smoke against prod — substituted by automated smokes: `tests/smoke/post_deploy.sh https://api.soundclash.org` and `tests/e2e/smoke/prod_realtime.spec.ts`. Smoke initially surfaced a separate prod regression in `_award_blocking` (PostgREST list-shape handling); fixed in PR #40.
-- [x] **SCORE-15** Re-link CLI back to preview (`supabase link --project-ref vriljyhpxfcwpqwshajv`) so future ad-hoc DB ops don't accidentally hit prod. Done 2026-05-07.
+- [x] **SCORE-15** Re-link CLI back to preview (`supabase link --project-ref <preview-project-ref>`) so future ad-hoc DB ops don't accidentally hit prod. Done 2026-05-07. The real project ref is in the Supabase dashboard.
 
 ---
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -4,7 +4,7 @@ Granular, checkboxed tasks grouped by area. Tasks within an area are roughly ord
 
 The new repo is **`Sound-Clash`** (GitHub). The legacy AWS-based repo is **`Sound-Clash-legacy`**.
 
-> **Status note (2026-05-07):** Phases 0 → 7 are shipped (production cutover complete; see `roadmap.md`). The boxes below have been reconciled against the live code; `[x]` means "in `main` and live at `https://soundclash.org`". The only remaining `[ ]` is **DOC-06** (architecture diagram). Post-launch work tracked separately under "Scoring revamp (post-Phase 7)".
+> **Status note (2026-05-07):** Phases 0 → 7 are shipped (production cutover complete; see `roadmap.md`). The boxes below have been reconciled against the live code; `[x]` means "in `main` and live at `https://soundclash.org`". All initial-phase tasks are now complete. Post-launch work tracked separately under "Scoring revamp (post-Phase 7)".
 
 ## Phase 0 — Naming
 
@@ -173,7 +173,7 @@ The new repo is **`Sound-Clash`** (GitHub). The legacy AWS-based repo is **`Soun
 - [x] **DOC-03** `docs/realtime-design.md` — copy from plan
 - [x] **DOC-04** `docs/data-model.md`, `docs/rpc-functions.md`, `docs/security-rls.md`, `docs/api-contracts.md`, `docs/game-rules.md`, `docs/tech-stack.md`, `docs/free-tier-budget.md`, `docs/local-development.md`, `docs/runbook.md` — copy from plan
 - [x] **DOC-05** `docs/aws-teardown-checklist.md` — explicit, dated checklist for the cutover
-- [ ] **DOC-06** Architecture diagram as PNG/SVG in `docs/diagrams/` (Excalidraw or Mermaid). Still missing — `architecture.md` §2 has the ASCII diagram, but no rendered image.
+- [x] **DOC-06** Architecture diagrams in `docs/diagrams/` — Mermaid in Markdown plus standalone HTML mirrors. `internal.md`/`internal.html` covers component map + buzz-race sequence; `external.md`/`external.html` covers service map + deploy sequence + secret-store matrix. Linked from `docs/README.md` and `architecture.md`.
 - [x] **DOC-07** `CONTRIBUTING.md` — coding style, PR template, test requirements
 - [x] **DOC-08** PR template `.github/pull_request_template.md` — sections: what changed, why, test plan, doc updates
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -1,0 +1,313 @@
+# Sound Clash — Tooling & Automation Guide
+
+This is the guide to every tool that touches the repo or the development workflow. The runtime services that the live game depends on (Supabase, Render, Cloudflare Pages) are documented in [`tech-stack.md`](tech-stack.md). This file covers everything *else*: CI workflows, code health, dependency bots, coverage, deploy automation, monitoring, and what runs on every PR.
+
+For the visual map of how these tools connect to the rest of the system, see [`diagrams/external.md`](diagrams/external.md).
+
+---
+
+## 1. What runs on every PR
+
+Quick reference: the checks that fire when a PR is opened against `main`.
+
+| Check | Source | Required to merge? | What it does |
+|---|---|---|---|
+| **Backend / lint + type + test** | `.github/workflows/backend.yml` | Yes (when `backend/` changes) | ruff check + format, mypy, pytest with branch coverage, `--cov-fail-under=90` |
+| **Frontend / lint + type + test** | `.github/workflows/frontend.yml` | Yes (when `frontend/` changes) | eslint, prettier, tsc, vitest with coverage, `npm run build`, service-role-leak check |
+| **CodeQL** | GitHub Default Setup | Advisory | Static analysis for security issues (JS/TS + Python) |
+| **Codecov / patch + project** | `codecov/codecov-action@v6` upload from CI | Advisory | Comments coverage delta on the PR |
+| **E2E / Playwright** | `.github/workflows/e2e.yml` | No (label-gated: `run-e2e`) | Playwright multi-context against `Sound-Clash-Preview` Supabase |
+| **Buzz race stress (100×)** | `e2e.yml` second job | No (label-gated: `run-stress`) | Race-test stress loop against an ephemeral Postgres service |
+| **DB Migrate** | `.github/workflows/db-migrate.yml` | Manual dispatch only | Applies migrations to chosen env; never auto-fires |
+
+Branch protection enforces the two "Yes" rows; details in [§10](#10-branch-protection).
+
+---
+
+## 2. GitHub Actions workflows
+
+Four workflow files under `.github/workflows/`. Each is path-filtered so it only runs when its area changes.
+
+### 2.1 `backend.yml`
+
+**Triggers**: push to `main` or PR with changes under `backend/**`, `tests/backend/**`, `tests/db/**`, or the workflow file itself. Also `workflow_dispatch` for manual reruns.
+
+**Job: `test`**
+1. Checkout
+2. Set up Python 3.11 with pip cache keyed on `backend/pyproject.toml`
+3. `pip install -e ".[dev]"` (the `[dev]` extras pull in pytest, ruff, mypy, etc.)
+4. `ruff check .`
+5. `ruff format --check .`
+6. `mypy app` (strict mode, configured in `pyproject.toml`)
+7. Reject `# pragma: no cover` in `app/` (banned per `testing-strategy.md` §2)
+8. `pytest --cov=app --cov-branch --cov-report=xml --cov-report=term-missing --cov-fail-under=90`
+9. Upload `coverage.xml` to Codecov (with `flags: backend`, `continue-on-error: true`)
+
+**Job: `deploy` (main only)**
+
+Runs after `test` succeeds, only on push to `main`. `curl -fsSL -X POST $RENDER_DEPLOY_HOOK` triggers the Render redeploy. If the secret isn't set the step prints a warning and exits 0 (handy for forks).
+
+**Failure modes**:
+- `ruff format --check` failure → run `ruff format .` locally
+- `mypy` failure → strict mode is on; add types or guard with `cast`
+- `--cov-fail-under=90` drop → add tests; never lower the threshold
+- Render hook returns non-200 → check Render dashboard; usually a Docker build issue
+
+### 2.2 `frontend.yml`
+
+**Triggers**: push to `main` or PR with changes under `frontend/**` or the workflow file.
+
+**Job: `test`**
+1. Checkout
+2. Set up Node 22 (npm cache disabled — see comment in the file about the unpinned `package-lock.json`)
+3. `npm ci` (or `npm install --no-audit --no-fund` if no lockfile)
+4. `npm run lint` (ESLint)
+5. `npm run format:check` (Prettier)
+6. `npm run typecheck` (`tsc --noEmit`)
+7. Reject skipped tests (`it.skip`, `test.skip`, `xfail` outside generated code)
+8. `npm run test:coverage` (vitest)
+9. `npm run build` and grep `dist/` for `SUPABASE_SERVICE_ROLE` — fails the build if found
+10. Upload `coverage/lcov.info` to Codecov (with `flags: frontend`)
+
+**Job: `deploy` (main only)**
+
+`npx wrangler@latest pages deploy dist --project-name=sound-clash --branch=main` using `CF_API_TOKEN` + `CF_ACCOUNT_ID`.
+
+### 2.3 `e2e.yml`
+
+**Triggers**: push to `main`, `workflow_dispatch`, **or** a PR labelled `run-e2e`. Label-gating keeps PR feedback fast since this job is heavy (~10–15 min).
+
+**Job: `e2e`**
+1. Checkout
+2. Set up Node 20 + Python 3.11
+3. Install backend + frontend + Playwright deps
+4. `npx playwright install --with-deps chromium`
+5. Run the suite against the **preview** Supabase project using `SUPABASE_PREVIEW_*` secrets
+
+The frontend gets `VITE_API_URL=http://localhost:8000` and the spec helpers get `API_URL=http://localhost:8000`; the test fixtures spin up the FastAPI dev server inline.
+
+**Job: `buzz_race_stress` (label-gated: `run-stress`)**
+
+Heavy stress test — boots a Postgres 15 container as a workflow service, then runs `pytest -x -m stress ../tests/db/test_buzz_in_race.py` 100 times in a row, exiting on first failure. This is the Phase-3 race-correctness gate, kept around as the canary for any future change that touches `buzz_in`.
+
+### 2.4 `db-migrate.yml`
+
+**Triggers**: `workflow_dispatch` only. Two inputs:
+- `target` — `preview` or `prod` (binds the `environment:` for env-secret resolution)
+- `confirm` — must be the literal string `MIGRATE` or the job is gated out
+
+**Steps**:
+1. Install `postgresql-client` (`psql`)
+2. Apply migrations via `./db/migrate.sh "$DATABASE_URL"`
+3. **Re-apply** the same migrations to verify idempotency
+
+Migrations are never auto-applied. The deploy playbook is in [`runbook.md`](runbook.md) §1.3.
+
+---
+
+## 3. Dependabot
+
+Configured in `.github/dependabot.yml`. Five package ecosystems, all on a weekly Monday schedule:
+
+| Ecosystem | Directory | Open-PR cap | Grouping | Labels |
+|---|---|---|---|---|
+| `github-actions` | `/` | 5 | – | `dependencies`, `ci` |
+| `pip` | `/backend` | 5 | minor + patch grouped | `dependencies`, `backend` |
+| `npm` | `/frontend` | 5 | minor + patch grouped | `dependencies`, `frontend` |
+| `npm` | `/tests/e2e` | 3 | – | `dependencies`, `tests` |
+| `docker` | `/backend` | 3 | – | `dependencies`, `docker` |
+
+**Commit message prefixes**: `deps` for prod, `deps-dev` for dev deps, `ci` for actions bumps. Scope is included.
+
+**How to interact with a Dependabot PR**:
+- Status green + diff is patch/minor → review the diff, merge if it looks safe
+- Major bump → read the upstream changelog before merging
+- `@dependabot rebase` — re-sync against latest `main`
+- `@dependabot ignore this minor version` — skip a single version
+- `@dependabot ignore this dependency` — stop opening PRs for this dep entirely
+
+Per `.claude/rules/dependencies.md`, **flag any new dependency before installing it**. Dependabot only bumps existing deps, so it never violates the rule — but reviewing its PRs is a good moment to spot transitive growth.
+
+---
+
+## 4. CodeQL
+
+GitHub's static-analysis security scanner. We use **Default Setup** (Settings → Code security and analysis), not a workflow file. Default Setup runs on PR + push to `main` + a weekly schedule, with no maintenance burden.
+
+The advanced workflow (`.github/workflows/codeql.yml`) was removed in commit `9956027` once Default Setup proved equivalent for the languages we use.
+
+**Languages scanned**: JavaScript/TypeScript (frontend), Python (backend).
+
+**Findings appear**:
+- As PR review comments on the offending lines
+- In the Security tab → "Code scanning alerts"
+
+**Triage**:
+- Real bug → fix it
+- False positive → dismiss with reason via the Security tab
+- In-code suppression: `// codeql[<rule-id>]` annotation; use sparingly and document why
+
+CodeQL is advisory in branch protection — it can't block a merge — but a finding should never be ignored without justification.
+
+---
+
+## 5. Codecov
+
+Coverage reporting service. The `coverage.xml` (backend) and `lcov.info` (frontend) files uploaded by the workflows are consumed by Codecov, which:
+
+- Posts a coverage comment on every PR (delta vs `main`, line + branch)
+- Maintains the `[![Coverage]](…)` badge in the root `README.md`
+- Tracks coverage trends over time on the project dashboard
+
+**Token**: `CODECOV_TOKEN` GitHub repo secret (single token for the repo).
+
+**Flags**: backend uploads use `flags: backend`, frontend uses `flags: frontend`. This lets the dashboard show per-area coverage.
+
+There is no `codecov.yml` config file; defaults are fine. The Codecov comment is **advisory** — coverage drops are reported but not enforced as a hard block. The actual hard gate lives in `pyproject.toml` (`--cov-fail-under=90`); see [`testing-strategy.md`](testing-strategy.md) §5 for ratchet plan.
+
+---
+
+## 6. Pre-commit hooks
+
+Local hooks defined in `.pre-commit-config.yaml`. They run on `git commit` once installed.
+
+**Install once per clone**:
+```
+pip install pre-commit
+pre-commit install
+```
+
+**What runs**:
+
+| Hook | Source | What it catches |
+|---|---|---|
+| `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending` | `pre-commit-hooks` | Whitespace and EOL hygiene |
+| `check-yaml`, `check-json`, `check-merge-conflict` | `pre-commit-hooks` | Syntax + leftover conflict markers |
+| `check-added-large-files` (500 KB) | `pre-commit-hooks` | Accidental binary check-ins |
+| `detect-private-key` | `pre-commit-hooks` | SSH/PGP keys |
+| `ruff --fix`, `ruff-format` | `astral-sh/ruff-pre-commit` | Lint + format for `backend/**` |
+| `no-jwt-leak` | local pygrep | Strings starting `eyJhbGciOi` (Supabase JWT prefix) |
+| `no-skip-tests` | local pygrep | `it.skip`, `test.skip`, `xfail` outside generated code |
+| `no-pragma-no-cover` | local pygrep | `# pragma: no cover` under `backend/app/` |
+
+Per `.claude/rules/git-workflow.md`, **bypassing a hook with `--no-verify` is not allowed** — fix the underlying issue.
+
+---
+
+## 7. Deploy automation
+
+### 7.1 Backend → Render
+
+Triggered by the `deploy` job in `backend.yml` on push to `main`. The job curls a webhook URL stored in the `RENDER_DEPLOY_HOOK` secret. Render then:
+
+1. Pulls `main`
+2. Builds the Docker image (multi-stage, non-root user)
+3. Health-checks `/health` (expects 200)
+4. Swaps traffic if green; rolls back if not
+
+**Cold-start budget after a deploy**: ~30s for the first request. The cron-job.org keepalive masks this in practice.
+
+### 7.2 Frontend → Cloudflare Pages
+
+`frontend.yml` calls `npx wrangler@latest pages deploy dist --project-name=sound-clash --branch=main` on push to `main`. Wrangler authenticates via `CF_API_TOKEN` and `CF_ACCOUNT_ID`.
+
+Pages serves from:
+- `https://sound-clash.pages.dev` (Cloudflare-issued)
+- `https://www.soundclash.org` (custom domain)
+
+The apex `soundclash.org` is a 301 redirect to `www.` (Cloudflare Page Rule).
+
+### 7.3 Database (manual)
+
+`db-migrate.yml` is the **one production write that requires human intervention**. Migrations are not auto-applied on push — you dispatch the workflow with the target env (`preview` or `prod`) and the confirmation string `MIGRATE`. See [`runbook.md`](runbook.md) §1.3 for the deploy-with-migration playbook.
+
+---
+
+## 8. Monitoring & observability
+
+### 8.1 Sentry
+
+Two projects:
+
+| Project | Init location | Sample rate | PII |
+|---|---|---|---|
+| `sound-clash-frontend` | `frontend/src/main.tsx` | `tracesSampleRate: 0` | default scrubbing |
+| `sound-clash-backend` | `backend/app/middleware/sentry.py` | `traces_sample_rate: 0.0` | `send_default_pii=False` |
+
+Both projects are skipped when their DSN env var is empty (so `pytest` runs and local dev without DSNs don't ship junk events). The backend init also skips if `PYTEST_CURRENT_TEST` is set.
+
+**Alerts**: workspace-default "new issue" email on both projects.
+
+**DSNs** are GitHub repo secrets (`SENTRY_DSN_FRONTEND`, `SENTRY_DSN_BACKEND`) and also baked into the Render env / Cloudflare Pages env so the deployed builds have them.
+
+### 8.2 Render keepalive — cron-job.org
+
+The Render free tier sleeps after 15 min of idle. cron-job.org pings `https://api.soundclash.org/health` every 14 min to keep the worker warm.
+
+Account credentials are stored in `.claude/phase7-secrets.local` (not committed; see the secrets-file memory).
+
+If the keepalive stops (cron-job.org outage, account locked), the symptom is a 30s wait on the first game-creation after an idle period. The buzzer is unaffected because it doesn't go through Render.
+
+### 8.3 Supabase quota alerts
+
+Configured in the Supabase dashboard under each project's settings. Email thresholds match `free-tier-budget.md` §4 (DB size 80%, egress 80%, Realtime msgs 80%).
+
+---
+
+## 9. PR-check timing
+
+Approximate order in which checks complete on a typical PR:
+
+1. **Pre-commit** — runs locally before the commit lands (sub-second)
+2. **CodeQL** — completes ~2–5 min after push
+3. **Backend / Frontend** workflows — complete ~3–7 min
+4. **Codecov comment** — appears once the workflows have uploaded
+5. **E2E** (only if labelled `run-e2e`) — 10–15 min
+6. **Stress** (only if labelled `run-stress`) — up to 30 min
+
+If a PR sits without checks running, the most likely cause is path filtering — the PR didn't change any file under the workflow's `paths:` filter. Force a run with `workflow_dispatch` or a no-op file touch.
+
+---
+
+## 10. Branch protection
+
+Configured on `main`:
+
+- Require pull request before merging
+- Require status checks to pass: `Backend / lint + type + test`, `Frontend / lint + type + test`
+- Require branches to be up to date before merging
+- Do not allow force pushes
+- Do not allow deletions
+
+E2E, CodeQL, and Codecov are **not** required checks — they're advisory. Adding them as required checks is a one-line settings change but would block merges when the preview Supabase is being maintained.
+
+Per `.claude/rules/ci-and-repo-config.md`, **changing branch protection requires explicit user approval** — Claude will not modify it autonomously.
+
+---
+
+## 11. Cheat sheet
+
+```sh
+# Run the same checks CI does, locally:
+
+# Backend
+cd backend
+ruff check .
+ruff format --check .
+mypy app
+pytest --cov=app --cov-branch --cov-fail-under=90
+
+# Frontend
+cd frontend
+npm run lint
+npm run format:check
+npm run typecheck
+npm run test:coverage
+npm run build
+
+# E2E (against local stack)
+cd tests/e2e
+npm test
+```
+
+For the secrets you need locally, see [`local-development.md`](local-development.md) §4.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -126,7 +126,7 @@ Configured in `.github/dependabot.yml`. Five package ecosystems, all on a weekly
 - `@dependabot ignore this minor version` — skip a single version
 - `@dependabot ignore this dependency` — stop opening PRs for this dep entirely
 
-Per `.claude/rules/dependencies.md`, **flag any new dependency before installing it**. Dependabot only bumps existing deps, so it never violates the rule — but reviewing its PRs is a good moment to spot transitive growth.
+Project rule: **flag any new dependency before installing it** (keep the project lean). Dependabot only bumps existing deps, so it never violates the rule — but reviewing its PRs is a good moment to spot transitive growth.
 
 ---
 
@@ -190,7 +190,7 @@ pre-commit install
 | `no-skip-tests` | local pygrep | `it.skip`, `test.skip`, `xfail` outside generated code |
 | `no-pragma-no-cover` | local pygrep | `# pragma: no cover` under `backend/app/` |
 
-Per `.claude/rules/git-workflow.md`, **bypassing a hook with `--no-verify` is not allowed** — fix the underlying issue.
+Project rule: **bypassing a hook with `--no-verify` is not allowed** — fix the underlying issue.
 
 ---
 
@@ -244,7 +244,7 @@ Both projects are skipped when their DSN env var is empty (so `pytest` runs and 
 
 The Render free tier sleeps after 15 min of idle. cron-job.org pings `https://api.soundclash.org/health` every 14 min to keep the worker warm.
 
-Account credentials are stored in `.claude/phase7-secrets.local` (not committed; see the secrets-file memory).
+Account credentials are kept out of the repo — see your password manager.
 
 If the keepalive stops (cron-job.org outage, account locked), the symptom is a 30s wait on the first game-creation after an idle period. The buzzer is unaffected because it doesn't go through Render.
 
@@ -281,7 +281,7 @@ Configured on `main`:
 
 E2E, CodeQL, and Codecov are **not** required checks — they're advisory. Adding them as required checks is a one-line settings change but would block merges when the preview Supabase is being maintained.
 
-Per `.claude/rules/ci-and-repo-config.md`, **changing branch protection requires explicit user approval** — Claude will not modify it autonomously.
+Project rule: **changing branch protection requires explicit user approval** — automation tools should not modify it autonomously.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the last open task (`DOC-06`): adds visual architecture diagrams and a comprehensive guide to the dev/CI tooling around the repo. Also preps GitHub Pages so the HTML diagrams have a permanent hosted URL.

**Diagrams + tooling guide:**
- `docs/diagrams/README.md` — index for the diagram set, explains the dual `.md` + `.html` format
- `docs/diagrams/internal.md` + `internal.html` — internal architecture: component map (browser ↔ FastAPI ↔ Supabase), buzz-race sequence diagram, auth surface table
- `docs/diagrams/external.md` + `external.html` — external services: full service map (Cloudflare, Render, Supabase prod/preview, Sentry, cron-job.org, GitHub Actions, CodeQL, Dependabot, Codecov, YouTube), `git push main` deploy sequence, secret-store matrix
- `docs/tooling.md` — every tool that touches the repo: workflows, Dependabot, CodeQL, Codecov, pre-commit, deploy automation, monitoring, branch protection, local cheat sheet

**GitHub Pages hosting (new):**
- `docs/.nojekyll` — disables Jekyll processing so the HTML files are served as-is (no template munging of `<script type="module">`)
- `docs/index.html` — landing page linking to the diagrams + the Markdown docs on github.com

To enable Pages **after merging this PR**: Settings → Pages → Source: *Deploy from a branch* → Branch: `main` → Folder: `/docs` → Save. The site goes live at `https://benartzi4.github.io/Sound-Clash/` within ~1 min. Diagrams will be at `/diagrams/internal.html` and `/diagrams/external.html`.

**Wiring:**
- `docs/README.md` — added entries 16–17 + new rows in the file-summary table
- `docs/architecture.md` — two new bullets pointing at `diagrams/` and `tooling.md`
- `docs/tasks.md` — `DOC-06` flipped to `[x]`; status note updated to "all initial-phase tasks complete"

Doc-only PR; no behavior changes. No CHANGELOG entry per `.claude/rules/changelog.md` (doc-only edits are excluded).

## Test plan

- [ ] Open `docs/diagrams/internal.md` on github.com — both Mermaid blocks render (component flowchart + buzz-race sequence).
- [ ] Open `docs/diagrams/external.md` on github.com — both Mermaid blocks render (service map + deploy sequence).
- [ ] Preview the HTMLs via raw.githack while the PR is open:
  - https://raw.githack.com/BenArtzi4/Sound-Clash/docs/architecture-diagrams-and-tooling-guide/docs/diagrams/internal.html
  - https://raw.githack.com/BenArtzi4/Sound-Clash/docs/architecture-diagrams-and-tooling-guide/docs/diagrams/external.html
  - https://raw.githack.com/BenArtzi4/Sound-Clash/docs/architecture-diagrams-and-tooling-guide/docs/index.html
- [ ] After merge: enable Pages (Settings → Pages → branch `main`, folder `/docs`); confirm the live site renders at `https://benartzi4.github.io/Sound-Clash/` and diagram links work.
- [ ] Skim `docs/tooling.md` — workflow descriptions match `.github/workflows/`; cheat sheet at the bottom reproduces what CI runs.
- [ ] Confirm `docs/tasks.md` has zero remaining `[ ]` boxes.