### PR TITLE
Docs UI/UX audit: fix issue templates, refresh stale notes, polish Pages site

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,3 @@
-<!--
-This file goes in the new repo at: .github/ISSUE_TEMPLATE/bug_report.md
--->
-
 ---
 name: Bug report
 about: Something isn't working

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,3 @@
-<!--
-This file goes in the new repo at: .github/ISSUE_TEMPLATE/feature_request.md
--->
-
 ---
 name: Feature request
 about: Suggest a new feature or improvement

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-<!--
-This file goes in the new repo at: .github/pull_request_template.md
-GitHub auto-loads it as the description when you open a PR.
--->
-
 ## What
 
 <!-- One-paragraph summary of what this PR changes. Focus on user-visible or system-visible effects, not the diff. -->

--- a/db/README.md
+++ b/db/README.md
@@ -2,26 +2,17 @@
 
 Postgres-as-code. Schema, RPC functions, RLS policies, and the pg_cron job all live here as ordered SQL migrations.
 
-**Phase 3 deliverable.** Empty in Phase 1.
-
 ## Layout
 
 ```
 db/
 ├── README.md         (this file)
 ├── migrate.sh        (applies migrations in order; used locally and in CI)
-├── migrations/       (numbered SQL files)
-│   ├── 001_extensions.sql
-│   ├── 002_durable_tables.sql
-│   ├── 003_ephemeral_tables.sql
-│   ├── 004_indexes.sql
-│   ├── 005_rpc_functions.sql
-│   ├── 006_rls_policies.sql
-│   ├── 007_cron_jobs.sql
-│   └── 008_seed_genres.sql
-└── seed/
-    └── (one-time seed data not tied to migrations)
+├── migrations/       (numbered SQL files — see the directory for the canonical list)
+└── seed/             (one-time seed data not tied to migrations)
 ```
+
+Migrations are applied in numeric order. The initial set (`001`–`008`) ships the schema, indexes, the original five RPC functions, RLS policies, the cron job, and the genre seed. Later migrations layer fixes and feature work on top — Realtime publication wiring (`009`), `char(n)` → `text` for game codes (`010`), buzz/round mirroring (`011`), the per-game manager token (`012`), and the scoring revamp + `award_bonus` (`014`). New migrations get the next free numeric prefix.
 
 ## Authority
 

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -188,27 +188,73 @@
       const next = currentTheme() === "dark" ? "light" : "dark";
       localStorage.setItem(STORAGE_KEY, next);
       applyTheme(next);
+      // Re-render diagrams against the new theme.
+      renderMermaid();
     });
   }
 
   // ---------- Mermaid ----------
-  function initMermaid() {
-    if (!document.querySelector(".mermaid")) return;
+  // Cache the resolved module + the original source of each diagram so we
+  // can re-render without re-fetching when the user toggles the theme.
+  let mermaidModule = null;
+  const mermaidSources = new WeakMap();
+
+  function captureMermaidSources() {
+    document.querySelectorAll(".mermaid").forEach((el) => {
+      if (!mermaidSources.has(el)) {
+        mermaidSources.set(el, el.textContent);
+      }
+    });
+  }
+
+  function isDarkTheme() {
+    const explicit = root.getAttribute("data-theme");
+    if (explicit === "dark") return true;
+    if (explicit === "light") return false;
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  }
+
+  function renderMermaid() {
+    const nodes = document.querySelectorAll(".mermaid");
+    if (!nodes.length) return;
+    captureMermaidSources();
+
+    const run = (mermaid) => {
+      // Reset any previously-rendered SVG back to its original Mermaid source
+      // so mermaid.run() re-processes it under the current theme.
+      nodes.forEach((el) => {
+        el.removeAttribute("data-processed");
+        const src = mermaidSources.get(el);
+        if (src != null) el.textContent = src;
+      });
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: isDarkTheme() ? "dark" : "default",
+        securityLevel: "antiscript",
+        flowchart: { htmlLabels: true, curve: "basis" },
+        sequence: { mirrorActors: false, showSequenceNumbers: true },
+      });
+      mermaid.run({ querySelector: ".mermaid" }).catch((err) => {
+        console.error("Mermaid render failed:", err);
+      });
+    };
+
+    if (mermaidModule) {
+      run(mermaidModule);
+      return;
+    }
     import("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs")
       .then((mod) => {
-        const mermaid = mod.default;
-        mermaid.initialize({
-          startOnLoad: true,
-          theme: "default", // diagrams render on white background regardless of page theme
-          securityLevel: "loose",
-          flowchart: { htmlLabels: true, curve: "basis" },
-          sequence: { mirrorActors: false, showSequenceNumbers: true },
-        });
+        mermaidModule = mod.default;
+        run(mermaidModule);
       })
       .catch((err) => {
         console.error("Mermaid failed to load:", err);
       });
   }
+
+  // Keep the older name as a thin alias so the boot path reads the same.
+  const initMermaid = renderMermaid;
 
   // ---------- TOC active-link on scroll ----------
   function setupTOC() {

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -300,6 +300,10 @@ body {
   color: var(--fg-subtle);
   margin: 0 0 0.7rem;
   font-weight: 600;
+  /* Reset h2 base styles when .toc-title is applied to a heading element. */
+  padding: 0;
+  border: 0;
+  line-height: 1.4;
 }
 .toc ul { list-style: none; padding: 0; margin: 0; border-left: 1px solid var(--rule); }
 .toc li { margin: 0; }
@@ -519,8 +523,10 @@ td.center, th.center { text-align: center; }
 .card:hover .card-arrow { transform: translateX(3px); }
 
 /* ---------- Mermaid containers ---------- */
+/* Mermaid is initialised with theme: "default" or "dark" matching the page
+   theme (see assets/script.js), so the diagram canvas blends with the surface. */
 .diagram {
-  background: #ffffff;        /* always white for Mermaid contrast */
+  background: var(--bg-elevated);
   border: 1px solid var(--rule);
   border-radius: var(--radius);
   padding: 1.5rem;
@@ -530,7 +536,6 @@ td.center, th.center { text-align: center; }
 }
 .diagram .mermaid { text-align: center; }
 .diagram .mermaid svg { max-width: 100%; height: auto !important; }
-.diagram, .diagram * { color-scheme: light; }
 
 .caption {
   font-size: 0.88rem;
@@ -593,7 +598,7 @@ details > :not(summary) {
   padding: 0 1.2rem 1rem;
   margin: 0;
 }
-details ul { padding-left: 2.4rem; }
+details ul { padding-left: 1.4rem; }
 
 /* ---------- Page nav (prev/next, rendered by script.js) ---------- */
 .page-nav {

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -21,6 +21,11 @@ The `.md` files are the source of truth — they're text, version-controlled, an
 3. Open the `.html` locally in a browser to verify the diagram renders.
 4. Commit both files in the same change.
 
-## Why not GitHub Pages
+## Where the HTML versions live
 
-The `.md` versions render natively at `https://github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md`. The `.html` versions render fully when opened locally. Hosting a separate docs site would add a maintenance surface (and a second public URL alongside `https://soundclash.org`) for negligible benefit on a solo project. If that calculus changes, flipping on Pages is a single repo-Settings toggle.
+The whole `docs/` directory is published via GitHub Pages from `main`. The HTML diagrams render at:
+
+- `https://benartzi4.github.io/Sound-Clash/diagrams/internal.html`
+- `https://benartzi4.github.io/Sound-Clash/diagrams/external.html`
+
+The `.md` versions still render natively on GitHub at `github.com/BenArtzi4/Sound-Clash/blob/main/docs/diagrams/internal.md` — that's the source of truth and what code reviews comment on. The published HTML is a convenience for sharing, presenting, or browsing offline (`open docs/diagrams/internal.html` in a browser works without any server).

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -216,8 +216,8 @@ sequenceDiagram
 
   </main>
 
-  <aside class="toc">
-    <p class="toc-title">On this page</p>
+  <aside class="toc" aria-labelledby="toc-heading">
+    <h2 id="toc-heading" class="toc-title">On this page</h2>
     <ul>
       <li><a href="#service-map">Service map</a></li>
       <li><a href="#inventory">Service inventory</a></li>

--- a/docs/diagrams/internal.html
+++ b/docs/diagrams/internal.html
@@ -173,13 +173,13 @@ sequenceDiagram
 
   </main>
 
-  <aside class="toc">
-    <p class="toc-title">On this page</p>
+  <aside class="toc" aria-labelledby="toc-heading">
+    <h2 id="toc-heading" class="toc-title">On this page</h2>
     <ul>
       <li><a href="#component-map">Component map</a></li>
       <li><a href="#auth-surfaces">Auth surfaces</a></li>
-      <li><a href="#buzz-race">Buzz race sequence</a></li>
-      <li><a href="#not-here">What's not here</a></li>
+      <li><a href="#buzz-race">Hot-path: buzz race</a></li>
+      <li><a href="#not-here">What's deliberately not here</a></li>
     </ul>
   </aside>
 </div>

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -29,8 +29,6 @@ git clone https://github.com/BenArtzi4/Sound-Clash.git
 cd Sound-Clash
 ```
 
-(After Phase 1 of the roadmap is done. Until then, the repo is empty.)
-
 ```
 Sound-Clash/
 ├── backend/               # FastAPI app

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -48,6 +48,7 @@ Two distinct shared secrets gate FastAPI endpoints. Both checked with `secrets.c
 | `buzz_in`               | ✅ | ✅ |
 | `start_round`           | ❌ | ✅ |
 | `award_points`          | ❌ | ✅ |
+| `award_bonus`           | ❌ | ✅ |
 | `end_game`              | ❌ | ✅ |
 | `cleanup_expired_games` | ❌ | ✅ |
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="Sound Clash — real-time multiplayer music trivia. Buzz in, name the tune, win the round."
     />
-    <meta name="theme-color" content="#3b82f6" />
+    <meta name="theme-color" content="#06b6d4" />
     <meta name="color-scheme" content="light" />
 
     <meta property="og:type" content="website" />


### PR DESCRIPTION
## What

Audit of every authored ``*.md`` and ``*.html`` in the repo. Found one rendering bug that broke a GitHub feature and several drift / polish issues on the new GitHub Pages docs site. Fixes split into four commits so they're easy to review.

## Why

- **Issue templates were silently broken.** ``.github/ISSUE_TEMPLATE/bug_report.md`` and ``feature_request.md`` started with an HTML comment, so the YAML frontmatter wasn't on line 1. GitHub's parser fell back to "plain markdown file" — the title prefix, ``bug`` / ``enhancement`` labels, and template names never applied.
- **Doc content drift.** ``docs/diagrams/README.md`` had a "Why not GitHub Pages" section even though Pages was enabled in ``ccb4e8f``. ``docs/security-rls.md`` was missing ``award_bonus`` from the RPC EXECUTE matrix (added in migration 014). ``db/README.md`` claimed "Phase 3 deliverable, empty in Phase 1" and listed only migrations 001–008. ``docs/local-development.md`` told readers the repo is empty until Phase 1.
- **Pages site polish.** Mermaid was hard-coded to a white canvas regardless of theme — in dark mode the diagrams looked like punched-out white cards. The TOC label was a ``<p>`` (not navigable by screen-reader heading) and the aside had no ``aria-label``. Also tightened ``securityLevel`` to ``antiscript`` and re-renders Mermaid on theme toggle. Minor: ``details ul`` over-indented on phones; ``frontend/index.html`` had an unrelated ``theme-color: #3b82f6`` that doesn't appear anywhere in the brand.

## How

Four commits, each scoped to one concern:

1. ``fix(github): strip leading html comments breaking issue-template parser``
2. ``docs: refresh stale notes (pages live, migration list, award_bonus row)``
3. ``docs(pages): theme-aware mermaid + toc heading/aria + css polish``
4. ``fix(spa): correct mobile theme-color to match brand gradient``

## Test plan

- [ ] Open ``docs/index.html``, ``docs/diagrams/internal.html``, ``docs/diagrams/external.html`` in a browser. Toggle the theme button — diagrams should re-render against the new theme rather than staying on a white card.
- [ ] Inspect the TOC aside on a diagram page: heading is now ``<h2 id="toc-heading" class="toc-title">``; aside has ``aria-labelledby="toc-heading"``.
- [ ] Resize to 360px wide and open one of the ``<details>`` blocks on the home page. Bullet padding should look reasonable, not over-indented.
- [ ] On the GitHub UI, click "New issue" — both Bug and Feature templates should appear in the chooser with their titles and labels. (Visible after merge.)
- [ ] On a dark-mode phone, navigate to ``soundclash.org``: address-bar tint changes from blue to teal-cyan.

## Docs

- [x] No doc change needed (this PR _is_ doc changes — the relevant docs are updated in-tree)