### PR TITLE
docs: remove predecessor/legacy-AWS mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,5 +85,3 @@ E2E (`cd tests/e2e`, one-time `npm install && npx playwright install`):
 - `docs/local-development.md` — full dev setup + Windows notes + troubleshooting.
 - `docs/testing-strategy.md` — what to test, where, and the CI gates.
 - `docs/roadmap.md` — phase boundaries and exit criteria.
-
-The legacy AWS version lives at https://github.com/BenArtzi4/Sound-Clash-legacy and is reference-only.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,3 @@ The game is live and playable at [https://soundclash.org](https://soundclash.org
 ## License
 
 MIT — see [`LICENSE`](LICENSE).
-
-## Predecessor
-
-The earlier AWS-based version is at https://github.com/BenArtzi4/Sound-Clash-legacy (archived). That version ran ~$20/month on AWS; this rewrite runs at $0/month on free tiers without sacrificing the buzzer-latency requirement.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,6 @@ The system has a deliberately small attack surface (no PII, no payments, no user
 - Vulnerabilities in third-party services we depend on (Supabase, Render, Cloudflare). Report those upstream.
 - Bugs that require physical access to the host's device.
 - Reports about missing best practices that don't lead to an exploit (e.g., "you should use header X"). Open an issue or PR for those.
-- Issues in the [legacy AWS repo](https://github.com/BenArtzi4/Sound-Clash-legacy). That codebase is archived and won't receive security fixes.
 
 ## Disclosure policy
 

--- a/docs/diagrams/external.html
+++ b/docs/diagrams/external.html
@@ -201,7 +201,6 @@ sequenceDiagram
 
     <h2 id="not-here">What is <em>not</em> in this diagram</h2>
     <ul>
-      <li><strong>AWS</strong> — torn down 2026-05-07. The legacy stack lives in <code>Sound-Clash-legacy</code> for reference only; nothing in the new system depends on AWS resources.</li>
       <li><strong>CDN for YouTube</strong> — YouTube IFrame Player loads its own JS from <code>youtube.com</code>; there's no separate CDN dependency we manage.</li>
       <li><strong>Email</strong> — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.</li>
     </ul>

--- a/docs/diagrams/external.md
+++ b/docs/diagrams/external.md
@@ -160,6 +160,5 @@ The full secret rotation procedure is in `runbook.md` §3.
 
 ## What is **not** in this diagram
 
-- **AWS** — torn down 2026-05-07. The legacy stack lives in `Sound-Clash-legacy` for reference only; nothing in the new system depends on AWS resources.
 - **CDN for YouTube** — YouTube IFrame Player loads its own JS from `youtube.com`; there's no separate CDN dependency we manage.
 - **Email** — there is no transactional email in the system. Only ops alerts (Sentry "new issue", Render failure, Supabase quota) email the workspace owner directly.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -13,7 +13,6 @@ For *building* the system, see `roadmap.md` and `tasks.md`. For *quotas*, see `f
 | Database | Supabase | https://app.supabase.com → project `Sound-Clash` |
 | DNS | Cloudflare | https://dash.cloudflare.com → `soundclash.org` |
 | Source code | GitHub | https://github.com/BenArtzi4/Sound-Clash |
-| Legacy AWS code (read-only reference) | GitHub | https://github.com/BenArtzi4/Sound-Clash-legacy |
 | Error tracking | Sentry | https://sentry.io → project `sound-clash` |
 | Keepalive | cron-job.org | https://console.cron-job.org |
 
@@ -85,19 +84,6 @@ Postgres migrations are forward-only by design. To revert:
 - **Hard revert** (data corruption only): restore from Supabase backup. Free tier has 1 day of backups; Pro has more.
 
 Supabase free tier does NOT have point-in-time recovery. For prod-impacting incidents, accept that the last full backup is your floor.
-
-### 2.4 DNS rollback (cutover undo)
-
-> **No longer available as of 2026-05-07.** The legacy CloudFront distribution `E2NIDUY011R5N4`, the ALBs, the ECR images, the ACM cert, and all S3 backing data were deleted during Phase 7 teardown. There is nothing to revert DNS to. If the new stack breaks, the recovery path is **forward** (deploy a fix) or **rebuild from source** per §6 — there is no quick DNS flip back.
->
-> The original rollback procedure is preserved below for historical reference.
-
-If the migration cutover fails and you need to send traffic back to the legacy AWS stack:
-1. DNS → `soundclash.org` records (currently at Namecheap, not Cloudflare) → change `www` CNAME from `sound-clash.pages.dev` back to the CloudFront distribution domain (was `d149g9hh3mks89.cloudfront.net`, distribution ID `E2NIDUY011R5N4`).
-2. Propagation: 5-30 min at Namecheap.
-3. Spin AWS back up if it was destroyed (legacy repo's `scripts/ondemand/deploy-all.sh` — file no longer present in the current legacy clone; would need to be re-created from git history).
-
-This rollback path was only available while the AWS stack remained alive. After the Phase 7 teardown the option is gone.
 
 ## 3. Secret Rotation
 


### PR DESCRIPTION
## Summary

- Drop the **Predecessor** section from `README.md` and the equivalent legacy-AWS pointers from `CLAUDE.md`, `SECURITY.md`, the `runbook.md` resources table, and the diagrams' "What is not in this diagram" bullet.
- Delete the dead **Runbook §2.4 — DNS rollback (cutover undo)** section, which described reverting traffic to AWS infrastructure that was torn down on 2026-05-07 and no longer exists.
- Migration-history docs (`aws-teardown-checklist.md`, `phase7-cutover-checklist.md`, `roadmap.md` Phases 0–2, `tasks.md`, `data-model.md` §9, `CHANGELOG.md`) are intentionally untouched — they are procedural records of work that already happened. Code-side `legacy_*` identifiers in tests are also untouched (different meaning).

## Test plan

- [ ] `README.md` no longer renders a "Predecessor" section on GitHub.
- [ ] `docs/diagrams/external.html` still renders correctly (only the AWS bullet removed from one `<ul>`).
- [ ] `docs/runbook.md` table of contents / heading numbering still reads sensibly with §2.4 gone (§2.3 → §3 is fine; the runbook does not have an external TOC).