### PR TITLE
chore: dedupe postgrest error wrap and team-storage helpers

### DIFF
--- a/backend/app/db/errors.py
+++ b/backend/app/db/errors.py
@@ -13,6 +13,8 @@ multiple fallback fields.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 
@@ -119,3 +121,18 @@ def map_postgrest_error(exc: Exception) -> DomainError:
         return NotFoundError(msg)
 
     return InternalError(msg)
+
+
+@contextmanager
+def mapped_postgrest_errors() -> Iterator[None]:
+    """Wrap a Supabase call and translate raw exceptions to DomainErrors.
+
+    DomainErrors raised inside the block (already shaped) propagate untouched;
+    every other exception goes through ``map_postgrest_error``.
+    """
+    try:
+        yield
+    except DomainError:
+        raise
+    except Exception as exc:
+        raise map_postgrest_error(exc) from exc

--- a/backend/app/routers/admin_songs.py
+++ b/backend/app/routers/admin_songs.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import anyio
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile, status
 
-from app.db.errors import NotFoundError, map_postgrest_error
+from app.db.errors import NotFoundError, mapped_postgrest_errors
 from app.db.supabase_client import SupabaseClientLike, get_supabase_client
 from app.middleware.admin_auth import require_admin
 from app.middleware.rate_limit import limiter
@@ -85,10 +85,8 @@ def _create_song_blocking(client: SupabaseClientLike, body: SongCreate) -> dict[
         "is_soundtrack": body.is_soundtrack,
         "source": body.source,
     }
-    try:
+    with mapped_postgrest_errors():
         resp = client.table("songs").insert(payload).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     rows = resp.data or []
     if not rows:
         raise NotFoundError("song insert returned no row")
@@ -96,10 +94,8 @@ def _create_song_blocking(client: SupabaseClientLike, body: SongCreate) -> dict[
 
     joins = [{"song_id": song["id"], "genre_id": str(g)} for g in body.genre_ids]
     if joins:
-        try:
+        with mapped_postgrest_errors():
             client.table("song_genres").insert(joins).execute()
-        except Exception as exc:
-            raise map_postgrest_error(exc) from exc
     return song
 
 
@@ -115,20 +111,16 @@ def _update_song_blocking(
         "is_soundtrack": body.is_soundtrack,
         "source": body.source,
     }
-    try:
+    with mapped_postgrest_errors():
         resp = client.table("songs").update(payload).eq("id", song_id).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     rows = resp.data or []
     song = rows[0] if rows else _fetch_song_blocking(client, song_id)
 
     client.table("song_genres").delete().eq("song_id", song_id).execute()
     joins = [{"song_id": song_id, "genre_id": str(g)} for g in body.genre_ids]
     if joins:
-        try:
+        with mapped_postgrest_errors():
             client.table("song_genres").insert(joins).execute()
-        except Exception as exc:
-            raise map_postgrest_error(exc) from exc
     return song
 
 

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -15,10 +15,9 @@ from fastapi import APIRouter, Depends, Request, status
 
 from app.db.errors import (
     ConflictError,
-    DomainError,
     GoneError,
     NotFoundError,
-    map_postgrest_error,
+    mapped_postgrest_errors,
 )
 from app.db.supabase_client import SupabaseClientLike, get_supabase_client
 from app.middleware.manager_auth import require_manager_token
@@ -58,10 +57,8 @@ def _insert_game_blocking(
         "total_rounds": total_rounds,
         "selected_genres": genre_ids,
     }
-    try:
+    with mapped_postgrest_errors():
         resp = client.table("active_games").insert(payload).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     rows = resp.data or []
     if not rows:
         raise NotFoundError("game insert returned no row")
@@ -88,10 +85,8 @@ def _join_team_blocking(client: SupabaseClientLike, code: str, name: str) -> dic
     if game["status"] == "ended" or game.get("ended_at"):
         raise GoneError(f"game {code} has ended")
 
-    try:
+    with mapped_postgrest_errors():
         resp = client.table("game_teams").insert({"game_code": code, "name": name}).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     rows = resp.data or []
     if not rows:
         raise NotFoundError("team insert returned no row")
@@ -101,12 +96,10 @@ def _join_team_blocking(client: SupabaseClientLike, code: str, name: str) -> dic
 def _start_round_blocking(
     client: SupabaseClientLike, code: str, song: dict[str, Any]
 ) -> tuple[str, int]:
-    try:
+    with mapped_postgrest_errors():
         rpc_resp = client.rpc(
             "start_round", {"p_game_code": code, "p_song_id": song["id"]}
         ).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     round_id = rpc_resp.data
     if isinstance(round_id, list) and round_id:
         round_id = round_id[0]
@@ -130,7 +123,7 @@ def _award_blocking(
         timeout=body.timeout,
     )
 
-    try:
+    with mapped_postgrest_errors():
         rpc_resp = client.rpc(
             "award_points",
             {
@@ -142,8 +135,6 @@ def _award_blocking(
                 "p_timeout": timeout,
             },
         ).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     # PostgREST returns a TABLE-shaped function as a list of row-dicts (a
     # length-1 list here, since award_points always RETURN QUERY one row).
     # Some test mocks pass a bare dict, so accept both shapes.
@@ -160,7 +151,7 @@ def _bonus_blocking(
     code: str,
     body: AwardBonusRequest,
 ) -> dict[str, Any]:
-    try:
+    with mapped_postgrest_errors():
         rpc_resp = client.rpc(
             "award_bonus",
             {
@@ -169,8 +160,6 @@ def _bonus_blocking(
                 "p_points": body.points,
             },
         ).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     # award_bonus returns RETURNS integer: a single scalar new total.
     return {
         "team_id": str(body.team_id),
@@ -180,10 +169,8 @@ def _bonus_blocking(
 
 
 def _end_game_blocking(client: SupabaseClientLike, code: str) -> dict[str, Any]:
-    try:
+    with mapped_postgrest_errors():
         client.rpc("end_game", {"p_game_code": code}).execute()
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
     return _fetch_game_blocking(client, code)
 
 
@@ -293,12 +280,8 @@ async def award_points(
     request: Request, game_code: str, body: AwardPointsRequest
 ) -> AwardPointsResponse:
     client = get_supabase_client()
-    try:
+    with mapped_postgrest_errors():
         result = await anyio.to_thread.run_sync(_award_blocking, client, game_code, body)
-    except DomainError:
-        raise
-    except Exception as exc:
-        raise map_postgrest_error(exc) from exc
 
     return AwardPointsResponse(
         round_id=body.round_id,

--- a/frontend/src/lib/teamStorage.ts
+++ b/frontend/src/lib/teamStorage.ts
@@ -1,0 +1,49 @@
+// Per-game team identity storage. After a player joins via JoinTeamPage,
+// the team's id+name lives under `game:<code>:team` in localStorage so
+// TeamGameplayPage can hydrate after a refresh. Game rows auto-expire
+// after 4 hours via pg_cron, at which point the stored identity becomes
+// meaningless and the next page load will redirect to the join screen.
+//
+// adminPassword.ts is intentionally NOT consolidated here; it lives in
+// memory only (see .claude/rules/lessons-learned.md, 2026-05-05 entry).
+
+export interface StoredTeam {
+  id: string;
+  name: string;
+}
+
+function teamKey(gameCode: string): string {
+  return `game:${gameCode}:team`;
+}
+
+export function getStoredTeam(gameCode: string): StoredTeam | null {
+  try {
+    const raw = window.localStorage.getItem(teamKey(gameCode));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredTeam>;
+    if (!parsed.id || !parsed.name) return null;
+    return { id: parsed.id, name: parsed.name };
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredTeam(gameCode: string, team: StoredTeam): void {
+  try {
+    window.localStorage.setItem(
+      teamKey(gameCode),
+      JSON.stringify({ id: team.id, name: team.name }),
+    );
+  } catch {
+    // Storage may be unavailable (private mode, quota); the player can
+    // still play in the current tab; they just can't refresh.
+  }
+}
+
+export function clearStoredTeam(gameCode: string): void {
+  try {
+    window.localStorage.removeItem(teamKey(gameCode));
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/pages/JoinTeamPage.tsx
+++ b/frontend/src/pages/JoinTeamPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ApiError, joinTeam } from "../lib/api";
+import { setStoredTeam } from "../lib/teamStorage";
 import styles from "./JoinTeamPage.module.css";
 
 const CODE_RE = /^[A-Z2-9]{6}$/;
@@ -8,10 +9,6 @@ const CODE_CHAR_RE = /[A-Z2-9]/g;
 
 function normalizeCode(raw: string): string {
   return (raw.toUpperCase().match(CODE_CHAR_RE) ?? []).join("").slice(0, 6);
-}
-
-function teamStorageKey(gameCode: string): string {
-  return `game:${gameCode}:team`;
 }
 
 export function JoinTeamPage() {
@@ -35,10 +32,7 @@ export function JoinTeamPage() {
     setError(null);
     try {
       const team = await joinTeam(code, trimmedName);
-      window.localStorage.setItem(
-        teamStorageKey(code),
-        JSON.stringify({ id: team.id, name: team.name }),
-      );
+      setStoredTeam(code, { id: team.id, name: team.name });
       navigate(`/team/${code}`);
     } catch (err) {
       if (err instanceof ApiError) {

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -5,35 +5,15 @@ import { Scoreboard } from "../components/Scoreboard";
 import { useBuzzer } from "../hooks/useBuzzer";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { serverTimeNow } from "../hooks/useServerTime";
+import { clearStoredTeam, getStoredTeam } from "../lib/teamStorage";
 import styles from "./TeamGameplayPage.module.css";
 
 const ROUND_DURATION_SEC = 20;
 
-interface StoredTeam {
-  id: string;
-  name: string;
-}
-
-function readStoredTeam(gameCode: string): StoredTeam | null {
-  try {
-    const raw = window.localStorage.getItem(`game:${gameCode}:team`);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<StoredTeam>;
-    if (!parsed.id || !parsed.name) return null;
-    return { id: parsed.id, name: parsed.name };
-  } catch {
-    return null;
-  }
-}
-
-function clearStoredTeam(gameCode: string): void {
-  window.localStorage.removeItem(`game:${gameCode}:team`);
-}
-
 export function TeamGameplayPage() {
   const { gameCode = "" } = useParams<{ gameCode: string }>();
   const navigate = useNavigate();
-  const stored = useMemo(() => readStoredTeam(gameCode), [gameCode]);
+  const stored = useMemo(() => getStoredTeam(gameCode), [gameCode]);
   const [hydratedOnce, setHydratedOnce] = useState(false);
   const [now, setNow] = useState(() => serverTimeNow().getTime());
 


### PR DESCRIPTION
## Summary

Two narrow internal cleanups, no behavior change.

- Backend: extract a `mapped_postgrest_errors()` context manager in `app/db/errors.py` and replace 11 identical 4-line `try / except / raise map_postgrest_error(...) from exc` blocks across `routers/games.py` (8) and `routers/admin_songs.py` (4). The double-`except` in `award_points` (which had an explicit `except DomainError: raise` guard) collapses into a single `with` since the helper already passes DomainErrors through.
- Frontend: extract per-game team identity storage to `lib/teamStorage.ts` (mirroring the shape of `lib/managerToken.ts`). `JoinTeamPage.tsx` and `TeamGameplayPage.tsx` now both go through the helper; the inline `teamStorageKey` / `readStoredTeam` / `clearStoredTeam` impls are gone. The storage key (`game:<code>:team`) and JSON shape (`{id, name}`) are preserved exactly.

`adminPassword.ts` is intentionally NOT consolidated; it stays in-memory only per the 2026-05-05 CodeQL lesson recorded in `.claude/rules/lessons-learned.md`.

Net diff: 6 files, +83 / -68. New file is the helper; everything else is shorter.

No CHANGELOG entry: internal refactor with no user-visible change (per `.claude/rules/changelog.md`).

## Test plan

- [x] `ruff format --check`, `ruff check`, `mypy app` green
- [x] `pytest -m "not needs_docker"` green (25/25 local; the docker-gated suite runs in CI)
- [x] `npm run lint`, `npm run typecheck`, `npm run format -- --check` green
- [x] `npm run test:run` green (188 / 188)
- [ ] CI backend + frontend + e2e workflows green