### PR TITLE
fix(frontend): hide YT pause leaks + team podium + scored-round button polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-09: When a team buzzes, the manager's YouTube player no longer flashes the paused-state "more videos" tiles (which can include other songs in the same artist's channel and spoil future rounds). The black "Ready" overlay now stays on top of the iframe whenever a buzz is being scored.
+- 2026-05-09: Manager scoring buttons no longer act as a footgun after a round was already scored. `End round` and `Restart song` are now disabled once the current round has an `ended_at`, so a second click can't fire a `round_already_ended` error toast - the host's only enabled action is `Next round`.
+- 2026-05-09: YouTube embed chrome (player labels, captions) is forced to English regardless of the host's browser/IP locale, so a host on a Hebrew-locale browser no longer sees Hebrew controls bleeding through the iframe overlay.
 - 2026-05-09: Refreshing the manager tab mid-round no longer drops the host into a "No round started yet" view. The current song is now re-fetched from the round row and pushed back into the YouTube player so the host can keep scoring the buzz instead of being forced to start over with Next round.
 - 2026-05-09: When a song plays through to its natural end, the manager (and any other YouTube view) no longer leaks YouTube's endscreen tiles, which could include other tracks from the same artist's channel and spoil future rounds. The player now stops playback on `ENDED` and re-shows the "Song ended" cover.
 - 2026-05-09: YouTube player on the manager screen no longer fails with error 153 / "video player settings" - the embed iframe was being rebuilt every render with no video ID and bombarding the YouTube CDN (~10 req/s, hundreds of MB/min). Stabilised the player's mount effect so it initializes once per page lifetime.
@@ -16,6 +19,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-09: Team page now shows the same celebratory "FINAL RESULTS" podium (with confetti, trophy, WINNER label) that the display and manager already show, instead of a small "Game over." banner with a still-rendered (disabled) BUZZ button.
 - 2026-05-09: Round timer reworked. There is no longer a 20-second pre-buzz countdown. Instead, when a team buzzes, a 10-second countdown starts on the team and display screens so the buzzed team has a clear answer window. The manager screen no longer shows the timer.
 - 2026-05-07: Repo README pivots to a player-facing pitch with a "Play it at https://soundclash.org" CTA. The developer "Quick start" is removed; the repo is a public showcase, not soliciting external PRs. (PR #41)
 - 2026-05-07: Trimmed the home page intro and moved "How to Play" to its own `/how-to-play` page (with roles, game flow, and scoring sections). The home page now shows only the title, tagline, three role cards, and a small "How to Play" link.

--- a/PLAYTEST_FINDINGS.md
+++ b/PLAYTEST_FINDINGS.md
@@ -1,0 +1,174 @@
+# Sound Clash playtest — findings & follow-ups
+
+Driven through Playwright MCP against `http://localhost:5173` with backend on `:8000`.
+Game: 3 teams (Alpha / Bravo / Charlie) + Manager + Display, 3-round happy path
+plus a battery of edge / simple cases. This file is a punch list — each item has
+a Severity, where it surfaced, and (for fixes) a concrete plan. Items at the
+bottom are suggestions for later that I deliberately did **not** ship.
+
+## Status legend
+
+- 🔴 **Bug** — actual misbehaviour, fix in this pass.
+- 🟠 **UX gap** — works but reads wrong / surprises a user; fix in this pass if cheap.
+- 🟢 **Suggestion** — nice-to-have, leaving for the user to decide.
+
+---
+
+## Findings
+
+### ✅ 1. YouTube end-screen / pause-state suggestions revealed song info
+
+**Where:** Manager — embedded YouTube player after a buzz.
+
+**Symptom:** When a team buzzed, the player paused and YouTube's embedded
+"more videos" / channel cards appeared inside the iframe with related
+song titles + thumbnails (e.g. "Carly Rae Jepsen — Call Me Maybe",
+"Britney Spears — Oops!...I Did It Again"). Same with the natural-end
+state.
+
+**Fix shipped:** `YouTubePlayer` already covers the iframe on natural
+end via the existing `ended` state. Added a new `coverWhilePaused` prop
+that the manager wires from `lockedTeam != null`, so the same black
+"Ready" overlay is layered over the player while a buzz is being scored.
+The host (and the room behind them) no longer sees the YouTube pause-
+state thumbnail at all between buzz and award. (`YouTubePlayer.tsx` +
+`ManagerConsolePage.tsx`.)
+
+### ✅ 2. Team view never showed a "Winner" celebration after the game ended
+
+**Where:** `/team/<code>` after the host clicks End game.
+
+**Symptom:** All teams saw `Game over.` with the regular Scoreboard and
+a still-rendered (disabled) BUZZ button. No celebration, no winner
+acknowledgement — Display + Manager already showed a confetti podium.
+
+**Fix shipped:** When `state.game.status === "ended"`, the team page
+short-circuits to render the same `<EndScreen>` component the manager
+and display use. The team's row gets a "WINNER" pill if they won, and
+the BUZZ button is gone (there's nothing left to do). One existing
+test was updated from asserting "Game over." to asserting on the
+"FINAL RESULTS" heading + absence of the buzz button.
+
+### ✅ 3. End-round / Restart-song stayed active after a round was already scored
+
+**Where:** Manager Console.
+
+**Symptom:** After awarding points (or marking wrong), the round showed
+"Song ended" but `End round` and `Restart song` remained enabled.
+Clicking `End round` again hit `award_points` a second time, which the
+SQL function rejects with `round_already_ended` → confusing red toast.
+
+**Fix shipped:** The manager now derives `roundAlreadyScored` from
+`state.currentRound?.ended_at != null` and folds that into both
+`endRoundDisabled` and `restartDisabled`. After scoring, the only
+enabled action is "Next round", which is the intended path.
+
+### ✅ 4. YouTube iframe rendered in Hebrew on a Hebrew-locale browser
+
+**Where:** Manager — iframe player chrome.
+
+**Symptom:** Captions / button labels ("הפעלת הסרטון" / "הסתרת כפתורי
+הנגן") rendered in Hebrew because the YT API picks up the operator's
+browser/IP locale.
+
+**Fix shipped:** Added `hl: "en"` to the `playerVars` config in
+`YouTubePlayer.tsx`. Cosmetic, but keeps the host's view consistent
+across operator locales.
+
+---
+
+## Edge cases — exercised live, all green ✅
+
+- ✅ Timeout with no buzz → ending the round awards 0 points, advances cleanly
+- ✅ Wrong-buzz penalty → team can go and stay negative (-3, then -6 after a 2nd wrong)
+- ✅ Two teams buzzing → first to commit wins (`Latecomer buzzed first` shown
+  to the loser), losing team's button locks instantly via Realtime
+- ✅ Restart song → works (calls `selectSong(currentSong.id)`); the round
+  counter does increment because the SQL function unconditionally bumps
+  `round_number + 1`. Documented intentional behaviour
+  (`docs/game-rules.md` §11), see suggestion below for a UX polish.
+- ✅ Manager tab refresh mid-round → manager-token survives via
+  localStorage, console rehydrates, song reloads into the player from
+  `current_round.song_id`
+- ✅ Team tab refresh → team-id survives via localStorage, scoreboard +
+  ranking restored
+- ✅ End game from `waiting` state → goes straight to FINAL RESULTS with
+  a clean "Game ended without any teams." copy
+- ✅ Joining mid-round → late team sees current round number in their
+  header, their BUZZ button is live immediately
+- ✅ Duplicate team name → backend returns 409, friendly inline error
+  "That team name is already taken."
+- ✅ Mobile viewport (390 × 844) on team / manager / display — all three
+  flow on a phone (manager has a known overlap, see below)
+- ✅ Display "Enable sound" toggle — flips between 🔇 / 🔊 cleanly
+- ✅ Empty-state for invalid display code → "Game has ended or expired."
+  (note in suggestions — wording could be clearer for never-existed)
+- ✅ Empty-state for invalid join code → "That game code does not exist."
+
+## Items I deliberately did NOT fix (and why)
+
+- 🔵 **Catalog typo "Californiacation"**: this is a row in the `songs`
+  table, not a code bug. Worth a separate fixup but lives in the seed
+  data / production catalog — out of scope for a UI fix PR.
+
+- 🔵 **`docs/playwright-mcp-findings.md`**: separate doc, not touched
+  to keep this PR scoped to the UI fixes the user asked for.
+
+---
+
+## Suggestions (not implementing — for the user to choose)
+
+- 🟢 **Buzz audio / haptic feedback**: when a team buzzes, every
+  team's device could vibrate (`navigator.vibrate(50)`) and the
+  manager could hear a short blip. Makes simultaneous buzzes feel
+  less ambiguous on phones.
+
+- 🟢 **Manager "Skip song" shortcut**: separate from `End round
+  (timeout)`. Currently the only way to abandon a song is to end the
+  round, which records a timeout. A dedicated "Skip" that doesn't
+  attribute a timeout would be useful for "audio's broken / pick
+  another."
+
+- 🟢 **`Restart song` should not bump the round counter**: SQL-level.
+  Today `start_round` always does `round_number + 1`, so "Restart
+  song" jumps Round 2 → Round 3 even though the host's mental model is
+  "play the same one again." Fix would be a new RPC (e.g. `restart_round`)
+  that reuses `current_round_id` and just clears `buzzed_team_id` /
+  resets `ended_at` — no new `game_rounds` row. Behavioural change,
+  needs `docs/game-rules.md` §11 update.
+
+- 🟢 **Lobby "Start" gate by team count**: today the host can hit
+  Start game with 0 teams (no error, just an empty round). Disable
+  Start until ≥1 team has joined, or warn with a toast.
+
+- 🟢 **Mobile manager: floating action bar overlaps scoreboard**:
+  on 390 × 844 the sticky `Restart / End round / Next` footer covers
+  the top scoreboard row. Either pad the scroll area by the footer
+  height or auto-collapse the footer when the action set is purely
+  passive (between rounds).
+
+- 🟢 **Mobile manager: song title is visible in the iframe thumbnail**.
+  Even with `coverWhilePaused`, the *first* frame of a paused video
+  shows the title above the thumbnail. Could be hidden by always
+  starting `coverWhilePaused=true` until the round is "in progress
+  and unbuzzed".
+
+- 🟢 **Display QR contrast**: light grey on light gradient background
+  is hard for a phone camera at TV-watching distance. Bump to
+  white-on-black inside the QR card.
+
+- 🟢 **Display empty-state copy for invalid code**: currently shows
+  "Game has ended or expired." even if the code never existed. A
+  separate "Game not found." path would be friendlier.
+
+- 🟢 **Manager kick-team UI**: `kickTeam` API + backend endpoint exist
+  (`DELETE /games/{code}/teams/{id}` + `kickTeam` in `lib/api.ts`),
+  but no UI surfaces it. Would be a single trash icon next to each
+  team in the manager Teams panel.
+
+- 🟢 **Per-team buzz history**: a small "buzzed first N times" stat at
+  the end of the game — fun for replay value.
+
+- 🟢 **Catalog cleanup**: at least one row has a typo
+  ("Californiacation" → "Californication"). A periodic catalog audit
+  (or a host-side report-broken-row link) would help.

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -10,6 +10,10 @@ export interface YouTubePlayerHandle {
 
 interface Props {
   hideOverlay?: boolean;
+  // When true, keep the cover visible even while the video is loaded (used by
+  // the manager view during a buzz / scoring pause so YouTube's pause-state
+  // "more videos" tiles can't leak song titles to the room).
+  coverWhilePaused?: boolean;
   onReady?: () => void;
   onError?: (code: number) => void;
 }
@@ -78,7 +82,7 @@ function loadApi(): Promise<YTNamespace> {
 }
 
 export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function YouTubePlayer(
-  { hideOverlay, onReady, onError },
+  { hideOverlay, coverWhilePaused, onReady, onError },
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -116,6 +120,10 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
           controls: 0,
           disablekb: 1,
           playsinline: 1,
+          // Force English UI strings on the iframe chrome so a host whose
+          // browser is set to e.g. Hebrew doesn't see "הפעלת הסרטון" /
+          // "סרטונים נוספים" in the player overlay.
+          hl: "en",
         },
         events: {
           onReady: () => {
@@ -163,7 +171,8 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     [],
   );
 
-  const overlayHidden = hideOverlay && loaded && errorCode === null && !ended;
+  const overlayHidden =
+    hideOverlay && loaded && errorCode === null && !ended && !coverWhilePaused;
   return (
     <div className={styles.wrapper} data-testid="youtube-player" data-ready={loaded}>
       <div ref={containerRef} className={styles.player} />

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -171,8 +171,7 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     [],
   );
 
-  const overlayHidden =
-    hideOverlay && loaded && errorCode === null && !ended && !coverWhilePaused;
+  const overlayHidden = hideOverlay && loaded && errorCode === null && !ended && !coverWhilePaused;
   return (
     <div className={styles.wrapper} data-testid="youtube-player" data-ready={loaded}>
       <div ref={containerRef} className={styles.player} />

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -293,10 +293,20 @@ export function ManagerConsolePage() {
   const statusClass = game.status === "playing" ? styles.statusPlaying : styles.statusWaiting;
 
   const nextRoundDisabled = busy || !player.ready;
+  // Once a round has been scored (ended_at set), the only meaningful action is
+  // "Next round". Calling award_points or selectSong(currentSong) again hits a
+  // round_already_ended SQL error, which surfaces as a confusing red toast --
+  // it's clearer to grey the button out so the host knows where to go next.
+  const roundAlreadyScored = state.currentRound?.ended_at != null;
   const restartDisabled =
-    busy || game.status !== "playing" || !currentSong || !player.ready || lockedTeam != null;
+    busy ||
+    game.status !== "playing" ||
+    !currentSong ||
+    !player.ready ||
+    lockedTeam != null ||
+    roundAlreadyScored;
   const scoringDisabled = busy || !lockedTeam;
-  const endRoundDisabled = busy || game.status !== "playing";
+  const endRoundDisabled = busy || game.status !== "playing" || roundAlreadyScored;
   const bonusDisabled = busy || teams.length === 0;
   const nextRoundLabel = game.status === "waiting" ? "Start game" : "Next round";
 
@@ -328,7 +338,12 @@ export function ManagerConsolePage() {
 
       <div className={styles.grid}>
         <div className={styles.column}>
-          <YouTubePlayer ref={playerRef} hideOverlay onReady={onPlayerReady} />
+          <YouTubePlayer
+            ref={playerRef}
+            hideOverlay
+            coverWhilePaused={lockedTeam != null}
+            onReady={onPlayerReady}
+          />
 
           <section className={styles.card}>
             <div className={styles.roundHeader}>

--- a/frontend/src/pages/TeamGameplayPage.test.tsx
+++ b/frontend/src/pages/TeamGameplayPage.test.tsx
@@ -164,7 +164,7 @@ describe("TeamGameplayPage", () => {
     expect(screen.getByText("join page")).toBeInTheDocument();
   });
 
-  it("shows the 'Game over.' banner when the game has ended", async () => {
+  it("renders the EndScreen podium when the game has ended", async () => {
     window.localStorage.setItem(
       "game:ABCDEF:team",
       JSON.stringify({ id: "team-1", name: "Alice" }),
@@ -178,8 +178,8 @@ describe("TeamGameplayPage", () => {
     await act(async () => {
       await fireSubscribed();
     });
-    expect(screen.getByText(/^game over\.$/i)).toBeInTheDocument();
-    expect(screen.getByTestId("buzz")).toBeDisabled();
+    expect(screen.getByText(/^final results$/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("buzz")).not.toBeInTheDocument();
   });
 
   it("does not render the post-buzz timer before any team has buzzed", async () => {

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BuzzButton } from "../components/BuzzButton";
+import { EndScreen } from "../components/EndScreen";
 import { Scoreboard } from "../components/Scoreboard";
 import { useBuzzer } from "../hooks/useBuzzer";
 import { useGameChannel } from "../hooks/useGameChannel";
@@ -58,6 +59,18 @@ export function TeamGameplayPage() {
         <div className={`${styles.statusBanner} ${styles.statusEnded}`}>
           This game has ended or expired.
         </div>
+      </main>
+    );
+  }
+
+  // Once the host has ended the game, surface the same celebratory podium the
+  // display + manager show. The team's own row gets a "YOU" pill via the
+  // EndScreen sort, and the BUZZ button is gone — there's nothing left to do.
+  if (state?.game.status === "ended") {
+    const finalTeams = Array.from(state.teams.values());
+    return (
+      <main className={styles.shell}>
+        <EndScreen teams={finalTeams} gameCode={gameCode} />
       </main>
     );
   }


### PR DESCRIPTION
## Summary

Drove the live app through Playwright MCP across one happy-path 3-round game and the full edge-case battery (timeout, wrong-buzz, near-simultaneous buzzes, refreshes, mid-game join, duplicate name, end-from-waiting, mobile viewport). Findings + plan written up in `PLAYTEST_FINDINGS.md`. This PR ships the four UI fixes that surfaced; the rest of the doc is scoped out as suggestions for you to triage.

- **YouTube pause-state spoilers**: when a team buzzes, the manager's iframe used to flash YT's "more videos" tiles (which can include other songs from the same artist's channel). New `coverWhilePaused` prop on `YouTubePlayer` keeps the black "Ready" overlay layered on top while a buzz is being scored. Same overlay logic, just extended to the buzz-paused state.
- **Team page now shows the FINAL RESULTS podium** (confetti + WINNER label) on game-end, instead of a small "Game over." banner with a still-rendered disabled BUZZ. Reuses the existing `<EndScreen>` component the display + manager already use.
- **Manager `End round` / `Restart song` disable after a round was already scored.** Today a second click hits `award_points` again, which the SQL function rejects with `round_already_ended` → confusing red toast. Now derived from `currentRound.ended_at`.
- **YouTube embed locale**: `playerVars.hl = "en"` so a host on a Hebrew-locale browser doesn't see Hebrew chrome bleed through the iframe overlay.

## Test plan

- [x] Frontend `npm run typecheck` clean
- [x] Frontend `npm run lint` clean
- [x] Frontend `npm run test:run` — 195 tests / 23 files pass (one existing test updated from "Game over." → "FINAL RESULTS" + buzz button absence)
- [x] Live: 3-round happy-path with 3+ teams, podium renders on team / display / manager
- [x] Live: buzz → manager iframe stays covered, no YT thumbnail leak
- [x] Live: after `End round`, `Restart song` and `End round` both disable; only `Next round` is enabled
- [x] Live: end-game-from-waiting empty state
- [x] Mobile viewport (390 × 844) screenshots captured for team / manager / display

`PLAYTEST_FINDINGS.md` lists everything I deliberately didn't touch (mobile manager footer overlap, "Restart song" SQL-level round-counter bump, kick-team UI, catalog typo "Californiacation", display QR contrast, etc.) so we can decide which of those to do in follow-ups.