### PR TITLE
Buzzer status modes + remove manager scoreboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-09: Team buzzer now shows four explicit status modes with matching colors: grey **Waiting** before the host starts the round, green **Playing** when the song is live, gold **You Buzzed** when this team is locked in awaiting adjudication, red **Someone else buzzed** when another team got there first. Replaces the old single-label BUZZ / LOCKED button.
 - 2026-05-09: Team page now shows the same celebratory "FINAL RESULTS" podium (with confetti, trophy, WINNER label) that the display and manager already show, instead of a small "Game over." banner with a still-rendered (disabled) BUZZ button.
 - 2026-05-09: Round timer reworked. There is no longer a 20-second pre-buzz countdown. Instead, when a team buzzes, a 10-second countdown starts on the team and display screens so the buzzed team has a clear answer window. The manager screen no longer shows the timer.
 - 2026-05-07: Repo README pivots to a player-facing pitch with a "Play it at https://soundclash.org" CTA. The developer "Quick start" is removed; the repo is a public showcase, not soliciting external PRs. (PR #41)
@@ -29,6 +30,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Removed
 
+- 2026-05-09: Removed the duplicate scoreboard and teams list from the manager console. Both already render on the Display screen (the projector view), and the host's screen now focuses purely on round controls.
 - 2026-05-09: Removed the "Invite players" QR/URL panel from the manager console - the game code is already prominent in the header and on the empty-teams hint, so the second copy was clutter.
 - 2026-05-09: Removed the per-team "Kick" button from the manager console. To get rid of a team, the host can end the game and start a fresh one.
 - 2026-05-07: Removed the "Rounds" picker from the Create-Game form. Games now run for as many rounds as the host wants and end only when the host clicks "End game"; round counters across the team page, display, and manager console show "Round N" without a denominator.

--- a/frontend/src/components/BuzzButton.module.css
+++ b/frontend/src/components/BuzzButton.module.css
@@ -12,10 +12,12 @@
   background: linear-gradient(135deg, #10b981 0%, #059669 100%);
   color: #fff;
   font-family: var(--font-display);
-  font-size: 3rem;
+  font-size: clamp(1.6rem, 6vw, 2.6rem);
   font-weight: 900;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+  text-align: center;
+  padding: 1.25rem;
   cursor: pointer;
   box-shadow:
     0 10px 40px rgba(16, 185, 129, 0.4),
@@ -72,6 +74,15 @@
   opacity: 1;
 }
 
+.toneWaiting:disabled {
+  background: linear-gradient(135deg, #94a3b8 0%, #475569 100%);
+  color: #f8fafc;
+  box-shadow:
+    0 6px 20px rgba(71, 85, 105, 0.35),
+    0 0 0 4px rgba(148, 163, 184, 0.18);
+  opacity: 1;
+}
+
 .toneWinner {
   animation: winner-celebrate 700ms cubic-bezier(0.34, 1.56, 0.64, 1) 1;
 }
@@ -101,6 +112,10 @@
   position: relative;
   z-index: 1;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  max-width: 100%;
+  line-height: 1.05;
+  word-break: break-word;
+  hyphens: none;
 }
 
 .subtitle {
@@ -130,7 +145,6 @@
 
 @media (max-width: 768px) {
   .button {
-    font-size: 2.5rem;
     width: min(85vw, 320px);
     height: min(85vw, 320px);
   }
@@ -138,7 +152,6 @@
 
 @media (max-width: 480px) {
   .button {
-    font-size: 2rem;
     width: min(90vw, 280px);
     height: min(90vw, 280px);
   }
@@ -146,7 +159,6 @@
 
 @media (min-width: 1200px) {
   .button {
-    font-size: 3.5rem;
     width: 420px;
     height: 420px;
   }

--- a/frontend/src/components/BuzzButton.test.tsx
+++ b/frontend/src/components/BuzzButton.test.tsx
@@ -81,6 +81,8 @@ describe("BuzzButton", () => {
     expect(screen.getByTestId("buzz")).toHaveAttribute("data-tone", "locked-other");
     rerender(<BuzzButton disabled isBuzzing={false} tone="winner" onBuzz={() => {}} />);
     expect(screen.getByTestId("buzz")).toHaveAttribute("data-tone", "winner");
+    rerender(<BuzzButton disabled isBuzzing={false} tone="waiting" onBuzz={() => {}} />);
+    expect(screen.getByTestId("buzz")).toHaveAttribute("data-tone", "waiting");
     rerender(<BuzzButton disabled={false} isBuzzing={false} onBuzz={() => {}} />);
     expect(screen.getByTestId("buzz")).toHaveAttribute("data-tone", "idle");
   });

--- a/frontend/src/components/BuzzButton.tsx
+++ b/frontend/src/components/BuzzButton.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type KeyboardEvent } from "react";
 import styles from "./BuzzButton.module.css";
 
-export type BuzzTone = "idle" | "locked-other" | "winner";
+export type BuzzTone = "idle" | "locked-other" | "winner" | "waiting";
 
 interface Props {
   disabled: boolean;
@@ -44,7 +44,13 @@ export function BuzzButton({
   };
 
   const toneClass =
-    tone === "winner" ? styles.toneWinner : tone === "locked-other" ? styles.toneLockedOther : "";
+    tone === "winner"
+      ? styles.toneWinner
+      : tone === "locked-other"
+        ? styles.toneLockedOther
+        : tone === "waiting"
+          ? styles.toneWaiting
+          : "";
 
   const className = [styles.button, pressed ? styles.pressed : "", toneClass]
     .filter(Boolean)

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -94,18 +94,6 @@
   align-items: center;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
-}
-
-@media (min-width: 960px) {
-  .grid {
-    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-  }
-}
-
 .column {
   display: flex;
   flex-direction: column;
@@ -513,73 +501,6 @@
   .mobileBar .btn {
     padding: 14px 12px;
   }
-}
-
-.teamRow {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  background: #ffffff;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  margin-bottom: 8px;
-  transition: border-color 200ms ease;
-}
-
-.teamRow:last-child {
-  margin-bottom: 0;
-}
-
-.teamRow:hover {
-  border-color: var(--color-primary);
-}
-
-.teamRowName {
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.teamRowMeta {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  color: var(--color-text-dim);
-  font-size: 0.95rem;
-}
-
-.emptyTeams {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 0.4rem;
-  padding: 1.75rem 1rem;
-  background: linear-gradient(180deg, rgba(59, 130, 246, 0.04) 0%, transparent 100%);
-  border: 1px dashed var(--color-border-strong);
-  border-radius: var(--radius-md);
-  color: var(--color-text-dim);
-}
-
-.emptyTeamsTitle {
-  margin: 0;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.emptyTeamsHint {
-  margin: 0;
-  font-size: 0.9rem;
-}
-
-.emptyTeamsCode {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-weight: 800;
-  letter-spacing: 0.16em;
-  background: linear-gradient(135deg, #3b82f6 0%, #06b6d4 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
 }
 
 .skeletonStack {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { EndScreen } from "../components/EndScreen";
-import { Scoreboard } from "../components/Scoreboard";
 import { Skeleton } from "../components/Skeleton";
 import { YouTubePlayer, type YouTubePlayerHandle } from "../components/YouTubePlayer";
 import { useToast } from "../context/useToast";
@@ -336,172 +335,139 @@ export function ManagerConsolePage() {
         </div>
       </header>
 
-      <div className={styles.grid}>
-        <div className={styles.column}>
-          <YouTubePlayer
-            ref={playerRef}
-            hideOverlay
-            coverWhilePaused={lockedTeam != null}
-            onReady={onPlayerReady}
-          />
+      <div className={styles.column}>
+        <YouTubePlayer
+          ref={playerRef}
+          hideOverlay
+          coverWhilePaused={lockedTeam != null}
+          onReady={onPlayerReady}
+        />
 
-          <section className={styles.card}>
-            <div className={styles.roundHeader}>
-              <div className={styles.roundHeaderInfo}>
-                <span className={styles.cardTitle}>Round controls</span>
-                {currentSong ? (
-                  <>
-                    <p className={styles.songLine}>{currentSong.title}</p>
-                    <p className={styles.songMeta}>
-                      {currentSong.artist}
-                      {currentSong.source ? ` - ${currentSong.source}` : ""}
-                    </p>
-                  </>
-                ) : (
-                  <p className={styles.songMeta}>No round started yet.</p>
-                )}
-              </div>
+        <section className={styles.card}>
+          <div className={styles.roundHeader}>
+            <div className={styles.roundHeaderInfo}>
+              <span className={styles.cardTitle}>Round controls</span>
+              {currentSong ? (
+                <>
+                  <p className={styles.songLine}>{currentSong.title}</p>
+                  <p className={styles.songMeta}>
+                    {currentSong.artist}
+                    {currentSong.source ? ` - ${currentSong.source}` : ""}
+                  </p>
+                </>
+              ) : (
+                <p className={styles.songMeta}>No round started yet.</p>
+              )}
             </div>
+          </div>
 
-            {lockedTeam ? (
-              <div className={styles.lockedBanner} role="status" aria-live="polite">
-                <span className={styles.lockedTeam}>{lockedTeam.name}</span> buzzed in. Score the
-                answer:
-              </div>
-            ) : null}
-
-            <div className={styles.scoreRow} aria-disabled={scoringDisabled}>
-              <button
-                type="button"
-                className={`${styles.scoreBtn} ${styles.scorePositive} ${titleCorrect ? styles.scoreActive : ""}`}
-                onClick={toggleTitle}
-                disabled={scoringDisabled}
-                aria-pressed={titleCorrect}
-                data-testid="score-title"
-              >
-                <span className={styles.scoreLabel}>Correct Song</span>
-                <span className={styles.scorePoints}>+10</span>
-              </button>
-              <button
-                type="button"
-                className={`${styles.scoreBtn} ${styles.scorePositive} ${artistCorrect ? styles.scoreActive : ""}`}
-                onClick={toggleArtist}
-                disabled={scoringDisabled}
-                aria-pressed={artistCorrect}
-                data-testid="score-artist"
-              >
-                <span className={styles.scoreLabel}>Correct Artist</span>
-                <span className={styles.scorePoints}>+5</span>
-              </button>
-              <button
-                type="button"
-                className={`${styles.scoreBtn} ${styles.scoreNegative} ${wrongBuzz ? styles.scoreActiveNeg : ""}`}
-                onClick={toggleWrong}
-                disabled={scoringDisabled}
-                aria-pressed={wrongBuzz}
-                data-testid="score-wrong"
-              >
-                <span className={styles.scoreLabel}>Wrong</span>
-                <span className={styles.scorePoints}>-3</span>
-              </button>
-              <button
-                type="button"
-                className={`${styles.scoreBtn} ${styles.scoreBonus} ${bonusOpen ? styles.scoreActiveBonus : ""}`}
-                onClick={() => setBonusOpen((o) => !o)}
-                disabled={bonusDisabled}
-                aria-expanded={bonusOpen}
-                aria-controls="bonus-team-picker"
-                data-testid="score-bonus"
-              >
-                <span className={styles.scoreLabel}>Bonus</span>
-                <span className={styles.scorePoints}>+4</span>
-              </button>
+          {lockedTeam ? (
+            <div className={styles.lockedBanner} role="status" aria-live="polite">
+              <span className={styles.lockedTeam}>{lockedTeam.name}</span> buzzed in. Score the
+              answer:
             </div>
+          ) : null}
 
-            {bonusOpen ? (
-              <div
-                id="bonus-team-picker"
-                className={styles.bonusPicker}
-                role="group"
-                aria-label="Pick a team for the bonus"
-              >
-                <span className={styles.bonusPickerHint}>Award +4 to:</span>
-                <div className={styles.bonusPickerList}>
-                  {teams.map((t) => (
-                    <button
-                      key={t.id}
-                      type="button"
-                      className="btn btn-ghost"
-                      onClick={() => void handleBonus(t.id, t.name)}
-                      disabled={busy}
-                      data-testid={`bonus-team-${t.id}`}
-                    >
-                      {t.name}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+          <div className={styles.scoreRow} aria-disabled={scoringDisabled}>
+            <button
+              type="button"
+              className={`${styles.scoreBtn} ${styles.scorePositive} ${titleCorrect ? styles.scoreActive : ""}`}
+              onClick={toggleTitle}
+              disabled={scoringDisabled}
+              aria-pressed={titleCorrect}
+              data-testid="score-title"
+            >
+              <span className={styles.scoreLabel}>Correct Song</span>
+              <span className={styles.scorePoints}>+10</span>
+            </button>
+            <button
+              type="button"
+              className={`${styles.scoreBtn} ${styles.scorePositive} ${artistCorrect ? styles.scoreActive : ""}`}
+              onClick={toggleArtist}
+              disabled={scoringDisabled}
+              aria-pressed={artistCorrect}
+              data-testid="score-artist"
+            >
+              <span className={styles.scoreLabel}>Correct Artist</span>
+              <span className={styles.scorePoints}>+5</span>
+            </button>
+            <button
+              type="button"
+              className={`${styles.scoreBtn} ${styles.scoreNegative} ${wrongBuzz ? styles.scoreActiveNeg : ""}`}
+              onClick={toggleWrong}
+              disabled={scoringDisabled}
+              aria-pressed={wrongBuzz}
+              data-testid="score-wrong"
+            >
+              <span className={styles.scoreLabel}>Wrong</span>
+              <span className={styles.scorePoints}>-3</span>
+            </button>
+            <button
+              type="button"
+              className={`${styles.scoreBtn} ${styles.scoreBonus} ${bonusOpen ? styles.scoreActiveBonus : ""}`}
+              onClick={() => setBonusOpen((o) => !o)}
+              disabled={bonusDisabled}
+              aria-expanded={bonusOpen}
+              aria-controls="bonus-team-picker"
+              data-testid="score-bonus"
+            >
+              <span className={styles.scoreLabel}>Bonus</span>
+              <span className={styles.scorePoints}>+4</span>
+            </button>
+          </div>
 
-            <div className={styles.actionsInline}>
-              <button
-                className="btn btn-ghost"
-                onClick={() => void handleRestartSong()}
-                disabled={restartDisabled}
-                data-testid="restart-song"
-              >
-                Restart song
-              </button>
-              <button
-                className={`btn btn-primary ${styles.awardBtn}`}
-                onClick={() => void handleEndRound(!lockedTeam)}
-                disabled={endRoundDisabled}
-                data-testid="end-round"
-              >
-                End round
-              </button>
-              <button
-                className="btn btn-primary"
-                onClick={() => void handleNextRound()}
-                disabled={nextRoundDisabled}
-                data-testid="start-round"
-              >
-                {nextRoundLabel}
-              </button>
-            </div>
-          </section>
-        </div>
-
-        <div className={styles.column}>
-          <section className={styles.card}>
-            <h2 className={styles.cardTitle}>Scoreboard</h2>
-            <Scoreboard teams={teams} buzzedTeamId={game.buzzed_team_id} />
-          </section>
-
-          <section className={styles.card}>
-            <h2 className={styles.cardTitle}>Teams</h2>
-            {teams.length === 0 ? (
-              <div className={styles.emptyTeams}>
-                <p className={styles.emptyTeamsTitle}>No teams have joined yet.</p>
-                <p className={styles.emptyTeamsHint}>
-                  Share <span className={styles.emptyTeamsCode}>{gameCode}</span> with players -
-                  they'll appear here once they join.
-                </p>
-              </div>
-            ) : (
-              <div>
+          {bonusOpen ? (
+            <div
+              id="bonus-team-picker"
+              className={styles.bonusPicker}
+              role="group"
+              aria-label="Pick a team for the bonus"
+            >
+              <span className={styles.bonusPickerHint}>Award +4 to:</span>
+              <div className={styles.bonusPickerList}>
                 {teams.map((t) => (
-                  <div key={t.id} className={styles.teamRow} data-team-id={t.id}>
-                    <span className={styles.teamRowName}>{t.name}</span>
-                    <span className={styles.teamRowMeta}>
-                      <span>{t.score} pts</span>
-                    </span>
-                  </div>
+                  <button
+                    key={t.id}
+                    type="button"
+                    className="btn btn-ghost"
+                    onClick={() => void handleBonus(t.id, t.name)}
+                    disabled={busy}
+                    data-testid={`bonus-team-${t.id}`}
+                  >
+                    {t.name}
+                  </button>
                 ))}
               </div>
-            )}
-          </section>
-        </div>
+            </div>
+          ) : null}
+
+          <div className={styles.actionsInline}>
+            <button
+              className="btn btn-ghost"
+              onClick={() => void handleRestartSong()}
+              disabled={restartDisabled}
+              data-testid="restart-song"
+            >
+              Restart song
+            </button>
+            <button
+              className={`btn btn-primary ${styles.awardBtn}`}
+              onClick={() => void handleEndRound(!lockedTeam)}
+              disabled={endRoundDisabled}
+              data-testid="end-round"
+            >
+              End round
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={() => void handleNextRound()}
+              disabled={nextRoundDisabled}
+              data-testid="start-round"
+            >
+              {nextRoundLabel}
+            </button>
+          </div>
+        </section>
       </div>
 
       <div className={styles.mobileBar} role="toolbar" aria-label="Round actions">

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { BuzzButton } from "../components/BuzzButton";
+import { BuzzButton, type BuzzTone } from "../components/BuzzButton";
 import { EndScreen } from "../components/EndScreen";
 import { Scoreboard } from "../components/Scoreboard";
 import { useBuzzer } from "../hooks/useBuzzer";
@@ -108,19 +108,19 @@ export function TeamGameplayPage() {
   const buzzDisabled =
     !state || status !== "subscribed" || game?.status !== "playing" || buzzer.isLocked;
 
-  const buzzTone: "idle" | "locked-other" | "winner" = lockedByMe
-    ? "winner"
-    : lockedTeam
-      ? "locked-other"
-      : "idle";
-  const buzzSubtitle =
-    game?.status === "playing"
-      ? lockedByMe
-        ? "Wait for the host"
-        : lockedTeam
-          ? `${lockedTeam.name} buzzed first`
-          : "Tap or press space"
-      : undefined;
+  const buzz = ((): { tone: BuzzTone; label: string; subtitle: string } => {
+    if (game?.status === "playing") {
+      if (lockedByMe) return { tone: "winner", label: "YOU BUZZED", subtitle: "Wait for the host" };
+      if (lockedTeam)
+        return {
+          tone: "locked-other",
+          label: "SOMEONE ELSE BUZZED",
+          subtitle: `${lockedTeam.name} got it first`,
+        };
+      return { tone: "idle", label: "PLAYING", subtitle: "Tap to buzz in" };
+    }
+    return { tone: "waiting", label: "WAITING", subtitle: "Waiting for host…" };
+  })();
 
   const connectionLabel = status === "subscribed" ? "Connected" : "Connecting…";
   const connectionStateClass = status === "subscribed" ? styles.connOk : styles.connWait;
@@ -174,9 +174,9 @@ export function TeamGameplayPage() {
         <BuzzButton
           disabled={buzzDisabled}
           isBuzzing={buzzer.isBuzzing}
-          label={lockedByMe ? "LOCKED" : "BUZZ"}
-          subtitle={buzzSubtitle}
-          tone={buzzTone}
+          label={buzz.label}
+          subtitle={buzz.subtitle}
+          tone={buzz.tone}
           onBuzz={() => void buzzer.buzz()}
         />
       </div>

--- a/tests/e2e/manager_cleanup_yt_csp.spec.ts
+++ b/tests/e2e/manager_cleanup_yt_csp.spec.ts
@@ -22,11 +22,11 @@ test.describe("manager-cleanup-yt-csp branch", () => {
     const manager = await openManagerAndCreateGame(browser, { genreName: "Rock" });
     const team = await joinAsTeam(browser, manager.gameCode, "Solo");
 
-    // Wait for the team to show up in the manager's Teams panel so the
-    // negative assertion below isn't racing the realtime hydrate. The
-    // team name renders in BOTH the Scoreboard and the Teams panel, so
-    // we wait for at least one occurrence.
-    await expect(manager.page.getByText("Solo").first()).toBeVisible({ timeout: 10_000 });
+    // Wait for the manager page to be fully hydrated before negative
+    // assertions. The Round controls card is always present once the
+    // game row has loaded; the manager page no longer shows a Scoreboard
+    // or Teams list, so we can't wait on the team name to appear.
+    await expect(manager.page.getByText(/round controls/i)).toBeVisible({ timeout: 10_000 });
 
     // #1: no "Invite Players" heading anywhere.
     await expect(


### PR DESCRIPTION
## Summary

- Team buzzer now displays four explicit status modes with distinct colors and labels: **WAITING** (grey, before host starts), **PLAYING** (green, can buzz), **YOU BUZZED** (gold, this team locked in), **SOMEONE ELSE BUZZED** (red, another team got it first). Replaces the old single `BUZZ`/`LOCKED` label so the team always knows which of the four phases they're in at a glance.
- Removed the duplicate **Scoreboard** and **Teams** cards from the manager console - both already render on the Display screen, and the host's screen now focuses purely on round controls.
- One internal refactor: `TeamGameplayPage` now derives `{tone, label, subtitle}` from a single helper instead of three nested ternaries that silently bypassed the disabled/waiting branch.

## Test plan

- [x] `npm run lint` / `npm run typecheck` clean
- [x] `npm run test:run` - 195/195 tests pass
- [x] `npm run test:coverage` - 91% statements / 94% lines (no regression)
- [x] `npm run build` succeeds
- [x] Playwright MCP manual smoke: 1 manager + 2 teams, all four buzzer states verified end-to-end (`data-tone` attribute matches state machine, manager screen has no Scoreboard/Teams cards)
- [ ] CI E2E job passes (covers `manager_cleanup_yt_csp` updated wait condition + buzzer race + full game flows)