### PR TITLE
UI cleanup: manager + team trim, display point pill, BUZZ recolor, podium heights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ Thumbs.db
 .claude/rules/
 .claude/*.local
 .claude/*.local.*
+# Personal scratch notes Claude creates during a session (e.g. "screenshots issues" punch lists)
+.claude/screenshots*
 
 # Supabase local
 supabase/.branches/
@@ -67,6 +69,12 @@ supabase/.temp/
 test-results/
 playwright-report/
 playwright/.cache/
+# Playwright MCP working cache (console + page-snapshot artifacts)
+.playwright-mcp/
+
+# Generated UI snapshots: regenerable from the local dev stack via Playwright MCP.
+# Per .claude/rules/binary-assets.md, don't commit binaries without asking.
+screenshots/
 
 # Wrangler local cache
 .wrangler/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project does not currently cut versioned releases; every change lands direc
 
 ## [Unreleased]
 
+### Added
+
+- 2026-05-10: Display screen now pops a small floating pill ("Alpha +10", "Bravo -3") whenever a team's score changes, so the audience watching the projector can see *who* just got points and how many without having to re-read the scoreboard.
+
+### Changed
+
+- 2026-05-10: Team buzzer page is now a single-purpose surface: just team name, round pill, and the buzz button. Status banner ("Waiting for the host…", "Buzz when you know it!", "{team} locked it.", "You buzzed in!"), the "Connected" pill, the game code, and the secondary scoreboard are all removed - the buzz button's own colour and label communicate the round state.
+- 2026-05-10: The "You buzzed" buzz button is now blue (was amber) so the colour no longer reads as a yellow "warning / waiting" cue.
+- 2026-05-10: BUZZ button copy slimmed down: idle reads just "BUZZ" (no subtitle), waiting reads "WAITING / for the game to start", you-buzzed reads just "YOU BUZZED".
+- 2026-05-10: End-of-game podium heights are now strictly ordered 1st > 2nd > 3rd in pixel height, so when 1st place has one team but 2nd holds two tied teams the gold card still visibly outranks silver.
+
+### Removed
+
+- 2026-05-10: Removed the "Home" and "Restart song" buttons from the manager console. The header trims to just "End game"; the round-controls toolbar trims to "End round" + "Next round" / "Start game".
+
 ### Fixed
 
 - 2026-05-09: When a team buzzes, the manager's YouTube player no longer flashes the paused-state "more videos" tiles (which can include other songs in the same artist's channel and spoil future rounds). The black "Ready" overlay now stays on top of the iframe whenever a buzz is being scored.

--- a/frontend/src/components/BuzzButton.module.css
+++ b/frontend/src/components/BuzzButton.module.css
@@ -88,11 +88,11 @@
 }
 
 .toneWinner:disabled {
-  background: linear-gradient(135deg, #fbbf24 0%, #d97706 100%);
-  color: #fff;
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+  color: #ffffff;
   box-shadow:
-    0 12px 40px rgba(245, 158, 11, 0.55),
-    0 0 0 8px rgba(245, 158, 11, 0.22);
+    0 12px 40px rgba(59, 130, 246, 0.55),
+    0 0 0 8px rgba(59, 130, 246, 0.22);
   opacity: 1;
 }
 

--- a/frontend/src/components/EndScreen.module.css
+++ b/frontend/src/components/EndScreen.module.css
@@ -241,6 +241,12 @@
   gap: 0.55rem;
   width: 100%;
   overflow-y: auto;
+  /* Scroll is only meaningful when 4+ teams tie at one rank; hide the bar
+     so it doesn't render as visual chrome on the typical 1-3-team case. */
+  scrollbar-width: none;
+}
+.podiumTeams::-webkit-scrollbar {
+  display: none;
 }
 
 .podiumTeam {

--- a/frontend/src/components/EndScreen.module.css
+++ b/frontend/src/components/EndScreen.module.css
@@ -125,7 +125,6 @@
   background: #ffffff;
   border: 2px solid var(--color-border);
   box-shadow: var(--shadow-lg);
-  min-height: 200px;
   opacity: 0;
   animation-fill-mode: forwards;
 }
@@ -135,11 +134,12 @@
   visibility: hidden;
 }
 
+/* Heights are fixed (not min-height) so 1st > 2nd > 3rd holds even when 2nd
+   places hold 2-3 tied teams. Inner podiumTeams scrolls if it overflows. */
 .gold {
   background: linear-gradient(160deg, #fef3c7 0%, #fde68a 50%, #fbbf24 100%);
   border-color: #f59e0b;
-  min-height: 260px;
-  transform: translateY(-24px);
+  height: 320px;
   box-shadow:
     0 18px 50px rgba(245, 158, 11, 0.35),
     0 0 0 6px rgba(245, 158, 11, 0.18);
@@ -151,14 +151,14 @@
 .silver {
   background: linear-gradient(160deg, #f8fafc 0%, #e2e8f0 50%, #cbd5e1 100%);
   border-color: #94a3b8;
-  min-height: 230px;
+  height: 250px;
   animation: podium-rise 550ms cubic-bezier(0.34, 1.56, 0.64, 1) 350ms forwards;
 }
 
 .bronze {
   background: linear-gradient(160deg, #fef3c7 0%, #fbbf24 30%, #d97706 100%);
   border-color: #b45309;
-  min-height: 200px;
+  height: 200px;
   animation: podium-rise 500ms cubic-bezier(0.34, 1.56, 0.64, 1) 0ms forwards;
 }
 
@@ -171,10 +171,6 @@
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.gold {
-  /* gold uses translateY(-24px) at rest; keyframes for rise + glow override correctly */
 }
 
 @keyframes gold-glow {
@@ -244,6 +240,7 @@
   flex-direction: column;
   gap: 0.55rem;
   width: 100%;
+  overflow-y: auto;
 }
 
 .podiumTeam {
@@ -407,13 +404,14 @@
     align-items: stretch;
   }
   .gold {
-    transform: none;
     order: -1;
-    min-height: 200px;
+    height: 240px;
   }
-  .silver,
+  .silver {
+    height: 200px;
+  }
   .bronze {
-    min-height: 160px;
+    height: 170px;
   }
   .gold .medal {
     width: 60px;

--- a/frontend/src/components/PointChange.module.css
+++ b/frontend/src/components/PointChange.module.css
@@ -1,0 +1,67 @@
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1.5rem;
+  border-radius: var(--radius-pill);
+  background: #ffffff;
+  border: 2px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  font-weight: 800;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  pointer-events: none;
+  animation:
+    point-in 280ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    point-out 360ms ease-in 2140ms forwards;
+}
+
+.team {
+  color: #0f172a;
+  font-size: 1.2rem;
+}
+
+.delta {
+  font-variant-numeric: tabular-nums;
+  font-size: 1.65rem;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+.positive {
+  border-color: var(--color-success);
+  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+}
+.positive .delta {
+  color: #047857;
+}
+
+.negative {
+  border-color: var(--color-danger);
+  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+}
+.negative .delta {
+  color: #b91c1c;
+}
+
+@keyframes point-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes point-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.96);
+  }
+}

--- a/frontend/src/components/PointChange.tsx
+++ b/frontend/src/components/PointChange.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import styles from "./PointChange.module.css";
+
+interface Props {
+  teamName: string;
+  delta: number;
+  onDone: () => void;
+  durationMs?: number;
+}
+
+export function PointChange({ teamName, delta, onDone, durationMs = 2500 }: Props) {
+  useEffect(() => {
+    const id = window.setTimeout(onDone, durationMs);
+    return () => window.clearTimeout(id);
+  }, [onDone, durationMs]);
+
+  const sign = delta > 0 ? "+" : "";
+  const toneClass = delta > 0 ? styles.positive : styles.negative;
+  return (
+    <div
+      className={`${styles.pill} ${toneClass}`}
+      role="status"
+      aria-live="polite"
+      data-testid="point-change"
+    >
+      <span className={styles.team}>{teamName}</span>
+      <span className={styles.delta}>
+        {sign}
+        {delta}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/DisplayPage.module.css
+++ b/frontend/src/pages/DisplayPage.module.css
@@ -8,6 +8,20 @@
   margin: 0 auto;
 }
 
+.pointStack {
+  position: fixed;
+  top: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: center;
+  pointer-events: none;
+  max-width: min(92vw, 520px);
+}
+
 .entry {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/DisplayPage.test.tsx
+++ b/frontend/src/pages/DisplayPage.test.tsx
@@ -9,7 +9,9 @@ vi.mock("../lib/supabase", async () => {
 
 import {
   fireSubscribed,
+  fireTeam,
   makeActiveGame,
+  makePayload,
   makeTeam,
   resetSupabaseMock,
   setHydrate,
@@ -174,6 +176,47 @@ describe("DisplayPage board", () => {
       await fireSubscribed();
     });
     expect(screen.getByText(/waiting for teams/i)).toBeInTheDocument();
+  });
+
+  it("pops a +N pill when a team's score goes up", async () => {
+    const alice = makeTeam({ id: "t1", name: "Alice", score: 0 });
+    setHydrate({
+      game: makeActiveGame({ status: "playing", round_number: 1 }),
+      teams: [alice],
+      rounds: [],
+    });
+    renderAt("/display/ABCDEF");
+    await act(async () => {
+      await fireSubscribed();
+    });
+    expect(screen.queryByTestId("point-change")).not.toBeInTheDocument();
+
+    act(() => {
+      fireTeam(makePayload("game_teams", "UPDATE", { new: { ...alice, score: 10 } }));
+    });
+    const pill = await screen.findByTestId("point-change");
+    expect(pill).toHaveTextContent("Alice");
+    expect(pill).toHaveTextContent("+10");
+  });
+
+  it("pops a -N pill when a team's score goes down (wrong buzz)", async () => {
+    const bravo = makeTeam({ id: "t2", name: "Bravo", score: 5 });
+    setHydrate({
+      game: makeActiveGame({ status: "playing", round_number: 1 }),
+      teams: [bravo],
+      rounds: [],
+    });
+    renderAt("/display/ABCDEF");
+    await act(async () => {
+      await fireSubscribed();
+    });
+
+    act(() => {
+      fireTeam(makePayload("game_teams", "UPDATE", { new: { ...bravo, score: 2 } }));
+    });
+    const pill = await screen.findByTestId("point-change");
+    expect(pill).toHaveTextContent("Bravo");
+    expect(pill).toHaveTextContent("-3");
   });
 
   it("toggles the sound button between off and on states", async () => {

--- a/frontend/src/pages/DisplayPage.tsx
+++ b/frontend/src/pages/DisplayPage.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { EndScreen } from "../components/EndScreen";
+import { PointChange } from "../components/PointChange";
 import { QRPanel } from "../components/QRPanel";
 import { Skeleton } from "../components/Skeleton";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { useGameSounds } from "../hooks/useGameSounds";
 import { serverTimeNow } from "../hooks/useServerTime";
 import styles from "./DisplayPage.module.css";
+
+interface PointEvent {
+  id: string;
+  teamName: string;
+  delta: number;
+}
 
 const ANSWER_DURATION_SEC = 10;
 
@@ -66,9 +73,11 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
   const sounds = useGameSounds();
   const [soundOn, setSoundOn] = useState(false);
   const [now, setNow] = useState(() => serverTimeNow().getTime());
+  const [pointEvents, setPointEvents] = useState<PointEvent[]>([]);
   const prevBuzzedRef = useRef<string | null | undefined>(undefined);
   const prevScoresRef = useRef<Record<string, number>>({});
   const prevRoundRef = useRef<number | undefined>(undefined);
+  const eventSeqRef = useRef(0);
 
   // Tick once a second so the post-buzz countdown re-renders.
   useEffect(() => {
@@ -77,28 +86,38 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
   }, []);
 
   useEffect(() => {
-    if (!soundOn || !state) return;
+    if (!state) return;
     const game = state.game;
 
-    if (prevBuzzedRef.current !== undefined) {
+    if (soundOn && prevBuzzedRef.current !== undefined) {
       if (game.buzzed_team_id != null && prevBuzzedRef.current !== game.buzzed_team_id) {
         sounds.playBuzz();
       }
     }
     prevBuzzedRef.current = game.buzzed_team_id ?? null;
 
-    if (prevRoundRef.current !== undefined && game.round_number > prevRoundRef.current) {
+    if (soundOn && prevRoundRef.current !== undefined && game.round_number > prevRoundRef.current) {
       sounds.playRoundStart();
     }
     prevRoundRef.current = game.round_number;
 
-    let scoreIncreased = false;
+    const events: PointEvent[] = [];
     for (const t of state.teams.values()) {
       const prev = prevScoresRef.current[t.id];
-      if (prev !== undefined && t.score > prev) scoreIncreased = true;
+      if (prev !== undefined && t.score !== prev) {
+        eventSeqRef.current += 1;
+        events.push({
+          id: `${t.id}-${eventSeqRef.current}`,
+          teamName: t.name,
+          delta: t.score - prev,
+        });
+      }
       prevScoresRef.current[t.id] = t.score;
     }
-    if (scoreIncreased) sounds.playAward();
+    if (events.length > 0) {
+      if (soundOn && events.some((e) => e.delta > 0)) sounds.playAward();
+      setPointEvents((current) => [...current, ...events]);
+    }
   }, [state, sounds, soundOn]);
 
   function toggleSound() {
@@ -163,6 +182,18 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
 
   return (
     <main className={styles.shell}>
+      <div className={styles.pointStack} aria-live="polite">
+        {pointEvents.map((ev) => (
+          <PointChange
+            key={ev.id}
+            teamName={ev.teamName}
+            delta={ev.delta}
+            onDone={() =>
+              setPointEvents((current) => current.filter((existing) => existing.id !== ev.id))
+            }
+          />
+        ))}
+      </div>
       <header className={styles.header}>
         <h1>Sound Clash</h1>
         <div className={styles.headerActions}>

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -484,20 +484,6 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(getManagerToken("ABCDEF")).toBeNull());
   });
 
-  it("Home button navigates back to the landing page", async () => {
-    setHydrate({
-      game: makeActiveGame({ status: "playing" }),
-      teams: [],
-      rounds: [],
-    });
-    renderConsole();
-    await act(async () => {
-      await fireSubscribed();
-    });
-    fireEvent.click(screen.getByRole("button", { name: /^home$/i }));
-    await waitFor(() => expect(screen.getByText("home page")).toBeInTheDocument());
-  });
-
   it("renders the EndScreen with the FINAL RESULTS heading when the game is ended", async () => {
     setHydrate({
       game: makeActiveGame({ status: "ended" }),
@@ -541,59 +527,6 @@ describe("ManagerConsolePage", () => {
     expect(getManagerToken("ABCDEF")).toBe(TOKEN);
   });
 
-  it("Restart song re-selects the current song via selectSong with a song_id", async () => {
-    setHydrate({
-      game: makeActiveGame({ status: "playing", round_number: 1, current_round_id: "r1" }),
-      teams: [],
-      rounds: [makeRound({ id: "r1", song_id: "song-A" })],
-    });
-    vi.mocked(selectSong).mockResolvedValueOnce({
-      round_id: "r2",
-      round_number: 2,
-      song: {
-        id: "song-A",
-        title: "Bohemian Rhapsody",
-        artist: "Queen",
-        youtube_id: "abcdefghijk",
-        start_time: 0,
-        is_soundtrack: false,
-        source: null,
-      },
-    });
-    renderConsole();
-    await act(async () => {
-      await fireSubscribed();
-    });
-    act(() => {
-      onReadyHandler?.();
-    });
-    // Restart needs `currentSong` (local React state populated by a successful
-    // selectSong). Trigger one Next-round click to seed it, then Restart.
-    const next = screen.getAllByRole("button", { name: /^next round$/i })[0]!;
-    await waitFor(() => expect(next).toBeEnabled());
-    fireEvent.click(next);
-    await waitFor(() => expect(screen.getByText("Bohemian Rhapsody")).toBeInTheDocument());
-
-    // Set up the next response for the Restart click; same song.
-    vi.mocked(selectSong).mockResolvedValueOnce({
-      round_id: "r3",
-      round_number: 3,
-      song: {
-        id: "song-A",
-        title: "Bohemian Rhapsody",
-        artist: "Queen",
-        youtube_id: "abcdefghijk",
-        start_time: 0,
-        is_soundtrack: false,
-        source: null,
-      },
-    });
-    const restart = screen.getAllByRole("button", { name: /^restart song$/i })[0]!;
-    await waitFor(() => expect(restart).toBeEnabled());
-    fireEvent.click(restart);
-    await waitFor(() => expect(selectSong).toHaveBeenLastCalledWith("ABCDEF", TOKEN, "song-A"));
-  });
-
   it("rehydrates the current song after a manager refresh mid-round", async () => {
     // Repro for the playwright-mcp finding (2026-05-09): hitting F5 mid-round
     // used to drop the manager into "No round started yet." even though the
@@ -629,8 +562,6 @@ describe("ManagerConsolePage", () => {
       onReadyHandler?.();
     });
     await waitFor(() => expect(lastHandle?.loadVideoById).toHaveBeenCalledWith("abcdefghijk", 12));
-    // Restart-song now has a currentSong to operate on.
-    expect(screen.getAllByRole("button", { name: /^restart song$/i })[0]).toBeEnabled();
   });
 
   it("shows a clear toast when the song pool is exhausted", async () => {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { EndScreen } from "../components/EndScreen";
 import { Skeleton } from "../components/Skeleton";
@@ -16,7 +16,6 @@ import styles from "./ManagerConsolePage.module.css";
 export function ManagerConsolePage() {
   const { gameCode = "" } = useParams<{ gameCode: string }>();
   const { toast } = useToast();
-  const navigate = useNavigate();
   const managerToken = useMemo(() => getManagerToken(gameCode), [gameCode]);
   const { state, status } = useGameChannel(gameCode);
   const player = usePlayerReady();
@@ -102,22 +101,6 @@ export function ManagerConsolePage() {
       setCurrentSong(result.song);
       resetAwardChecks();
       await loadSongIntoPlayer(result.song);
-    } catch (err) {
-      reportError(err);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function handleRestartSong() {
-    if (busy || !managerToken || !currentSong) return;
-    setBusy(true);
-    try {
-      const result = await selectSong(gameCode, managerToken, currentSong.id);
-      setCurrentSong(result.song);
-      resetAwardChecks();
-      await loadSongIntoPlayer(result.song);
-      toast("Song restarted", { variant: "info" });
     } catch (err) {
       reportError(err);
     } finally {
@@ -293,17 +276,10 @@ export function ManagerConsolePage() {
 
   const nextRoundDisabled = busy || !player.ready;
   // Once a round has been scored (ended_at set), the only meaningful action is
-  // "Next round". Calling award_points or selectSong(currentSong) again hits a
-  // round_already_ended SQL error, which surfaces as a confusing red toast --
-  // it's clearer to grey the button out so the host knows where to go next.
+  // "Next round". Calling award_points again hits a round_already_ended SQL
+  // error, which surfaces as a confusing red toast -- it's clearer to grey the
+  // button out so the host knows where to go next.
   const roundAlreadyScored = state.currentRound?.ended_at != null;
-  const restartDisabled =
-    busy ||
-    game.status !== "playing" ||
-    !currentSong ||
-    !player.ready ||
-    lockedTeam != null ||
-    roundAlreadyScored;
   const scoringDisabled = busy || !lockedTeam;
   const endRoundDisabled = busy || game.status !== "playing" || roundAlreadyScored;
   const bonusDisabled = busy || teams.length === 0;
@@ -328,9 +304,6 @@ export function ManagerConsolePage() {
             data-testid="end-game"
           >
             End game
-          </button>
-          <button className="btn btn-ghost" onClick={() => navigate("/")}>
-            Home
           </button>
         </div>
       </header>
@@ -443,14 +416,6 @@ export function ManagerConsolePage() {
 
           <div className={styles.actionsInline}>
             <button
-              className="btn btn-ghost"
-              onClick={() => void handleRestartSong()}
-              disabled={restartDisabled}
-              data-testid="restart-song"
-            >
-              Restart song
-            </button>
-            <button
               className={`btn btn-primary ${styles.awardBtn}`}
               onClick={() => void handleEndRound(!lockedTeam)}
               disabled={endRoundDisabled}
@@ -471,14 +436,6 @@ export function ManagerConsolePage() {
       </div>
 
       <div className={styles.mobileBar} role="toolbar" aria-label="Round actions">
-        <button
-          className="btn btn-ghost"
-          onClick={() => void handleRestartSong()}
-          disabled={restartDisabled}
-          data-testid="restart-song-mobile"
-        >
-          Restart
-        </button>
         <button
           className={`btn btn-primary ${styles.awardBtn}`}
           onClick={() => void handleEndRound(!lockedTeam)}

--- a/frontend/src/pages/TeamGameplayPage.module.css
+++ b/frontend/src/pages/TeamGameplayPage.module.css
@@ -22,9 +22,10 @@
 }
 
 .identity {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .teamName {
@@ -32,21 +33,6 @@
   font-weight: 800;
   color: #0f172a;
   letter-spacing: -0.01em;
-}
-
-.identityMeta {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-}
-
-.gameCode {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.95rem;
-  color: var(--color-text-dim);
-  letter-spacing: 0.16em;
-  font-weight: 600;
 }
 
 .roundPill {
@@ -61,98 +47,16 @@
   letter-spacing: 0.02em;
 }
 
-.connection {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: var(--radius-pill);
-  background: rgba(148, 163, 184, 0.12);
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-dim);
-  letter-spacing: 0.02em;
-  transition:
-    background 200ms ease,
-    color 200ms ease;
-}
-
-.connectionDot {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--color-text-mute);
-}
-
-.connOk {
-  background: rgba(16, 185, 129, 0.12);
-  color: #047857;
-}
-.connOk .connectionDot {
-  background: #10b981;
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18);
-}
-
-.connWait {
-  background: rgba(245, 158, 11, 0.14);
-  color: #92400e;
-}
-.connWait .connectionDot {
-  background: #f59e0b;
-  animation: conn-blink 1.2s ease-in-out infinite;
-}
-
-.connBad {
-  background: rgba(239, 68, 68, 0.12);
-  color: #b91c1c;
-}
-.connBad .connectionDot {
-  background: var(--color-danger);
-}
-
-@keyframes conn-blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-}
-
-.statusBanner {
+.statusEnded {
   text-align: center;
   padding: 1rem 1.25rem;
   border-radius: var(--radius-md);
-  background: #ffffff;
-  border: 2px solid var(--color-border);
+  background: rgba(148, 163, 184, 0.12);
+  border: 2px solid var(--color-border-strong);
   font-weight: 700;
   font-size: 1.05rem;
   color: var(--color-text-dim);
   box-shadow: var(--shadow-sm);
-  transition:
-    background 280ms ease,
-    border-color 280ms ease,
-    color 280ms ease,
-    transform 280ms ease;
-}
-
-.statusPlaying {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.16) 0%, rgba(52, 211, 153, 0.08) 100%);
-  border-color: var(--color-success);
-  color: #065f46;
-}
-
-.statusEnded {
-  background: rgba(148, 163, 184, 0.12);
-  border-color: var(--color-border-strong);
-  color: var(--color-text-dim);
-}
-
-.statusLocked {
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0%, rgba(251, 191, 36, 0.08) 100%);
-  border-color: var(--color-warning);
-  color: #92400e;
 }
 
 .timer {

--- a/frontend/src/pages/TeamGameplayPage.test.tsx
+++ b/frontend/src/pages/TeamGameplayPage.test.tsx
@@ -48,7 +48,7 @@ describe("TeamGameplayPage", () => {
     expect(screen.getByText("join page")).toBeInTheDocument();
   });
 
-  it("renders the team name and game code from storage", async () => {
+  it("renders the team name from storage", async () => {
     window.localStorage.setItem(
       "game:ABCDEF:team",
       JSON.stringify({ id: "team-1", name: "Alice" }),
@@ -63,7 +63,6 @@ describe("TeamGameplayPage", () => {
       await fireSubscribed();
     });
     expect(screen.getAllByText("Alice").length).toBeGreaterThan(0);
-    expect(screen.getByText("ABCDEF")).toBeInTheDocument();
   });
 
   it("disables buzz when game is waiting", async () => {
@@ -100,7 +99,7 @@ describe("TeamGameplayPage", () => {
     await waitFor(() => expect(screen.getByTestId("buzz")).toBeEnabled());
   });
 
-  it("shows ‘you buzzed’ banner when own team holds the lock", async () => {
+  it("flips the buzz button to the winner tone when own team holds the lock", async () => {
     window.localStorage.setItem(
       "game:ABCDEF:team",
       JSON.stringify({ id: "team-1", name: "Alice" }),
@@ -117,10 +116,12 @@ describe("TeamGameplayPage", () => {
     await act(async () => {
       await fireSubscribed();
     });
-    expect(screen.getByText(/you buzzed in/i)).toBeInTheDocument();
+    const buzz = screen.getByTestId("buzz");
+    expect(buzz).toHaveAttribute("data-tone", "winner");
+    expect(buzz).toHaveTextContent(/you buzzed/i);
   });
 
-  it("shows other team locked it when someone else holds the lock", async () => {
+  it("flips the buzz button to the locked-other tone when someone else holds the lock", async () => {
     window.localStorage.setItem(
       "game:ABCDEF:team",
       JSON.stringify({ id: "team-1", name: "Alice" }),
@@ -137,7 +138,9 @@ describe("TeamGameplayPage", () => {
     await act(async () => {
       await fireSubscribed();
     });
-    expect(screen.getByText(/Bob locked it/i)).toBeInTheDocument();
+    const buzz = screen.getByTestId("buzz");
+    expect(buzz).toHaveAttribute("data-tone", "locked-other");
+    expect(buzz).toHaveTextContent(/Bob got it first/i);
   });
 
   it("clears storage and goes home when our team is gone after hydrate", async () => {

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BuzzButton, type BuzzTone } from "../components/BuzzButton";
 import { EndScreen } from "../components/EndScreen";
-import { Scoreboard } from "../components/Scoreboard";
 import { useBuzzer } from "../hooks/useBuzzer";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { serverTimeNow } from "../hooks/useServerTime";
@@ -56,9 +55,7 @@ export function TeamGameplayPage() {
   if (status === "gone") {
     return (
       <main className={styles.shell}>
-        <div className={`${styles.statusBanner} ${styles.statusEnded}`}>
-          This game has ended or expired.
-        </div>
+        <div className={styles.statusEnded}>This game has ended or expired.</div>
       </main>
     );
   }
@@ -75,7 +72,6 @@ export function TeamGameplayPage() {
     );
   }
 
-  const teams = state ? Array.from(state.teams.values()) : [];
   const game = state?.game;
   const lockedByMe = buzzer.lockedByMe;
   const lockedTeam =
@@ -87,71 +83,35 @@ export function TeamGameplayPage() {
   const timerActive = game?.status === "playing" && lockedTeam != null && lockedAt != null;
   const timerPct = Math.max(0, Math.min(100, (remainingSec / ANSWER_DURATION_SEC) * 100));
 
-  let bannerClass = styles.statusBanner;
-  let bannerText = "Waiting for the host to start…";
-  if (game?.status === "ended") {
-    bannerClass = `${styles.statusBanner} ${styles.statusEnded}`;
-    bannerText = "Game over.";
-  } else if (game?.status === "playing") {
-    if (lockedByMe) {
-      bannerClass = `${styles.statusBanner} ${styles.statusLocked}`;
-      bannerText = "You buzzed in! Wait for the host.";
-    } else if (lockedTeam) {
-      bannerClass = `${styles.statusBanner} ${styles.statusLocked}`;
-      bannerText = `${lockedTeam.name} locked it.`;
-    } else {
-      bannerClass = `${styles.statusBanner} ${styles.statusPlaying}`;
-      bannerText = "Buzz when you know it!";
-    }
-  }
-
   const buzzDisabled =
     !state || status !== "subscribed" || game?.status !== "playing" || buzzer.isLocked;
 
-  const buzz = ((): { tone: BuzzTone; label: string; subtitle: string } => {
+  const buzz = ((): { tone: BuzzTone; label: string; subtitle?: string } => {
     if (game?.status === "playing") {
-      if (lockedByMe) return { tone: "winner", label: "YOU BUZZED", subtitle: "Wait for the host" };
+      if (lockedByMe) return { tone: "winner", label: "YOU BUZZED" };
       if (lockedTeam)
         return {
           tone: "locked-other",
           label: "SOMEONE ELSE BUZZED",
           subtitle: `${lockedTeam.name} got it first`,
         };
-      return { tone: "idle", label: "PLAYING", subtitle: "Tap to buzz in" };
+      return { tone: "idle", label: "BUZZ" };
     }
-    return { tone: "waiting", label: "WAITING", subtitle: "Waiting for host…" };
+    return { tone: "waiting", label: "WAITING", subtitle: "for the game to start" };
   })();
-
-  const connectionLabel = status === "subscribed" ? "Connected" : "Connecting…";
-  const connectionStateClass = status === "subscribed" ? styles.connOk : styles.connWait;
 
   return (
     <main className={styles.shell}>
       <header className={styles.header}>
         <div className={styles.identity}>
           <span className={styles.teamName}>{stored.name}</span>
-          <span className={styles.identityMeta}>
-            <span className={styles.gameCode}>{gameCode}</span>
-            {game && game.status !== "waiting" ? (
-              <span className={styles.roundPill} data-testid="round-indicator">
-                Round {game.round_number}
-              </span>
-            ) : null}
-          </span>
-        </div>
-        <div
-          className={`${styles.connection} ${connectionStateClass}`}
-          role="status"
-          aria-live="polite"
-        >
-          <span className={styles.connectionDot} aria-hidden="true" />
-          <span>{connectionLabel}</span>
+          {game && game.status !== "waiting" ? (
+            <span className={styles.roundPill} data-testid="round-indicator">
+              Round {game.round_number}
+            </span>
+          ) : null}
         </div>
       </header>
-
-      <div className={bannerClass} role="status" aria-live="polite">
-        {bannerText}
-      </div>
 
       {timerActive ? (
         <div
@@ -182,15 +142,6 @@ export function TeamGameplayPage() {
       </div>
 
       {buzzer.error ? <p className="error">{buzzer.error.message}</p> : null}
-
-      <section className={styles.scoreCard}>
-        <h2 className={styles.scoreCardTitle}>Scoreboard</h2>
-        <Scoreboard
-          teams={teams}
-          buzzedTeamId={game?.buzzed_team_id ?? null}
-          myTeamId={stored.id}
-        />
-      </section>
     </main>
   );
 }

--- a/tests/e2e/buzzer_race.spec.ts
+++ b/tests/e2e/buzzer_race.spec.ts
@@ -39,12 +39,12 @@ test("two teams race the buzzer; exactly one wins; all contexts agree", async ({
   await expect(startBtn).toBeEnabled();
   await startBtn.click();
 
-  // 5. Wait for the team pages to flip into "Buzz when you know it!".
+  // 5. Wait for the team pages to flip into idle (BUZZ) tone.
   await Promise.all([
-    expect(team1.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+    expect(team1.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
       timeout: 15_000,
     }),
-    expect(team2.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+    expect(team2.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
       timeout: 15_000,
     }),
   ]);
@@ -79,13 +79,12 @@ test("two teams race the buzzer; exactly one wins; all contexts agree", async ({
   ).toBeVisible({ timeout: 10_000 });
 
   // 9. Manager toggles "Correct Song" and ends the round; the winner's
-  //    score should update on display + both team scoreboards.
+  //    score should update on display (team buzzer screens no longer show
+  //    a scoreboard).
   await manager.page.getByTestId("score-title").click();
   await manager.page.getByTestId("end-round").click();
 
-  for (const page of [team1.page, team2.page, display.page]) {
-    await expect(
-      page.locator(`[data-team-id]:has-text("${winnerName}"):has-text("10")`).first(),
-    ).toBeVisible({ timeout: 10_000 });
-  }
+  await expect(
+    display.page.locator(`[data-team-id]:has-text("${winnerName}"):has-text("10")`).first(),
+  ).toBeVisible({ timeout: 10_000 });
 });

--- a/tests/e2e/fixtures/team-context.ts
+++ b/tests/e2e/fixtures/team-context.ts
@@ -22,9 +22,8 @@ export async function joinAsTeam(
   await page.getByRole("button", { name: /join game/i }).click();
 
   await expect(page).toHaveURL(new RegExp(`/team/${gameCode}$`));
-  await expect(page.getByRole("status").filter({ hasText: /Connected/i })).toBeVisible({
-    timeout: 15_000,
-  });
+  // BuzzButton mounts only after Realtime SUBSCRIBED — wait for it.
+  await expect(page.getByTestId("buzz")).toBeVisible({ timeout: 15_000 });
 
   return { page, name: teamName };
 }

--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -41,7 +41,7 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
     ).toBeVisible({ timeout: 10_000 });
 
     // Team can now buzz.
-    await expect(team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i })).toBeVisible({
+    await expect(team.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
       timeout: 10_000,
     });
     await team.page.getByTestId("buzz").click();

--- a/tests/e2e/mobile_team.spec.ts
+++ b/tests/e2e/mobile_team.spec.ts
@@ -20,9 +20,7 @@ async function joinAsMobileTeam(browser: Browser, code: string, name: string) {
   await page.locator("#team-name").fill(name);
   await page.getByRole("button", { name: /join game/i }).click();
   await expect(page).toHaveURL(new RegExp(`/team/${code}$`));
-  await expect(page.getByRole("status").filter({ hasText: /Connected/i })).toBeVisible({
-    timeout: 15_000,
-  });
+  await expect(page.getByTestId("buzz")).toBeVisible({ timeout: 15_000 });
   return { page, name };
 }
 
@@ -44,20 +42,17 @@ test("mobile viewport: team can join, buzz, and score", async ({ browser }) => {
   // Manager starts the round (manager runs at desktop chromium viewport).
   await expect(manager.page.getByTestId("start-round")).toBeEnabled();
   await manager.page.getByTestId("start-round").click();
-  await expect(
-    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
-  ).toBeVisible({ timeout: 15_000 });
+  await expect(buzz).toHaveAttribute("data-tone", "idle", { timeout: 15_000 });
 
   // Tap. Playwright synthesizes a touch from .click() in a touch-enabled
   // device descriptor.
   await buzz.click();
   await expect(buzz).toHaveAttribute("data-tone", "winner", { timeout: 10_000 });
 
-  // Award and confirm the score reaches the team's own scoreboard on
-  // the small viewport.
+  // Award and confirm the round closes (buzz button leaves the winner tone
+  // once the manager scores). Score correctness is covered by buzzer_race
+  // and full_game; this spec only asserts mobile UX still wires up.
   await manager.page.getByTestId("score-title").click();
   await manager.page.getByTestId("end-round").click();
-  await expect(
-    team.page.locator('[data-team-id]:has-text("Mobile"):has-text("10")').first(),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(buzz).not.toHaveAttribute("data-tone", "winner", { timeout: 10_000 });
 });

--- a/tests/e2e/reconnection.spec.ts
+++ b/tests/e2e/reconnection.spec.ts
@@ -26,12 +26,12 @@ test("team identity survives a mid-game tab reload", async ({ browser }) => {
   expect(parsed.name).toBe("Persistent");
   expect(parsed.id).toMatch(/^[0-9a-f-]{36}$/i);
 
-  // Round starts; the team page flips into "Buzz when you know it!".
+  // Round starts; the team's buzz button flips to the idle (BUZZ) tone.
   await expect(manager.page.getByTestId("start-round")).toBeEnabled();
   await manager.page.getByTestId("start-round").click();
-  await expect(
-    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
-  ).toBeVisible({ timeout: 15_000 });
+  await expect(team.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
+    timeout: 15_000,
+  });
 
   // Hard reload; useGameChannel re-subscribes, hydrate refetches, and the
   // stored team identity is read again from localStorage.
@@ -45,13 +45,10 @@ test("team identity survives a mid-game tab reload", async ({ browser }) => {
   );
   expect(storedAfter).toBe(storedBefore);
 
-  // Realtime should reconnect; banner ought to flip back to "Buzz when you know it!"
-  await expect(
-    team.page.getByRole("status").filter({ hasText: /Connected/i }),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    team.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
-  ).toBeVisible({ timeout: 15_000 });
+  // Realtime reconnects; buzz button flips back to idle tone.
+  await expect(team.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
+    timeout: 15_000,
+  });
 
   // The buzzer is functional after the reconnect.
   await team.page.getByTestId("buzz").click();
@@ -59,10 +56,12 @@ test("team identity survives a mid-game tab reload", async ({ browser }) => {
     timeout: 10_000,
   });
 
-  // Award and verify the score lands on the (reloaded) team's own scoreboard.
+  // Award and verify the round closes (the team page no longer renders a
+  // scoreboard; correctness of the score-update path is covered by
+  // full_game.spec.ts and buzzer_race.spec.ts via the display).
   await manager.page.getByTestId("score-title").click();
   await manager.page.getByTestId("end-round").click();
-  await expect(
-    team.page.locator('[data-team-id]:has-text("Persistent"):has-text("10")').first(),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(team.page.getByTestId("buzz")).not.toHaveAttribute("data-tone", "winner", {
+    timeout: 10_000,
+  });
 });

--- a/tests/e2e/smoke/prod_realtime.spec.ts
+++ b/tests/e2e/smoke/prod_realtime.spec.ts
@@ -42,14 +42,14 @@ test("prod smoke: one buzzer round end-to-end against the deployed app", async (
     await expect(startBtn).toBeEnabled();
     await startBtn.click();
 
-    // 4. Wait for both team pages to enter "buzz when you know it" state.
+    // 4. Wait for both team buzz buttons to enter idle (BUZZ) tone.
     await Promise.all([
-      expect(
-        team1.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
-      ).toBeVisible({ timeout: 20_000 }),
-      expect(
-        team2.page.getByRole("status").filter({ hasText: /Buzz when you know it/i }),
-      ).toBeVisible({ timeout: 20_000 }),
+      expect(team1.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
+        timeout: 20_000,
+      }),
+      expect(team2.page.getByTestId("buzz")).toHaveAttribute("data-tone", "idle", {
+        timeout: 20_000,
+      }),
     ]);
 
     // 5. Race. The PL/pgSQL buzz_in function decides the winner atomically.


### PR DESCRIPTION
## Summary

- Manager console: removed Home + Restart song (desktop & mobile bar) and the dead handleRestartSong helper.
- Team buzzer page: removed status banner, Connected pill, game code, and inline scoreboard. Header trims to team name + round pill.
- BUZZ button copy: idle reads just BUZZ, waiting reads WAITING / for the game to start, you-buzzed reads YOU BUZZED. Winner tone recolored amber to blue (#3b82f6 to #1d4ed8).
- Display page: new centered PointChange pill that pops on every score delta (positive and negative), self-removes after 2.5s, independent of the sound toggle.
- EndScreen podium: fixed heights gold 320 / silver 250 / bronze 200, dropped the translateY(-24px) trick. 1st > 2nd > 3rd holds even when 2nd has tied teams.
- E2E specs re-aimed off the deleted Connected / Buzz when you know it banner text and onto data-tone on the existing buzz button.

## Test plan

- [x] frontend npm run typecheck passes
- [x] frontend npm run lint passes
- [x] frontend npm run test:run passes (195 tests / 23 files)
- [x] tests/e2e npx playwright test --list parses all 7 specs
- [ ] manual desktop walkthrough on the deployed preview: confirm copy / colors / podium ordering match the screenshots brief
- [ ] manual mobile walkthrough on the deployed preview: phone-sized buzzer and end screen