### PR TITLE
Round feedback toast + display reveal + Wrong one-click + free-guess waiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-05-10: Team's own phone now shows a "+10 / −3" pill the instant their score changes — same look as the projector toast — so a player gets immediate feedback on the device they're already looking at.
+- 2026-05-10: Display screen now reveals the song title and artist name in a dedicated panel once the manager confirms the corresponding correct answer. Unrevealed halves show "???" so the audience can see what's still secret. Token chips below still show which team claimed each.
 - 2026-05-10: Display screen now pops a small floating pill ("Alpha +10", "Bravo -3") whenever a team's score changes, so the audience watching the projector can see *who* just got points and how many without having to re-read the scoreboard.
 
 ### Changed
 
-- 2026-05-10: Rounds now allow multiple buzzes on the same song. The +10 Title token and +5 Artist token are claimed independently — Team A can take Title, Team B can take Artist, all on the same song. A wrong buzz still costs −3 but no longer locks the team out: the same team can buzz again. The manager has a new "Continue round" button (re-arm buzzers, same song) alongside "Next round" (advance song). Display screens show small chips for each token's claim state.
+- 2026-05-10: Manager Wrong button is now a one-click verdict: pressing Wrong fires the score immediately and re-arms the buzzers (no separate Continue Round press). On mobile the sticky bottom bar gains a third Wrong shortcut so the host can score a wrong call without scrolling.
+- 2026-05-10: Wrong buzz waives the −3 penalty when the round already has a correct answer recorded ("free guess" sweetener). Round-wide and one-shot: the next attempt after a correct is free, then normal scoring resumes. Rewards teams who got one half of the song right.
+- 2026-05-10: Rounds now allow multiple buzzes on the same song. The +10 Title token and +5 Artist token are claimed independently — Team A can take Title, Team B can take Artist, all on the same song. A wrong buzz still costs −3 (unless the free-guess rule above applies) but no longer locks the team out: the same team can buzz again. The manager has a new "Continue round" button (re-arm buzzers, same song) alongside "Next round" (advance song). Display screens show small chips for each token's claim state.
 - 2026-05-10: Team buzzer page is now a single-purpose surface: just team name, round pill, and the buzz button. Status banner ("Waiting for the host…", "Buzz when you know it!", "{team} locked it.", "You buzzed in!"), the "Connected" pill, the game code, and the secondary scoreboard are all removed - the buzz button's own colour and label communicate the round state.
 - 2026-05-10: The "You buzzed" buzz button is now blue (was amber) so the colour no longer reads as a yellow "warning / waiting" cue.
 - 2026-05-10: BUZZ button copy slimmed down: idle reads just "BUZZ" (no subtitle), waiting reads "WAITING / for the game to start", you-buzzed reads just "YOU BUZZED".

--- a/db/migrations/017_free_guess_flag.sql
+++ b/db/migrations/017_free_guess_flag.sql
@@ -1,0 +1,160 @@
+-- 017_free_guess_flag.sql
+-- "Free guess" sweetener: after any team scores a correct token in a
+-- round, the next award_attempt that round waives the wrong-buzz penalty.
+-- The flag is per-round and is consumed (cleared) on every subsequent
+-- attempt regardless of outcome.
+--
+-- Rationale: in the multi-buzz model a team that gets one half of the
+-- song right (e.g. the title) often immediately knows the artist too.
+-- Letting them re-buzz "for free" rewards being on the right track and
+-- speeds up rounds where one team is dominating. See docs/game-rules.md
+-- §4 (rewritten in this PR).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, CREATE OR REPLACE FUNCTION.
+
+-- ---------------------------------------------------------------------------
+-- 1. game_rounds.free_guess_active
+-- ---------------------------------------------------------------------------
+ALTER TABLE game_rounds
+  ADD COLUMN IF NOT EXISTS free_guess_active boolean NOT NULL DEFAULT false;
+
+-- ---------------------------------------------------------------------------
+-- 2. award_attempt: identical to migration 016 except for the free-guess
+--    branch on wrong_buzz and the flag-update step at the end.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION award_attempt(
+  p_game_code  text,
+  p_round_id   uuid,
+  p_title      integer DEFAULT 0,
+  p_artist     integer DEFAULT 0,
+  p_wrong_buzz integer DEFAULT 0
+)
+RETURNS TABLE(
+  team_id              uuid,
+  points_delta         integer,
+  team_total_score     integer,
+  title_claimed_by     uuid,
+  artist_claimed_by    uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id        uuid;
+  v_round_ended    timestamptz;
+  v_title_claimed  uuid;
+  v_artist_claimed uuid;
+  v_free_guess     boolean;
+  v_outcome        text;
+  v_delta          integer;
+  v_score          integer;
+  v_new_free_guess boolean;
+BEGIN
+  -- RETURNS TABLE shadows column names; qualify everything.
+  SELECT gr.ended_at, gr.title_claimed_by, gr.artist_claimed_by, gr.free_guess_active
+    INTO v_round_ended, v_title_claimed, v_artist_claimed, v_free_guess
+    FROM game_rounds gr
+   WHERE gr.id = p_round_id AND gr.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'round_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_round_ended IS NOT NULL THEN
+    RAISE EXCEPTION 'round_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT ag.buzzed_team_id INTO v_team_id
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF v_team_id IS NULL THEN
+    RAISE EXCEPTION 'no_buzz_to_score' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0
+     AND (COALESCE(p_title, 0) > 0 OR COALESCE(p_artist, 0) > 0) THEN
+    RAISE EXCEPTION 'wrong_buzz_with_correct' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_title, 0) > 0 AND v_title_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'title_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+  IF COALESCE(p_artist, 0) > 0 AND v_artist_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'artist_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    -- Free-guess sweetener: if the round had a prior correct attempt,
+    -- the next wrong is free (delta = 0) but is still recorded so the
+    -- attempts log shows the buzz happened.
+    IF v_free_guess THEN
+      v_delta := 0;
+    ELSE
+      v_delta := -p_wrong_buzz;
+    END IF;
+    v_outcome := 'wrong';
+  ELSIF COALESCE(p_title, 0) > 0 AND COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_title + p_artist;
+    v_outcome := 'title_artist';
+  ELSIF COALESCE(p_title, 0) > 0 THEN
+    v_delta := p_title;
+    v_outcome := 'title';
+  ELSIF COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_artist;
+    v_outcome := 'artist';
+  ELSE
+    v_delta := 0;
+    v_outcome := NULL;
+  END IF;
+
+  -- New flag value: true after any correct attempt; false after wrong
+  -- (consumes the prior free-guess) and false on the no-op continue case.
+  IF v_outcome IN ('title', 'artist', 'title_artist') THEN
+    v_new_free_guess := true;
+  ELSE
+    v_new_free_guess := false;
+  END IF;
+
+  IF v_delta <> 0 THEN
+    UPDATE game_teams SET score = score + v_delta WHERE id = v_team_id;
+  END IF;
+
+  IF COALESCE(p_title, 0) > 0 THEN
+    UPDATE game_rounds SET title_claimed_by = v_team_id, title_points = p_title
+     WHERE id = p_round_id;
+  END IF;
+  IF COALESCE(p_artist, 0) > 0 THEN
+    UPDATE game_rounds SET artist_claimed_by = v_team_id, artist_points = p_artist
+     WHERE id = p_round_id;
+  END IF;
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    UPDATE game_rounds SET wrong_buzz_penalty = p_wrong_buzz
+     WHERE id = p_round_id;
+  END IF;
+
+  -- Always rewrite the flag, even when no other game_rounds column moved,
+  -- so the next attempt reads the right value.
+  UPDATE game_rounds SET free_guess_active = v_new_free_guess
+   WHERE id = p_round_id;
+
+  IF v_outcome IS NOT NULL THEN
+    INSERT INTO game_round_attempts (round_id, game_code, team_id, outcome, points_delta)
+    VALUES (p_round_id, p_game_code, v_team_id, v_outcome, v_delta);
+  END IF;
+
+  UPDATE active_games
+     SET buzzed_team_id = NULL, locked_at = NULL
+   WHERE game_code = p_game_code;
+
+  SELECT gt.score INTO v_score FROM game_teams gt WHERE gt.id = v_team_id;
+  SELECT gr.title_claimed_by, gr.artist_claimed_by
+    INTO v_title_claimed, v_artist_claimed
+    FROM game_rounds gr WHERE gr.id = p_round_id;
+
+  RETURN QUERY SELECT v_team_id, v_delta, COALESCE(v_score, 0),
+                      v_title_claimed, v_artist_claimed;
+END $$;
+
+REVOKE ALL ON FUNCTION award_attempt(text, uuid, integer, integer, integer) FROM PUBLIC;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -172,6 +172,8 @@ Integer. Can go negative; wrong-buzz deducts 3 (`award_attempt`). Updated by `aw
 
 Each round records `title_claimed_by`, `artist_claimed_by` (uuid refs to the team that claimed the corresponding token, NULL if unclaimed), plus `title_points` / `artist_points` / `wrong_buzz_penalty` for the most recent matching write (legacy denorm; the canonical per-buzz history is `game_round_attempts`). The `game_teams.score` field is the running cumulative across all rounds plus any `award_bonus` calls.
 
+`free_guess_active boolean` (migration 017) is a per-round flag managed by `award_attempt`. It is `true` after a correct attempt and `false` after a wrong attempt; while true, the next wrong attempt waives the −3 penalty. See `rpc-functions.md §3` for the state-transition rules and `game-rules.md §4` for the user-facing scoring story.
+
 ### `game_round_attempts`
 
 One row per `award_attempt` call: `(round_id, game_code, team_id, outcome, points_delta, created_at)`. `outcome` is one of `'title' | 'artist' | 'title_artist' | 'wrong'`. Insert-only; cascade-deletes with the round. Used to reconstruct per-buzz round detail (e.g. for a future "round breakdown" UI).
@@ -221,7 +223,8 @@ db/migrations/
 ├── 013_seed_extra_genres.sql
 ├── 014_scoring_revamp.sql    -- wrong-buzz penalty, +4 bonus, drop source/timeout
 ├── 015_drop_total_rounds.sql
-└── 016_multi_buzz_rounds.sql -- multi-buzz model: token claims, award_attempt, end_round
+├── 016_multi_buzz_rounds.sql -- multi-buzz model: token claims, award_attempt, end_round
+└── 017_free_guess_flag.sql   -- per-round free-guess flag; waives -3 after first correct
 ```
 
 All migrations are written to be idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. Re-running them is safe.

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -94,10 +94,19 @@ Per-round point components (locked at MVP, configurable later):
 |---|---|---|
 | Correct Song | **+10** | Manager toggles "Correct Song" on a buzz; claims TITLE token |
 | Correct Artist | **+5** | Manager toggles "Correct Artist" on a buzz; claims ARTIST token |
-| Wrong | **−3** | Team buzzed but got neither title nor artist right; no token claimed |
+| Wrong | **−3** or **0** | Team buzzed but got neither title nor artist right; see free-guess rule below |
 | Skip / abandoned token | **0** | Manager advances with one or both tokens unclaimed; no team's score moves |
 
-Maximum per **buzz** from `award_attempt`: **+15** (title + artist together). Minimum per buzz: **−3** (wrong buzz). A round can accumulate multiple buzz outcomes — e.g. T1 wrong → -3, T2 title → +10, T3 artist → +5. The host can also grant a discretionary **+4 Bonus** to any team at any time; see §4a.
+Maximum per **buzz** from `award_attempt`: **+15** (title + artist together). Minimum per buzz: **−3** (wrong buzz with no prior correct in the round). A round can accumulate multiple buzz outcomes — e.g. T1 wrong → -3, T2 title → +10, T3 artist → +5. The host can also grant a discretionary **+4 Bonus** to any team at any time; see §4a.
+
+### Free-guess rule
+
+After any team scores a correct token in a round, a "free-guess" flag activates for that round. The very next `award_attempt` in that round, if Wrong, costs **0** instead of −3. The flag is consumed by that next attempt regardless of outcome (and re-activates the moment another correct attempt happens). This rewards a team that got one half of the song right — they (or anyone) can risk the other half without paying for being wrong.
+
+- Scope: round-wide. Whichever team buzzes the next attempt benefits, not just the team that scored the prior correct.
+- The flag persists only across one attempt. If that attempt is wrong → flag clears. If it's correct → flag stays armed for the attempt after that.
+- `start_round` resets the flag for each new song.
+- Bonus does **not** activate or consume the flag.
 
 Scores are integers; ties are allowed. The team with the highest score at game end is the winner; tied teams share the win (no tiebreaker round in MVP; see §11).
 
@@ -105,7 +114,8 @@ Scores are integers; ties are allowed. The team with the highest score at game e
 
 - `Correct Song` and `Correct Artist` are **accumulating toggles** within a single buzz: the host may select either, both, or neither (which is treated as a no-score; the API rejects an attempt with no flags set).
 - `Wrong` is **mutually exclusive** with the two correct toggles, both in the UI and in the SQL function (`P0001 wrong_buzz_with_correct`).
-- `Continue Round` calls `award_attempt`: scores the current buzz, clears the lock, leaves the round open. Disabled when no buzz is held, both tokens are claimed, or no toggle is selected.
+- `Continue Round` calls `award_attempt`: scores the current buzz (Title and/or Artist toggles), clears the lock, leaves the round open. Disabled when no buzz is held, both tokens are claimed, or no toggle is selected.
+- `Wrong` is its own one-click action: it fires `award_attempt` immediately with `wrong_buzz=true` (no Continue Round press needed), re-arms the buzzers, and may waive the −3 per the free-guess rule above.
 - `Next Round` advances to the next song. If a buzz is held with toggles set, it scores first via `award_attempt`. Then `end_round` closes the current round and `start_round` advances.
 - Negative team scores are allowed.
 - The manager cannot retroactively change a previous round's score in MVP. (Future: an "edit last round" undo flow.)

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -212,10 +212,11 @@ SET search_path = public;
 ```
 
 Behavior:
-- Reads the current `buzzed_team_id` off `game_rounds`. If null → raises `P0001 no_buzz_to_score`.
+- Reads the current `buzzed_team_id` off `active_games`. If null → raises `P0001 no_buzz_to_score`.
 - `p_wrong_buzz > 0 AND (p_title > 0 OR p_artist > 0)` → raises `P0001 wrong_buzz_with_correct`.
 - `p_title > 0` while `title_claimed_by` is already set → raises `P0001 title_already_claimed`. Same shape for `artist_already_claimed`.
 - On success: applies score delta to the buzzed team, marks `title_claimed_by` / `artist_claimed_by` if applicable, inserts a `game_round_attempts` row, and clears `active_games.buzzed_team_id` and `locked_at` so other teams can buzz on the same song.
+- **Free-guess flag** (`game_rounds.free_guess_active`, migration 017): if `p_wrong_buzz > 0` AND `free_guess_active = true`, the penalty is waived (`points_delta = 0`); the attempt is still recorded with `outcome = 'wrong'`. After processing, the function sets `free_guess_active = true` if the outcome was correct (`title` / `artist` / `title_artist`) and `false` otherwise. So the flag is consumed by every attempt and re-armed by every correct one.
 
 ### Error semantics
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -37,6 +37,7 @@ export interface GameRound {
   wrong_buzz_penalty: number;
   title_claimed_by: string | null;
   artist_claimed_by: string | null;
+  free_guess_active: boolean;
   ended_at: string | null;
 }
 

--- a/frontend/src/pages/DisplayPage.module.css
+++ b/frontend/src/pages/DisplayPage.module.css
@@ -385,6 +385,44 @@
   color: #b45309;
 }
 
+.revealPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid var(--color-border);
+  text-align: center;
+}
+
+.revealRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-text-dim);
+  letter-spacing: -0.01em;
+}
+
+.revealRowOpen {
+  color: #0f172a;
+}
+
+.revealIcon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.revealText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 80vw;
+}
+
 .tokenChips {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/pages/DisplayPage.tsx
+++ b/frontend/src/pages/DisplayPage.tsx
@@ -7,6 +7,8 @@ import { Skeleton } from "../components/Skeleton";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { useGameSounds } from "../hooks/useGameSounds";
 import { serverTimeNow } from "../hooks/useServerTime";
+import { supabase } from "../lib/supabase";
+import type { Song } from "../lib/types";
 import styles from "./DisplayPage.module.css";
 
 interface PointEvent {
@@ -74,6 +76,7 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
   const [soundOn, setSoundOn] = useState(false);
   const [now, setNow] = useState(() => serverTimeNow().getTime());
   const [pointEvents, setPointEvents] = useState<PointEvent[]>([]);
+  const [currentSong, setCurrentSong] = useState<Song | null>(null);
   const prevBuzzedRef = useRef<string | null | undefined>(undefined);
   const prevScoresRef = useRef<Record<string, number>>({});
   const prevRoundRef = useRef<number | undefined>(undefined);
@@ -84,6 +87,35 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
     const id = window.setInterval(() => setNow(serverTimeNow().getTime()), 1000);
     return () => window.clearInterval(id);
   }, []);
+
+  // Fetch the current round's song so the reveal panel can display the
+  // actual title / artist text once the manager confirms a correct answer.
+  // Mirrors the lookup in ManagerConsolePage.tsx so all three roles can
+  // surface the same metadata after a token is claimed.
+  const currentRoundSongId = state?.currentRound?.song_id ?? null;
+  useEffect(() => {
+    if (!currentRoundSongId) {
+      setCurrentSong(null);
+      return;
+    }
+    if (currentSong && currentSong.id === currentRoundSongId) return;
+    let cancelled = false;
+    void (async () => {
+      const { data, error } = await supabase
+        .from("songs")
+        .select("id,title,artist,youtube_id,start_time,is_soundtrack,source")
+        .eq("id", currentRoundSongId)
+        .maybeSingle();
+      if (cancelled || error || !data) return;
+      setCurrentSong(data as Song);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // currentSong is included via the .id chain; full-object dep would
+    // re-run on every render and re-fetch the same song.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentRoundSongId, currentSong?.id]);
 
   useEffect(() => {
     if (!state) return;
@@ -219,6 +251,33 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
         <span className={styles.bannerText}>{bannerText}</span>
         {showRoundSubhead ? <span className={styles.bannerSubhead}>{roundLabel}</span> : null}
       </div>
+
+      {round && game.status === "playing" ? (
+        <div className={styles.revealPanel} aria-label="Song reveal">
+          <div
+            className={`${styles.revealRow} ${titleClaimedById ? styles.revealRowOpen : ""}`}
+            data-testid="display-reveal-title"
+          >
+            <span className={styles.revealIcon} aria-hidden="true">
+              🎵
+            </span>
+            <span className={styles.revealText}>
+              {titleClaimedById && currentSong ? currentSong.title : "???"}
+            </span>
+          </div>
+          <div
+            className={`${styles.revealRow} ${artistClaimedById ? styles.revealRowOpen : ""}`}
+            data-testid="display-reveal-artist"
+          >
+            <span className={styles.revealIcon} aria-hidden="true">
+              🎤
+            </span>
+            <span className={styles.revealText}>
+              {artistClaimedById && currentSong ? currentSong.artist : "???"}
+            </span>
+          </div>
+        </div>
+      ) : null}
 
       {round && game.status === "playing" ? (
         <div className={styles.tokenChips} aria-label="Round token state">

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -492,6 +492,31 @@
   box-shadow: 0 4px 14px rgba(6, 182, 212, 0.4);
 }
 
+/* Wrong is a one-click commit action (not a toggle). Solid red fill so it
+   reads as a final verdict, not a checkbox. Used in both the score-row
+   and the mobile sticky bar. */
+.wrongBtn {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.28);
+}
+
+.wrongBtn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 4px 14px rgba(239, 68, 68, 0.42);
+}
+
+.wrongBtn .scorePoints {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.wrongBtn .scoreLabel {
+  color: #ffffff;
+}
+
 .tokenChips {
   display: flex;
   flex-wrap: wrap;
@@ -524,7 +549,7 @@
 @media (max-width: 768px) {
   .mobileBar {
     display: grid;
-    grid-template-columns: 1fr 1.2fr;
+    grid-template-columns: 1fr 1fr 1.2fr;
     gap: 0.5rem;
     position: fixed;
     bottom: 0;

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -234,7 +234,7 @@ describe("ManagerConsolePage", () => {
     );
   });
 
-  it("Wrong button sends wrong_buzz=true and clears positives", async () => {
+  it("Wrong button auto-fires awardAttempt with wrong_buzz=true (no Continue press)", async () => {
     setHydrate({
       game: makeActiveGame({
         status: "playing",
@@ -256,9 +256,42 @@ describe("ManagerConsolePage", () => {
     await act(async () => {
       await fireSubscribed();
     });
+    fireEvent.click(screen.getByTestId("score-wrong"));
+    await waitFor(() =>
+      expect(awardAttempt).toHaveBeenCalledWith("ABCDEF", TOKEN, {
+        round_id: "r1",
+        title_correct: false,
+        artist_correct: false,
+        wrong_buzz: true,
+      }),
+    );
+  });
+
+  it("Wrong button ignores any toggled title/artist state (Wrong is a final verdict)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    vi.mocked(awardAttempt).mockResolvedValueOnce({
+      round_id: "r1",
+      team_id: "t1",
+      points_awarded: -3,
+      team_total_score: 0,
+      title_claimed_by: null,
+      artist_claimed_by: null,
+    });
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    // Toggle Title first; clicking Wrong should still send wrong=true with title=false.
     fireEvent.click(screen.getByTestId("score-title"));
     fireEvent.click(screen.getByTestId("score-wrong"));
-    fireEvent.click(screen.getByTestId("continue-round"));
     await waitFor(() =>
       expect(awardAttempt).toHaveBeenCalledWith("ABCDEF", TOKEN, {
         round_id: "r1",

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -24,7 +24,6 @@ export function ManagerConsolePage() {
   const [currentSong, setCurrentSong] = useState<Song | null>(null);
   const [titleCorrect, setTitleCorrect] = useState(false);
   const [artistCorrect, setArtistCorrect] = useState(false);
-  const [wrongBuzz, setWrongBuzz] = useState(false);
   const [busy, setBusy] = useState(false);
   const [endConfirmOpen, setEndConfirmOpen] = useState(false);
   const [bonusOpen, setBonusOpen] = useState(false);
@@ -96,43 +95,26 @@ export function ManagerConsolePage() {
   function resetAwardChecks() {
     setTitleCorrect(false);
     setArtistCorrect(false);
-    setWrongBuzz(false);
   }
 
   function toggleTitle() {
-    setTitleCorrect((v) => {
-      const next = !v;
-      if (next) setWrongBuzz(false);
-      return next;
-    });
+    setTitleCorrect((v) => !v);
   }
 
   function toggleArtist() {
-    setArtistCorrect((v) => {
-      const next = !v;
-      if (next) setWrongBuzz(false);
-      return next;
-    });
+    setArtistCorrect((v) => !v);
   }
 
-  function toggleWrong() {
-    setWrongBuzz((v) => {
-      const next = !v;
-      if (next) {
-        setTitleCorrect(false);
-        setArtistCorrect(false);
-      }
-      return next;
-    });
-  }
-
-  async function applyAttempt(roundId: string): Promise<boolean> {
+  // Apply an attempt with explicit flag values; the caller decides what to send
+  // (Continue Round uses the toggle state; the Wrong button hard-codes wrong=true).
+  async function applyAttempt(
+    roundId: string,
+    flags: { title_correct: boolean; artist_correct: boolean; wrong_buzz: boolean },
+  ): Promise<boolean> {
     if (!managerToken) return false;
     const result = await awardAttempt(gameCode, managerToken, {
       round_id: roundId,
-      title_correct: titleCorrect,
-      artist_correct: artistCorrect,
-      wrong_buzz: wrongBuzz,
+      ...flags,
     });
     if (result.points_awarded > 0) {
       toast(`+${result.points_awarded} pts awarded`, { variant: "success" });
@@ -146,15 +128,41 @@ export function ManagerConsolePage() {
     if (!state?.currentRound || busy || !managerToken) return;
     const lockedTeamId = state.game.buzzed_team_id;
     if (!lockedTeamId) return;
-    if (!titleCorrect && !artistCorrect && !wrongBuzz) {
-      toast("Pick a result first (Correct Song, Correct Artist, or Wrong)", {
+    if (!titleCorrect && !artistCorrect) {
+      toast("Pick a result first (Correct Song or Correct Artist), or press Wrong", {
         variant: "info",
       });
       return;
     }
     setBusy(true);
     try {
-      await applyAttempt(state.currentRound.id);
+      await applyAttempt(state.currentRound.id, {
+        title_correct: titleCorrect,
+        artist_correct: artistCorrect,
+        wrong_buzz: false,
+      });
+      resetAwardChecks();
+    } catch (err) {
+      reportError(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Wrong is a one-click verdict: it ignores any toggled state, fires
+  // award_attempt with wrong_buzz=true, and re-arms the buzzers. Per
+  // game-rules.md §4, if a correct answer was already scored this round,
+  // the SQL function waives the -3 penalty.
+  async function handleWrong() {
+    if (!state?.currentRound || busy || !managerToken) return;
+    if (!state.game.buzzed_team_id) return;
+    setBusy(true);
+    try {
+      await applyAttempt(state.currentRound.id, {
+        title_correct: false,
+        artist_correct: false,
+        wrong_buzz: true,
+      });
       resetAwardChecks();
     } catch (err) {
       reportError(err);
@@ -170,9 +178,13 @@ export function ManagerConsolePage() {
       const round = state?.currentRound;
       const lockedTeamId = state?.game.buzzed_team_id ?? null;
       // If a buzz is held with a verdict toggled, score it before advancing.
-      if (round && lockedTeamId && (titleCorrect || artistCorrect || wrongBuzz)) {
+      if (round && lockedTeamId && (titleCorrect || artistCorrect)) {
         try {
-          await applyAttempt(round.id);
+          await applyAttempt(round.id, {
+            title_correct: titleCorrect,
+            artist_correct: artistCorrect,
+            wrong_buzz: false,
+          });
         } catch (err) {
           reportError(err);
           return;
@@ -304,10 +316,9 @@ export function ManagerConsolePage() {
 
   const titleToggleDisabled = busy || !lockedTeam || titleClaimedById != null;
   const artistToggleDisabled = busy || !lockedTeam || artistClaimedById != null;
-  const wrongToggleDisabled = busy || !lockedTeam;
+  const wrongActionDisabled = busy || !lockedTeam;
   const scoringDisabled = busy || !lockedTeam;
-  const continueDisabled =
-    busy || !lockedTeam || bothClaimed || !(titleCorrect || artistCorrect || wrongBuzz);
+  const continueDisabled = busy || !lockedTeam || bothClaimed || !(titleCorrect || artistCorrect);
   const nextRoundDisabled = busy || !player.ready;
   const bonusDisabled = busy || teams.length === 0;
   const nextRoundLabel = game.status === "waiting" ? "Start game" : "Next round";
@@ -413,10 +424,9 @@ export function ManagerConsolePage() {
             </button>
             <button
               type="button"
-              className={`${styles.scoreBtn} ${styles.scoreNegative} ${wrongBuzz ? styles.scoreActiveNeg : ""}`}
-              onClick={toggleWrong}
-              disabled={wrongToggleDisabled}
-              aria-pressed={wrongBuzz}
+              className={`${styles.scoreBtn} ${styles.scoreNegative} ${styles.wrongBtn}`}
+              onClick={() => void handleWrong()}
+              disabled={wrongActionDisabled}
               data-testid="score-wrong"
             >
               <span className={styles.scoreLabel}>Wrong</span>
@@ -483,6 +493,14 @@ export function ManagerConsolePage() {
       </div>
 
       <div className={styles.mobileBar} role="toolbar" aria-label="Round actions">
+        <button
+          className={`btn ${styles.wrongBtn}`}
+          onClick={() => void handleWrong()}
+          disabled={wrongActionDisabled}
+          data-testid="score-wrong-mobile"
+        >
+          Wrong
+        </button>
         <button
           className={`btn ${styles.continueBtn}`}
           onClick={() => void handleContinueRound()}

--- a/frontend/src/pages/TeamGameplayPage.module.css
+++ b/frontend/src/pages/TeamGameplayPage.module.css
@@ -8,6 +8,20 @@
   margin: 0 auto;
 }
 
+.pointStack {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+  pointer-events: none;
+  max-width: min(92vw, 360px);
+}
+
 .header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -1,12 +1,18 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BuzzButton, type BuzzTone } from "../components/BuzzButton";
 import { EndScreen } from "../components/EndScreen";
+import { PointChange } from "../components/PointChange";
 import { useBuzzer } from "../hooks/useBuzzer";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { serverTimeNow } from "../hooks/useServerTime";
 import { clearStoredTeam, getStoredTeam } from "../lib/teamStorage";
 import styles from "./TeamGameplayPage.module.css";
+
+interface PointEvent {
+  id: string;
+  delta: number;
+}
 
 const ANSWER_DURATION_SEC = 10;
 
@@ -25,10 +31,28 @@ export function TeamGameplayPage() {
 
   const { state, status } = useGameChannel(gameCode);
   const buzzer = useBuzzer(gameCode, stored?.id ?? "", state);
+  const [pointEvents, setPointEvents] = useState<PointEvent[]>([]);
+  const prevScoreRef = useRef<number | null>(null);
+  const eventSeqRef = useRef(0);
 
   useEffect(() => {
     if (state) setHydratedOnce(true);
   }, [state]);
+
+  // Diff our team's score across renders. First hydrate just snapshots the
+  // baseline; subsequent changes emit a single "+N / -N" pill.
+  useEffect(() => {
+    if (!state || !stored) return;
+    const me = state.teams.get(stored.id);
+    if (!me) return;
+    const prev = prevScoreRef.current;
+    if (prev !== null && me.score !== prev) {
+      eventSeqRef.current += 1;
+      const id = `${stored.id}-${eventSeqRef.current}`;
+      setPointEvents((current) => [...current, { id, delta: me.score - prev }]);
+    }
+    prevScoreRef.current = me.score;
+  }, [state, stored]);
 
   // Tick every second so the round timer re-renders.
   useEffect(() => {
@@ -102,6 +126,18 @@ export function TeamGameplayPage() {
 
   return (
     <main className={styles.shell}>
+      <div className={styles.pointStack} aria-live="polite">
+        {pointEvents.map((ev) => (
+          <PointChange
+            key={ev.id}
+            teamName={stored.name}
+            delta={ev.delta}
+            onDone={() =>
+              setPointEvents((current) => current.filter((existing) => existing.id !== ev.id))
+            }
+          />
+        ))}
+      </div>
       <header className={styles.header}>
         <div className={styles.identity}>
           <span className={styles.teamName}>{stored.name}</span>

--- a/frontend/src/test/supabaseMock.ts
+++ b/frontend/src/test/supabaseMock.ts
@@ -222,6 +222,7 @@ export function makeRound(overrides: Partial<GameRound> = {}): GameRound {
     wrong_buzz_penalty: 0,
     title_claimed_by: null,
     artist_claimed_by: null,
+    free_guess_active: false,
     ended_at: null,
     ...overrides,
   };

--- a/tests/backend/test_games_attempt.py
+++ b/tests/backend/test_games_attempt.py
@@ -345,6 +345,93 @@ async def test_end_round_clears_buzz_lock(client, db) -> None:
     assert locked is None
 
 
+# ----- free-guess sweetener (migration 017) ----------------------------------
+
+
+async def test_attempt_wrong_after_correct_no_penalty(client, db) -> None:
+    """After any correct attempt, the next wrong returns 0 (free guess)."""
+    rock = await fetch_genre_ids(db, slugs=["rock"])
+    await insert_song(db, genre_slugs=["rock"])
+    code, token = await insert_game(db, status="playing", selected_genres=rock)
+    t1 = await insert_team(db, code, name="T1")
+    t2 = await insert_team(db, code, name="T2")
+    pick = await client.post(
+        f"/games/{code}/select-song", json={}, headers=manager_headers(token)
+    )
+    round_id = pick.json()["round_id"]
+
+    # T1 buzzes title correct -> activates the free-guess flag.
+    await _force_buzz(db, code, round_id, t1)
+    r1 = await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "title_correct": True},
+        headers=manager_headers(token),
+    )
+    assert r1.status_code == 200
+    assert r1.json()["points_awarded"] == 10
+
+    # T2 buzzes wrong on artist -> 0 (free).
+    await _force_buzz(db, code, round_id, t2)
+    r2 = await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "wrong_buzz": True},
+        headers=manager_headers(token),
+    )
+    assert r2.status_code == 200
+    assert r2.json()["points_awarded"] == 0
+    assert r2.json()["team_total_score"] == 0
+
+
+async def test_attempt_wrong_before_any_correct_penalizes(client, db) -> None:
+    """Wrong as the first attempt of the round still costs -3."""
+    code, round_id, team_id, token = await _start_round(client, db)
+    resp = await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "wrong_buzz": True},
+        headers=manager_headers(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["points_awarded"] == -3
+
+
+async def test_attempt_free_guess_consumed_after_one_attempt(client, db) -> None:
+    """The flag is consumed by the next attempt (whether correct or wrong)."""
+    rock = await fetch_genre_ids(db, slugs=["rock"])
+    await insert_song(db, genre_slugs=["rock"])
+    code, token = await insert_game(db, status="playing", selected_genres=rock)
+    t1 = await insert_team(db, code, name="T1")
+    t2 = await insert_team(db, code, name="T2")
+    t3 = await insert_team(db, code, name="T3")
+    pick = await client.post(
+        f"/games/{code}/select-song", json={}, headers=manager_headers(token)
+    )
+    round_id = pick.json()["round_id"]
+
+    # T1 title -> flag on
+    await _force_buzz(db, code, round_id, t1)
+    await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "title_correct": True},
+        headers=manager_headers(token),
+    )
+    # T2 wrong -> 0 (free), flag off
+    await _force_buzz(db, code, round_id, t2)
+    await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "wrong_buzz": True},
+        headers=manager_headers(token),
+    )
+    # T3 wrong -> -3 (flag was consumed)
+    await _force_buzz(db, code, round_id, t3)
+    r3 = await client.post(
+        f"/games/{code}/attempt",
+        json={"round_id": round_id, "wrong_buzz": True},
+        headers=manager_headers(token),
+    )
+    assert r3.status_code == 200
+    assert r3.json()["points_awarded"] == -3
+
+
 async def test_start_round_closes_prior_open_round(client, db) -> None:
     """If the manager advances without explicit end_round, the prior
     round's ended_at gets stamped by start_round automatically."""

--- a/tests/db/test_award_attempt.py
+++ b/tests/db/test_award_attempt.py
@@ -269,6 +269,109 @@ async def test_award_attempt_after_end_round_raises(db: asyncpg.Connection) -> N
     assert exc.value.sqlstate == "P0001"
 
 
+# ----- free-guess sweetener (migration 017) ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_wrong_before_correct_penalizes(
+    db: asyncpg.Connection,
+) -> None:
+    """A wrong buzz with no prior correct in the round costs the full -3."""
+    game_code = await create_test_game(db, status="playing")
+    team_id = await create_test_team(db, game_code)
+    round_id = await _start_round_and_buzz(db, game_code, team_id)
+
+    rows = await db.fetch(
+        "SELECT points_delta FROM award_attempt($1, $2, 0, 0, 3)",
+        game_code,
+        round_id,
+    )
+    assert rows[0]["points_delta"] == -3
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_wrong_after_correct_no_penalty(
+    db: asyncpg.Connection,
+) -> None:
+    """After any correct attempt, the next wrong waives the -3 penalty."""
+    game_code = await create_test_game(db, status="playing")
+    t1 = await create_test_team(db, game_code, name="T1")
+    t2 = await create_test_team(db, game_code, name="T2")
+    round_id = await _start_round_and_buzz(db, game_code, t1)
+
+    # T1 scores title correct -> activates free_guess flag for the round.
+    await db.execute("SELECT award_attempt($1, $2, 10, 0, 0)", game_code, round_id)
+
+    # T2 buzzes wrong on artist -> free, delta = 0.
+    await _force_buzz(db, game_code, round_id, t2)
+    rows = await db.fetch(
+        "SELECT points_delta FROM award_attempt($1, $2, 0, 0, 3)",
+        game_code,
+        round_id,
+    )
+    assert rows[0]["points_delta"] == 0
+    # Score did not move.
+    t2_score = await db.fetchval("SELECT score FROM game_teams WHERE id = $1", t2)
+    assert t2_score == 0
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_free_guess_clears_after_one_attempt(
+    db: asyncpg.Connection,
+) -> None:
+    """Flag is consumed by the next attempt regardless of outcome."""
+    game_code = await create_test_game(db, status="playing")
+    t1 = await create_test_team(db, game_code, name="T1")
+    t2 = await create_test_team(db, game_code, name="T2")
+    t3 = await create_test_team(db, game_code, name="T3")
+    round_id = await _start_round_and_buzz(db, game_code, t1)
+
+    # T1 title -> flag on
+    await db.execute("SELECT award_attempt($1, $2, 10, 0, 0)", game_code, round_id)
+
+    # T2 wrong -> 0 (free), flag off
+    await _force_buzz(db, game_code, round_id, t2)
+    await db.execute("SELECT award_attempt($1, $2, 0, 0, 3)", game_code, round_id)
+
+    # T3 wrong -> -3 (flag was consumed)
+    await _force_buzz(db, game_code, round_id, t3)
+    rows = await db.fetch(
+        "SELECT points_delta FROM award_attempt($1, $2, 0, 0, 3)",
+        game_code,
+        round_id,
+    )
+    assert rows[0]["points_delta"] == -3
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_free_guess_reactivates_on_subsequent_correct(
+    db: asyncpg.Connection,
+) -> None:
+    """Wrong consumes the flag; a later correct re-activates it for the next attempt."""
+    game_code = await create_test_game(db, status="playing")
+    t1 = await create_test_team(db, game_code, name="T1")
+    t2 = await create_test_team(db, game_code, name="T2")
+    round_id = await _start_round_and_buzz(db, game_code, t1)
+
+    # T1 title -> flag on. T2 wrong -> free, flag off.
+    await db.execute("SELECT award_attempt($1, $2, 10, 0, 0)", game_code, round_id)
+    await _force_buzz(db, game_code, round_id, t2)
+    await db.execute("SELECT award_attempt($1, $2, 0, 0, 3)", game_code, round_id)
+
+    # T2 artist correct -> flag re-activates.
+    await _force_buzz(db, game_code, round_id, t2)
+    await db.execute("SELECT award_attempt($1, $2, 0, 5, 0)", game_code, round_id)
+
+    # T1 wrong on the (now exhausted) round? Both tokens claimed, so wrong is the only valid call.
+    await _force_buzz(db, game_code, round_id, t1)
+    rows = await db.fetch(
+        "SELECT points_delta FROM award_attempt($1, $2, 0, 0, 3)",
+        game_code,
+        round_id,
+    )
+    assert rows[0]["points_delta"] == 0  # free again, the just-correct attempt re-armed it
+
+
 @pytest.mark.asyncio
 async def test_start_round_closes_prior_open_round(db: asyncpg.Connection) -> None:
     game_code = await create_test_game(db, status="playing")

--- a/tests/e2e/bonus_flow.spec.ts
+++ b/tests/e2e/bonus_flow.spec.ts
@@ -6,6 +6,7 @@ import {
   awardAndAdvance,
   awardAndContinue,
   awardBonusToTeam,
+  markWrong,
   openManagerAndCreateGame,
 } from "./fixtures/manager-context";
 import { buzzAndExpectWinner, expectBuzzGreen, joinAsTeam } from "./fixtures/team-context";
@@ -88,19 +89,19 @@ test("scenario 19: four teams, two wrongs + two splits + bonus to a wrong-guesse
 
   await manager.page.getByTestId("start-round").click();
 
-  // T1 wrong → -3
+  // T1 wrong → -3 (no prior correct, full penalty applies)
   await buzzAndExpectWinner(t1);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
-  // T2 artist correct → +5
+  // T2 artist correct → +5  (free-guess flag now active for next attempt)
   await expectBuzzGreen(t2);
   await buzzAndExpectWinner(t2);
   await awardAndContinue(manager.page, { artist: true });
 
-  // T3 wrong → -3
+  // T3 wrong → 0 (free-guess waives the -3; flag is then consumed)
   await expectBuzzGreen(t3);
   await buzzAndExpectWinner(t3);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   // T4 title correct → +10
   await expectBuzzGreen(t4);
@@ -111,11 +112,11 @@ test("scenario 19: four teams, two wrongs + two splits + bonus to a wrong-guesse
   await awardBonusToTeam(manager.page, "Alpha");
   await manager.page.getByTestId("start-round").click();
 
-  // Alpha: -3 + 4 = 1, Bravo: 5, Charlie: -3, Delta: 10.
+  // Alpha: -3 + 4 = 1, Bravo: 5, Charlie: 0 (free-guess), Delta: 10.
   const display = await browser.newPage();
   await display.goto(`/display/${manager.gameCode}`);
   await expectScore(display, "Alpha", 1);
   await expectScore(display, "Bravo", 5);
-  await expectScore(display, "Charlie", -3);
+  await expectScore(display, "Charlie", 0);
   await expectScore(display, "Delta", 10);
 });

--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -73,10 +73,13 @@ export async function openManagerAndCreateGame(
 // ---------------------------------------------------------------------------
 // Manager action helpers (multi-buzz round model)
 //
-// `awardAndContinue` toggles the requested score bits and presses
-// "Continue round": the buzz is scored, the lock is cleared, and the same
-// song keeps playing. `awardAndAdvance` does the same but presses
-// "Next round" so the round closes and the next song loads.
+// `awardAndContinue` toggles title/artist and presses "Continue round":
+// the buzz is scored, the lock is cleared, and the same song keeps playing.
+// `awardAndAdvance` does the same but presses "Next round" so the round
+// closes and the next song loads.
+//
+// Wrong is its own one-click action (auto-fires `award_attempt`, no Continue
+// press needed). Use `markWrong` for the wrong-buzz path.
 //
 // `skipRound` is the no-buzz timeout/skip path: presses "Next round"
 // without any toggles set, advancing straight to the next song.
@@ -87,7 +90,6 @@ export async function openManagerAndCreateGame(
 export interface AttemptToggles {
   title?: boolean;
   artist?: boolean;
-  wrong?: boolean;
 }
 
 async function setToggles(page: Page, toggles: AttemptToggles): Promise<void> {
@@ -97,13 +99,6 @@ async function setToggles(page: Page, toggles: AttemptToggles): Promise<void> {
     if ((await btn.getAttribute("aria-pressed")) === "true") return;
     await btn.click();
   };
-  // Wrong is mutually exclusive with title/artist. The UI clears the
-  // others when wrong is toggled, but we set them in a deterministic
-  // order so the final state matches caller intent.
-  if (toggles.wrong) {
-    await setIf("score-wrong", true);
-    return;
-  }
   await setIf("score-title", toggles.title);
   await setIf("score-artist", toggles.artist);
 }
@@ -119,6 +114,15 @@ export async function awardAndContinue(
   await expect(page.getByTestId("score-title")).toHaveAttribute("aria-pressed", "false", {
     timeout: 10_000,
   });
+}
+
+// markWrong fires the Wrong verdict in one click. It does NOT need a
+// follow-up Continue press: award_attempt runs immediately, the lock
+// clears, and the buzzers re-arm. The -3 penalty is automatically waived
+// by the SQL function if a correct answer was already scored this round
+// (free-guess sweetener; see migration 017).
+export async function markWrong(page: Page): Promise<void> {
+  await page.getByTestId("score-wrong").click();
 }
 
 export async function awardAndAdvance(

--- a/tests/e2e/multi_buzz_round.spec.ts
+++ b/tests/e2e/multi_buzz_round.spec.ts
@@ -6,6 +6,7 @@ import { test, expect } from "@playwright/test";
 import {
   awardAndAdvance,
   awardAndContinue,
+  markWrong,
   openManagerAndCreateGame,
 } from "./fixtures/manager-context";
 import { buzzAndExpectWinner, expectBuzzGreen, joinAsTeam } from "./fixtures/team-context";
@@ -82,7 +83,7 @@ test("scenario 5: same team recovers after wrong, then claims both", async ({ br
   await startNextRound(manager);
 
   await buzzAndExpectWinner(team);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(team);
   await buzzAndExpectWinner(team);
@@ -92,7 +93,7 @@ test("scenario 5: same team recovers after wrong, then claims both", async ({ br
   await buzzAndExpectWinner(team);
   await awardAndAdvance(manager.page, { artist: true });
 
-  // -3 + 10 + 5 = 12.
+  // -3 + 10 + 5 = 12. (Wrong was BEFORE any correct, so the -3 stands.)
   const display = await browser.newPage();
   await display.goto(`/display/${manager.gameCode}`);
   await expect(

--- a/tests/e2e/wrong_buzz_recovery.spec.ts
+++ b/tests/e2e/wrong_buzz_recovery.spec.ts
@@ -1,11 +1,18 @@
 // Wrong-buzz recovery scenarios. Wrong does NOT lock a team out -- they
 // (or anyone else) can buzz again on the same song. Covers matrix
 // scenarios 4, 8, 9, 15, and 18.
+//
+// Note on free-guess (migration 017): once any correct attempt has been
+// scored in a round, the *next* wrong waives the -3 penalty (round-wide,
+// next-attempt-only, consumed by use). Scenarios 4/8/9/18 wrong all the
+// way through with no correct in between, so the -3 stands. Scenario 15
+// has a correct first, so the next wrong is free.
 
 import { test, expect } from "@playwright/test";
 import {
   awardAndAdvance,
   awardAndContinue,
+  markWrong,
   openManagerAndCreateGame,
   skipRound,
 } from "./fixtures/manager-context";
@@ -35,7 +42,7 @@ test("scenario 4: T1 wrong, T2 wins title, T3 wins artist", async ({ browser }) 
   await startNextRound(manager);
 
   await buzzAndExpectWinner(t1);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t2);
   await buzzAndExpectWinner(t2);
@@ -62,17 +69,18 @@ test("scenario 8: two wrong buzzers, then correct claims both atomically", async
   await startNextRound(manager);
 
   await buzzAndExpectWinner(t1);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t2);
   await buzzAndExpectWinner(t2);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t1);
   await buzzAndExpectWinner(t1);
   await awardAndAdvance(manager.page, { title: true, artist: true });
 
-  // Alpha: -3 + 15 = 12, Bravo: -3.
+  // Alpha: -3 + 15 = 12, Bravo: -3. (No correct between the two wrongs,
+  // so free-guess never activates.)
   const display = await browser.newPage();
   await display.goto(`/display/${manager.gameCode}`);
   await expectScore(display, "Alpha", 12);
@@ -86,11 +94,11 @@ test("scenario 9: same team double-wrong then claims artist", async ({ browser }
   await startNextRound(manager);
 
   await buzzAndExpectWinner(team);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(team);
   await buzzAndExpectWinner(team);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(team);
   await buzzAndExpectWinner(team);
@@ -102,7 +110,7 @@ test("scenario 9: same team double-wrong then claims artist", async ({ browser }
   await expectScore(display, "Solo", -1);
 });
 
-test("scenario 15: team claims title then buzzes wrong on the same song", async ({
+test("scenario 15: team claims title then buzzes wrong (free-guess waiver)", async ({
   browser,
 }) => {
   const manager = await openManagerAndCreateGame(browser, { genreName: "Rock" });
@@ -114,18 +122,19 @@ test("scenario 15: team claims title then buzzes wrong on the same song", async 
   await buzzAndExpectWinner(t1);
   await awardAndContinue(manager.page, { title: true });
 
+  // Alpha already scored title, so this wrong is free (delta = 0).
   await expectBuzzGreen(t1);
   await buzzAndExpectWinner(t1);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t2);
   await buzzAndExpectWinner(t2);
   await awardAndAdvance(manager.page, { artist: true });
 
-  // Alpha: 10 - 3 = 7, Bravo: 5.
+  // Alpha: 10 + 0 = 10, Bravo: 5.
   const display = await browser.newPage();
   await display.goto(`/display/${manager.gameCode}`);
-  await expectScore(display, "Alpha", 7);
+  await expectScore(display, "Alpha", 10);
   await expectScore(display, "Bravo", 5);
 });
 
@@ -138,15 +147,15 @@ test("scenario 18: all three teams buzz wrong, manager skips", async ({ browser 
   await startNextRound(manager);
 
   await buzzAndExpectWinner(t1);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t2);
   await buzzAndExpectWinner(t2);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   await expectBuzzGreen(t3);
   await buzzAndExpectWinner(t3);
-  await awardAndContinue(manager.page, { wrong: true });
+  await markWrong(manager.page);
 
   // No more buzzers; manager skips to the next round.
   await skipRound(manager.page);


### PR DESCRIPTION
## Summary

Three follow-up polish items to PR #55, plus one scoring-rule sweetener.

- **Team score-delta toast** (suggestion #3): the team's own phone now shows a "+10 / −3" pill the instant their score changes — same `<PointChange />` component as the projector for visual consistency.
- **Display reveal panel** (new ask): when the manager confirms a Title or Artist correct, the projector now shows the actual song title / artist text in a dedicated panel above the existing token chips. Unrevealed halves show "???".
- **Wrong is one-click** (suggestion #7, modified): the Wrong button now fires `award_attempt` immediately and re-arms — no separate Continue Round press. Added a third Wrong shortcut to the manager mobile sticky bar. Title and Artist remain toggles (manager often combines them).
- **Free-guess waiver** (new gameplay rule, migration 017): once any team scores a correct token in a round, the next attempt waives the −3 wrong-buzz penalty. Round-wide and one-shot — flag re-arms after every correct, clears after every wrong.

Migration 017 has been applied to BOTH Supabase projects (preview + prod) before opening the PR, per the 2026-05-07 lessons-learned.

This PR targets `feature/multi-buzz-rounds` (PR #55) since #55 hasn't merged yet. After #55 merges to `main`, this branch will rebase / re-target cleanly.

## Test plan

- [x] `npm run typecheck` (frontend)
- [x] `npm run lint` (frontend)
- [x] `npm run format:check` (frontend)
- [x] `npm run test:run` (frontend, 196 tests pass)
- [x] `ruff check + format --check` (backend, all green)
- [ ] `pytest tests/backend tests/db` — runs in CI (no local Docker for testcontainers); new free-guess test cases added in `test_games_attempt.py` and `test_award_attempt.py`
- [ ] `cd tests/e2e && npm test` — runs in CI; updated scenario 15 (wrong-after-correct → 0 instead of −3) and scenario 19 (T3's wrong after T2's correct → 0)
- [ ] Manual three-tab smoke after CI green: team toast on phone, display reveal of song title/artist, Wrong one-click on both desktop and mobile, free-guess waiver in scenario 15