### PR TITLE
Quiet YouTube embed: youtube-nocookie host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-10: Quieter YouTube embed; switched to youtube-nocookie host to stop ad-tracking CORS errors (and reduce the IFrame API's postMessage warm-up warning) in the browser console while a game runs.
 - 2026-05-09: When a team buzzes, the manager's YouTube player no longer flashes the paused-state "more videos" tiles (which can include other songs in the same artist's channel and spoil future rounds). The black "Ready" overlay now stays on top of the iframe whenever a buzz is being scored.
 - 2026-05-09: Manager scoring buttons no longer act as a footgun after a round was already scored. `End round` and `Restart song` are now disabled once the current round has an `ended_at`, so a second click can't fire a `round_already_ended` error toast - the host's only enabled action is `Next round`.
 - 2026-05-09: YouTube embed chrome (player labels, captions) is forced to English regardless of the host's browser/IP locale, so a host on a Hebrew-locale browser no longer sees Hebrew controls bleeding through the iframe overlay.

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -168,12 +168,12 @@ Frontend served by Cloudflare Pages. Configure via `_headers` file:
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io
 ```
 
 Notes:
 - `'unsafe-inline'` for scripts is needed by Vite's runtime + YouTube IFrame Player. Tighten in a future hardening pass with hashes.
-- `frame-src https://www.youtube.com` is required for the IFrame Player.
+- `frame-src` lists both `https://www.youtube.com` and `https://www.youtube-nocookie.com`. The IFrame Player runs in privacy-enhanced mode (`host: "https://www.youtube-nocookie.com"`) to suppress the doubleclick conversion-tracking pixels; the `youtube.com` entry remains because the IFrame API JS itself still loads from there.
 - `connect-src` allows Supabase (REST + Realtime), backend API, and Sentry ingest only.
 
 Backend (FastAPI) sets:

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -45,6 +45,7 @@ interface YTNamespace {
     config: {
       width?: string | number;
       height?: string | number;
+      host?: string;
       playerVars?: Record<string, number | string>;
       events?: {
         onReady?: () => void;
@@ -114,6 +115,10 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
       playerRef.current = new YT.Player(containerRef.current, {
         width: "100%",
         height: "100%",
+        // Privacy-enhanced mode: iframe is created at youtube-nocookie.com
+        // instead of youtube.com, which suppresses the doubleclick conversion
+        // pixels that otherwise CORS-spam the console once the video plays.
+        host: "https://www.youtube-nocookie.com",
         playerVars: {
           modestbranding: 1,
           rel: 0,
@@ -124,6 +129,11 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
           // browser is set to e.g. Hebrew doesn't see "הפעלת הסרטון" /
           // "סרטונים נוספים" in the player overlay.
           hl: "en",
+          // Pre-declare the parent origin so the IFrame API can validate
+          // postMessage targets up-front, which mitigates the warm-up
+          // "target origin does not match" warning fired by www-widgetapi.js
+          // before the iframe finishes navigating.
+          origin: window.location.origin,
         },
         events: {
           onReady: () => {


### PR DESCRIPTION
## Summary

After creating a game on prod, the browser console was flooded with two YouTube-iframe-related errors (independent of the Grammarly extension noise):

1. `Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://www.youtube.com') does not match the recipient window's origin ...` — fired from `www-widgetapi.js` while the IFrame API set up communication with the embedded iframe.
2. A stream of `googleads.g.doubleclick.net` CORS-blocked fetches every time a video played.

This PR:

- Switches the embed to YouTube's privacy-enhanced "nocookie" host via `host: "https://www.youtube-nocookie.com"` on `YT.Player`. The iframe is now served from `youtube-nocookie.com/embed/...` which does not load the doubleclick conversion pixels — eliminates (2) entirely.
- Adds `origin: window.location.origin` to `playerVars` so the IFrame API can pre-validate the parent origin, mitigating the warm-up race that produced (1). Cannot be 100% suppressed (it's a known IFrame API quirk on cold init), but reduces from a stream of repeats to a single one-shot at iframe boot.
- Adds `https://www.youtube-nocookie.com` to the CSP `frame-src` directive in `frontend/public/_headers` so the new iframe host is allowed.
- Mirrors the CSP change in `docs/security-rls.md` §7 per the project rule that schema/security doc updates ride in the same PR.
- Adds a one-line `[Unreleased] → Fixed` entry to `CHANGELOG.md`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` — 195/195 tests pass, 95.22% line coverage (existing `YouTubePlayer.test.tsx` still passes; the fake `YT.Player` ignores extra config keys)
- [x] `npm run build` — bundle builds; service-role-key leak check passes
- [x] Manual three-tab playthrough against local backend + Supabase preview (manager + 2 teams + display): full game flow, scoring, Realtime fan-out all work; **zero `doubleclick.net` / `googleads` requests in the entire session**, manager tab shows 0 console errors