### PR TITLE
Reset answer timer on correct verdict; Wrong resumes song; even genre mixing; bigger BUZZ button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-12: When the host marks a Correct Song / Correct Artist, the buzzed team keeps control of the round for the other token (as before) **and** its 10-second answer countdown restarts — so the team that got one half right gets a fresh window to also guess the missing half.
+- 2026-05-12: The manager's Wrong button now also resumes the song immediately (in addition to re-arming the buzzers) — no separate Continue round press needed to un-pause playback.
+- 2026-05-12: The BUZZ button on the team (player) screen is bigger — it now fills most of a phone screen.
 - 2026-05-10: Manager Correct Song / Correct Artist buttons now apply their score the moment they're clicked — no second Continue press needed. The buzz lock stays held on the answering team until the manager presses Continue (which also resumes the song) or Wrong (which immediately re-arms the buzzers).
 - 2026-05-10: Team-page score pill no longer prefixes the team name. A player on their own phone now sees just `+10` / `-3` instead of `<team-name> +10`. The shared display screen still shows the team name in its score pill since multiple deltas can stack there.
 - 2026-05-10: Display screen waiting view (QR code + team list) is bigger on desktop — larger QR, taller team rows, larger scores — so a TV-mounted display is readable from across the room.
@@ -36,6 +39,8 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-12: Song selection now mixes the selected genres evenly. Each round picks a random genre among those chosen, then a random unplayed song within it, so a game with several genres no longer front-loads whichever genre happens to have the most songs in the catalog.
+- 2026-05-12: The host's Correct Song / Correct Artist buttons no longer go inactive a moment after a click — the answering team keeps control of the round for the other token until the host presses Continue round or Wrong.
 - 2026-05-10: Manager YouTube player no longer overlays a black "Ready" splash when a team buzzes. The cover that hides the iframe still appears (so YouTube's pause-state "more videos" tiles can't leak song titles), but it stays empty rather than re-using the pre-load loading text.
 - 2026-05-10: Quieter YouTube embed; switched to youtube-nocookie host to stop ad-tracking CORS errors (and reduce the IFrame API's postMessage warm-up warning) in the browser console while a game runs.
 - 2026-05-09: When a team buzzes, the manager's YouTube player no longer flashes the paused-state "more videos" tiles (which can include other songs in the same artist's channel and spoil future rounds). A blank cover stays on top of the iframe whenever a buzz is being scored.

--- a/backend/app/services/song_picker.py
+++ b/backend/app/services/song_picker.py
@@ -1,12 +1,17 @@
-"""Pick a random unplayed song for a game.
+"""Pick a random unplayed song for a game, mixing the selected genres evenly.
 
-Joins ``songs`` with ``song_genres`` filtered to the game's selected genres
-and excludes any song already used in this game's ``game_rounds``. Returns
-a single song dict or raises :class:`ConflictError` when the pool is empty.
+Each call picks a random *eligible* genre (one that still has an unplayed song
+in this game) and then a random unplayed song within it. Weighting genres
+equally — rather than sampling uniformly over the union of all candidate songs —
+keeps small genres from being drowned out by large ones, so a game with several
+selected genres interleaves them throughout instead of front-loading the biggest
+one. Songs already used in this game's ``game_rounds`` are excluded; when every
+selected genre is exhausted, raises :class:`ConflictError`.
 """
 
 from __future__ import annotations
 
+import secrets
 from typing import Any
 from uuid import UUID
 
@@ -18,33 +23,48 @@ from app.db.supabase_client import SupabaseClientLike
 SONG_COLUMNS = "id,title,artist,youtube_id,start_time,is_soundtrack,source"
 
 
+def _no_more_songs() -> ConflictError:
+    return ConflictError(
+        "no songs left in selected genres",
+        details={"reason": "no_more_songs"},
+    )
+
+
 def _pick_blocking(
     client: SupabaseClientLike, game_code: str, genre_ids: list[str]
 ) -> dict[str, Any]:
     played = client.table("game_rounds").select("song_id").eq("game_code", game_code).execute()
-    played_ids: list[str] = [row["song_id"] for row in (played.data or []) if row.get("song_id")]
+    played_ids: set[str] = {row["song_id"] for row in (played.data or []) if row.get("song_id")}
 
-    matching = client.table("song_genres").select("song_id").in_("genre_id", genre_ids).execute()
-    candidate_ids = {row["song_id"] for row in (matching.data or [])}
-    candidate_ids.difference_update(played_ids)
+    matching = (
+        client.table("song_genres").select("song_id,genre_id").in_("genre_id", genre_ids).execute()
+    )
+    # Bucket unplayed candidate songs by genre. A song that belongs to several
+    # selected genres lands in each bucket; once played it drops out of all of
+    # them via played_ids.
+    by_genre: dict[str, list[str]] = {}
+    for row in matching.data or []:
+        song_id = row.get("song_id")
+        genre_id = row.get("genre_id")
+        if song_id is None or genre_id is None or song_id in played_ids:
+            continue
+        by_genre.setdefault(genre_id, []).append(song_id)
 
-    if not candidate_ids:
-        raise ConflictError(
-            "no songs left in selected genres",
-            details={"reason": "no_more_songs"},
-        )
+    eligible_genres = [g for g, songs in by_genre.items() if songs]
+    if not eligible_genres:
+        raise _no_more_songs()
 
-    songs = client.table("songs").select(SONG_COLUMNS).in_("id", list(candidate_ids)).execute()
+    chosen_genre = eligible_genres[secrets.randbelow(len(eligible_genres))]
+    candidates = by_genre[chosen_genre]
+    chosen_id = candidates[secrets.randbelow(len(candidates))]
+
+    songs = client.table("songs").select(SONG_COLUMNS).eq("id", chosen_id).execute()
     rows: list[dict[str, Any]] = list(songs.data or [])
     if not rows:
-        raise ConflictError(
-            "no songs left in selected genres",
-            details={"reason": "no_more_songs"},
-        )
-
-    import secrets as _secrets
-
-    return rows[_secrets.randbelow(len(rows))]
+        # The song_genres row referenced a song that's no longer in the catalog.
+        # Treat it as a depleted pool rather than a 500.
+        raise _no_more_songs()
+    return rows[0]
 
 
 async def pick_random_song(

--- a/db/migrations/019_refresh_locked_at_on_correct.sql
+++ b/db/migrations/019_refresh_locked_at_on_correct.sql
@@ -1,0 +1,159 @@
+-- 019_refresh_locked_at_on_correct.sql
+-- Refresh active_games.locked_at on a correct attempt.
+--
+-- Migration 018 keeps the buzz lock held on the answering team after a
+-- Correct Song / Correct Artist, so that team retains the floor for the
+-- other token until the manager presses Continue or Wrong. The clients
+-- (team + display) derive the 10-second answer countdown purely from
+-- active_games.locked_at, so without this change the timer keeps counting
+-- down from the original buzz instead of restarting -- the team that just
+-- earned the floor for the other half effectively gets no fresh window.
+--
+-- This migration makes award_attempt set locked_at = now() on the
+-- title / artist / title_artist branches (buzzed_team_id is unchanged --
+-- the same team keeps control). The wrong-buzz branch still clears both,
+-- and the no-op continue branch still leaves the lock untouched.
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION. Body is identical to migration
+-- 018 except for the lock-side UPDATE at the end.
+
+CREATE OR REPLACE FUNCTION award_attempt(
+  p_game_code  text,
+  p_round_id   uuid,
+  p_title      integer DEFAULT 0,
+  p_artist     integer DEFAULT 0,
+  p_wrong_buzz integer DEFAULT 0
+)
+RETURNS TABLE(
+  team_id              uuid,
+  points_delta         integer,
+  team_total_score     integer,
+  title_claimed_by     uuid,
+  artist_claimed_by    uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id        uuid;
+  v_round_ended    timestamptz;
+  v_title_claimed  uuid;
+  v_artist_claimed uuid;
+  v_free_guess     boolean;
+  v_outcome        text;
+  v_delta          integer;
+  v_score          integer;
+  v_new_free_guess boolean;
+BEGIN
+  SELECT gr.ended_at, gr.title_claimed_by, gr.artist_claimed_by, gr.free_guess_active
+    INTO v_round_ended, v_title_claimed, v_artist_claimed, v_free_guess
+    FROM game_rounds gr
+   WHERE gr.id = p_round_id AND gr.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'round_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_round_ended IS NOT NULL THEN
+    RAISE EXCEPTION 'round_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT ag.buzzed_team_id INTO v_team_id
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF v_team_id IS NULL THEN
+    RAISE EXCEPTION 'no_buzz_to_score' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0
+     AND (COALESCE(p_title, 0) > 0 OR COALESCE(p_artist, 0) > 0) THEN
+    RAISE EXCEPTION 'wrong_buzz_with_correct' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_title, 0) > 0 AND v_title_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'title_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+  IF COALESCE(p_artist, 0) > 0 AND v_artist_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'artist_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    IF v_free_guess THEN
+      v_delta := 0;
+    ELSE
+      v_delta := -p_wrong_buzz;
+    END IF;
+    v_outcome := 'wrong';
+  ELSIF COALESCE(p_title, 0) > 0 AND COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_title + p_artist;
+    v_outcome := 'title_artist';
+  ELSIF COALESCE(p_title, 0) > 0 THEN
+    v_delta := p_title;
+    v_outcome := 'title';
+  ELSIF COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_artist;
+    v_outcome := 'artist';
+  ELSE
+    v_delta := 0;
+    v_outcome := NULL;
+  END IF;
+
+  IF v_outcome IN ('title', 'artist', 'title_artist') THEN
+    v_new_free_guess := true;
+  ELSE
+    v_new_free_guess := false;
+  END IF;
+
+  IF v_delta <> 0 THEN
+    UPDATE game_teams SET score = score + v_delta WHERE id = v_team_id;
+  END IF;
+
+  IF COALESCE(p_title, 0) > 0 THEN
+    UPDATE game_rounds SET title_claimed_by = v_team_id, title_points = p_title
+     WHERE id = p_round_id;
+  END IF;
+  IF COALESCE(p_artist, 0) > 0 THEN
+    UPDATE game_rounds SET artist_claimed_by = v_team_id, artist_points = p_artist
+     WHERE id = p_round_id;
+  END IF;
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    UPDATE game_rounds SET wrong_buzz_penalty = p_wrong_buzz
+     WHERE id = p_round_id;
+  END IF;
+
+  UPDATE game_rounds SET free_guess_active = v_new_free_guess
+   WHERE id = p_round_id;
+
+  IF v_outcome IS NOT NULL THEN
+    INSERT INTO game_round_attempts (round_id, game_code, team_id, outcome, points_delta)
+    VALUES (p_round_id, p_game_code, v_team_id, v_outcome, v_delta);
+  END IF;
+
+  -- Lock-side update:
+  --   * wrong  -> re-arm the room (clear the lock).
+  --   * title / artist / title_artist -> keep the same team on the floor,
+  --     but refresh locked_at so their answer countdown restarts for the
+  --     remaining token.
+  --   * no-op continue -> leave the lock untouched.
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    UPDATE active_games
+       SET buzzed_team_id = NULL, locked_at = NULL
+     WHERE game_code = p_game_code;
+  ELSIF v_outcome IN ('title', 'artist', 'title_artist') THEN
+    UPDATE active_games
+       SET locked_at = now()
+     WHERE game_code = p_game_code;
+  END IF;
+
+  SELECT gt.score INTO v_score FROM game_teams gt WHERE gt.id = v_team_id;
+  SELECT gr.title_claimed_by, gr.artist_claimed_by
+    INTO v_title_claimed, v_artist_claimed
+    FROM game_rounds gr WHERE gr.id = p_round_id;
+
+  RETURN QUERY SELECT v_team_id, v_delta, COALESCE(v_score, 0),
+                      v_title_claimed, v_artist_claimed;
+END $$;
+
+REVOKE ALL ON FUNCTION award_attempt(text, uuid, integer, integer, integer) FROM PUBLIC;

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -76,9 +76,9 @@ Each round is one song. The song carries **two independent claim tokens — TITL
 1. **Round starts**: manager picks (or system random-picks) a song; `start_round` RPC defensively closes any prior open round, then clears buzz state and assigns `current_song_id`.
 2. **Song plays**: manager controls YouTube IFrame Player.
 3. **Buzz**: a team calls `buzz_in` RPC; the first one to satisfy `buzzed_team_id IS NULL` wins. `locked_at` is the server timestamp.
-4. **Evaluation**: manager judges the verbal answer and toggles `Correct Song` / `Correct Artist` / `Wrong` in the console.
-5. **Continue Round**: manager presses "Continue round". `award_attempt` RPC scores the buzz (claiming a token if correct, deducting if wrong), clears the buzz lock, and **leaves the round open**. Other teams (or the same team) can buzz again immediately.
-6. **Next Round**: manager presses "Next round". If a buzz is held with toggles set, `award_attempt` runs first. Then `end_round` closes the current round and `start_round` advances to the next song. Any unclaimed tokens are abandoned (no penalty).
+4. **Evaluation**: manager judges the verbal answer. Each verdict button — `Correct Song` (+10), `Correct Artist` (+5), `Wrong` (−3) — fires `award_attempt` **immediately on click**; the score commits the moment the manager clicks. A correct verdict keeps the buzzing team on the floor for the other token and refreshes its 10-second answer countdown (migration 019); a Wrong verdict re-arms the buzzers and resumes the song.
+5. **Continue Round**: manager presses "Continue round" to re-open buzzes after a correct verdict — `release_buzz_lock` clears the buzz lock and the song resumes, **leaving the round open**. Other teams (or the same team) can buzz again immediately. No scoring happens here.
+6. **Next Round**: manager presses "Next round". (Any held buzz should be scored first via the verdict buttons; Next Round does not auto-score.) `end_round` closes the current round and `start_round` advances to the next song. Any unclaimed tokens are abandoned (no penalty).
 
 ### Token claim rules
 
@@ -114,9 +114,10 @@ Scores are integers; ties are allowed. The team with the highest score at game e
 
 - `Correct Song` and `Correct Artist` are **accumulating toggles** within a single buzz: the host may select either, both, or neither (which is treated as a no-score; the API rejects an attempt with no flags set).
 - `Wrong` is **mutually exclusive** with the two correct toggles, both in the UI and in the SQL function (`P0001 wrong_buzz_with_correct`).
-- `Continue Round` calls `award_attempt`: scores the current buzz (Title and/or Artist toggles), clears the lock, leaves the round open. Disabled when no buzz is held, both tokens are claimed, or no toggle is selected.
-- `Wrong` is its own one-click action: it fires `award_attempt` immediately with `wrong_buzz=true` (no Continue Round press needed), re-arms the buzzers, and may waive the −3 per the free-guess rule above.
-- `Next Round` advances to the next song. If a buzz is held with toggles set, it scores first via `award_attempt`. Then `end_round` closes the current round and `start_round` advances.
+- `Correct Song` / `Correct Artist` each fire `award_attempt` immediately on click. The buzzing team keeps the floor for the other token (its answer countdown restarts) until the manager presses `Continue Round` or `Wrong`. Disabled when no buzz is held; the matching toggle also greys out once that token is claimed.
+- `Continue Round` calls `release_buzz_lock` (no scoring): it clears the buzz lock and resumes the song, leaving the round open. Disabled when no buzz is held.
+- `Wrong` is its own one-click action: it fires `award_attempt` immediately with `wrong_buzz=true` (no Continue Round press needed), re-arms the buzzers, resumes the song, and may waive the −3 per the free-guess rule above.
+- `Next Round` advances to the next song: `end_round` closes the current round and `start_round` advances. It does not auto-score a held buzz — the manager should use the verdict buttons first.
 - Negative team scores are allowed.
 - The manager cannot retroactively change a previous round's score in MVP. (Future: an "edit last round" undo flow.)
 
@@ -142,7 +143,7 @@ A separate manager action, independent of round and buzz state.
 
 - Only one team can hold the lock at a time. The atomic guarantee is in the `buzz_in` PL/pgSQL function (see `rpc-functions.md`).
 - The buzz button is enabled only while `active_games.status = 'playing'` AND `buzzed_team_id IS NULL`.
-- After lock, the button is disabled for ALL teams until the manager presses "Continue round" or "Next round" (which clears the lock via `award_attempt` / `end_round`).
+- After lock, the button is disabled for ALL teams until the manager presses "Wrong" (`award_attempt` with `wrong_buzz`), "Continue round" (`release_buzz_lock`), or "Next round" (`end_round` / `start_round`) — any of which clears `buzzed_team_id`. A Correct Song / Correct Artist verdict keeps the lock on the buzzing team (so they get the other token) and only refreshes `locked_at`.
 - A team that buzzed wrong (or correct) on the current song is **not** locked out for the remainder of the round; the buzzer re-arms for everyone, including them. The only constraint is that an already-claimed token cannot be re-claimed by anyone.
 - The `locked_at` timestamp is server-authoritative. Clients display "X locked it" with no client-side ordering logic.
 - Rejected buzz attempts (lock already held) get a quiet UI signal; no error toast, just disabled state.
@@ -172,8 +173,8 @@ The current Sound Clash has a 15-second grace window for team disconnect. The ne
 
 ### Answer-evaluation window
 
-- After buzz lock, the manager has unbounded time to listen and evaluate. No server timeout.
-- (Future: optional 10-second answer countdown for tournament mode; out of MVP.)
+- After buzz lock, the team + display pages show a **10-second answer countdown** derived purely from `active_games.locked_at` (`ANSWER_DURATION_SEC` in the frontend). It is informational/cosmetic — the **server never auto-timeouts**; the manager has unbounded time to listen and evaluate, and nothing happens when the countdown hits zero.
+- The countdown **restarts** when the manager marks a Correct Song / Correct Artist: `award_attempt` keeps the same team on the floor for the other token but sets `locked_at = now()` (migration 019), so the floor-holding team gets a fresh 10 seconds for the remaining half. A Wrong clears the lock (countdown disappears until the next buzz); Continue Round clears the lock too.
 
 ## 10. Game Expiration & TTL
 

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -2,7 +2,7 @@
 
 The eight PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
 
-Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), and `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path).
+Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), and `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token).
 
 ## 0. Conventions
 
@@ -216,7 +216,7 @@ Behavior:
 - `p_wrong_buzz > 0 AND (p_title > 0 OR p_artist > 0)` → raises `P0001 wrong_buzz_with_correct`.
 - `p_title > 0` while `title_claimed_by` is already set → raises `P0001 title_already_claimed`. Same shape for `artist_already_claimed`.
 - On success: applies score delta to the buzzed team, marks `title_claimed_by` / `artist_claimed_by` if applicable, and inserts a `game_round_attempts` row.
-- **Buzz-lock handling** (migration 018): only the wrong-buzz path clears `active_games.buzzed_team_id` and `locked_at`. A correct `title` or `artist` attempt leaves the lock in place — the answering team retains the floor for the other token until the manager presses Continue (`release_buzz_lock`) or Wrong, or until `start_round` defensively clears the lock for the next song. Before 018 the lock was always cleared regardless of outcome.
+- **Buzz-lock handling** (migration 018, refined by migration 019): only the wrong-buzz path clears `active_games.buzzed_team_id` and `locked_at`. A correct `title` / `artist` / `title_artist` attempt leaves `buzzed_team_id` in place — the answering team retains the floor for the other token until the manager presses Continue (`release_buzz_lock`) or Wrong, or until `start_round` defensively clears the lock for the next song — but it **refreshes `locked_at = now()`** so the clients' answer countdown restarts for the remaining token (migration 019). The no-op continue case (no toggles, no `wrong_buzz`) leaves the lock untouched. Before 018 the lock was always cleared regardless of outcome.
 - **Free-guess flag** (`game_rounds.free_guess_active`, migration 017): if `p_wrong_buzz > 0` AND `free_guess_active = true`, the penalty is waived (`points_delta = 0`); the attempt is still recorded with `outcome = 'wrong'`. After processing, the function sets `free_guess_active = true` if the outcome was correct (`title` / `artist` / `title_artist`) and `false` otherwise. So the flag is consumed by every attempt and re-armed by every correct one.
 
 ### Error semantics

--- a/frontend/src/components/BuzzButton.module.css
+++ b/frontend/src/components/BuzzButton.module.css
@@ -5,8 +5,8 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  width: min(80vw, 360px);
-  height: min(80vw, 360px);
+  width: min(86vw, 400px);
+  height: min(86vw, 400px);
   border-radius: 50%;
   border: none;
   background: linear-gradient(135deg, #10b981 0%, #059669 100%);
@@ -145,21 +145,21 @@
 
 @media (max-width: 768px) {
   .button {
-    width: min(85vw, 320px);
-    height: min(85vw, 320px);
+    width: min(94vw, 420px);
+    height: min(94vw, 420px);
   }
 }
 
 @media (max-width: 480px) {
   .button {
-    width: min(90vw, 280px);
-    height: min(90vw, 280px);
+    width: min(94vw, 380px);
+    height: min(94vw, 380px);
   }
 }
 
 @media (min-width: 1200px) {
   .button {
-    width: 420px;
-    height: 420px;
+    width: 460px;
+    height: 460px;
   }
 }

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -331,7 +331,7 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(screen.getByText(/rpc exploded/i)).toBeInTheDocument());
   });
 
-  it("Wrong button auto-fires awardAttempt with wrong_buzz=true (no Continue press)", async () => {
+  it("Wrong button auto-fires awardAttempt with wrong_buzz=true and resumes the player", async () => {
     setHydrate({
       game: makeActiveGame({
         status: "playing",
@@ -362,6 +362,28 @@ describe("ManagerConsolePage", () => {
         wrong_buzz: true,
       }),
     );
+    // Wrong re-arms the buzzers AND resumes the song -- no separate Continue press.
+    await waitFor(() => expect(lastHandle?.play).toHaveBeenCalled());
+  });
+
+  it("Wrong does not resume the player when awardAttempt fails", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    vi.mocked(awardAttempt).mockRejectedValueOnce(new Error("rpc down"));
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    fireEvent.click(screen.getByTestId("score-wrong"));
+    await waitFor(() => expect(screen.getByText(/rpc down/i)).toBeInTheDocument());
+    expect(lastHandle?.play).not.toHaveBeenCalled();
   });
 
   it("Next round with a held buzz ends the round and selects a new song (no auto-score)", async () => {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -167,9 +167,10 @@ export function ManagerConsolePage() {
     }
   }
 
-  // Wrong is a one-click verdict: it fires award_attempt with wrong_buzz=true
-  // and re-arms the buzzers. Per game-rules.md §4, if a correct answer was
-  // already scored this round, the SQL function waives the -3 penalty.
+  // Wrong is a one-click verdict: it fires award_attempt with wrong_buzz=true,
+  // re-arms the buzzers, and resumes the song immediately (no separate
+  // "Continue round" press needed). Per game-rules.md §4, if a correct answer
+  // was already scored this round, the SQL function waives the -3 penalty.
   async function handleWrong() {
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
@@ -180,6 +181,7 @@ export function ManagerConsolePage() {
         artist_correct: false,
         wrong_buzz: true,
       });
+      playerRef.current?.play();
     } catch (err) {
       reportError(err);
     } finally {

--- a/tests/backend/test_song_picker_genre_mixing.py
+++ b/tests/backend/test_song_picker_genre_mixing.py
@@ -2,15 +2,17 @@
 
 User requirement: when a manager selects two or more genres, the round-by-round
 sequence should mix them throughout the game; not play "all rock, then all
-pop." The picker uses ``secrets.randbelow`` over the union of candidate songs,
-so genre-blind uniform sampling is the implementation. This test guards against
-a future refactor that re-introduces per-genre batching (e.g., grouping by
-genre_id and walking groups round-robin or sequentially).
+pop." The picker (``app.services.song_picker``) draws a random *eligible* genre
+first and then a random unplayed song within it — equal genre weighting, so a
+large genre can't drown out a small one and the sequence interleaves. This test
+guards against a future refactor that re-introduces per-genre batching (e.g.,
+grouping by genre_id and walking groups round-robin or sequentially).
 
-Statistical reasoning: with 50 rock + 50 pop songs, a uniform random shuffle
-produces ~50 expected genre transitions. A perfectly batched sequence has
-exactly 1. Any reasonable threshold > a handful catches batching with
-overwhelming probability while staying robust against actual randomness.
+Statistical reasoning: with 50 rock + 50 pop songs and a 50/50 genre draw, the
+sequence behaves like a uniform random shuffle (~50 expected genre transitions).
+A perfectly batched sequence has exactly 1. Any reasonable threshold > a handful
+catches batching with overwhelming probability while staying robust against
+actual randomness.
 """
 
 from __future__ import annotations
@@ -65,25 +67,29 @@ async def test_two_genres_are_interleaved_across_picks(client, db) -> None:
     assert sequence.count("pop") == SONGS_PER_GENRE
 
     # 1) Both genres must appear in the first quarter: the game shouldn't open
-    #    with a single-genre run. Probability of all-one-genre across 25 picks
-    #    from 50/50 pool is C(50,25)/C(100,25) ≈ 5e-15, effectively zero.
+    #    with a single-genre run. With a 50/50 genre draw the first 25 picks
+    #    are 25 fair coin flips, so P(monogenre) = 2 * 2^-25 ≈ 6e-8.
     first_quarter = set(sequence[: TOTAL // 4])
     assert first_quarter == {"rock", "pop"}, (
         f"first 25 picks were single-genre: {sequence[: TOTAL // 4]}"
     )
 
-    # 2) Both genres must appear in the LAST quarter: guards against the
-    #    inverse failure (last block monogenre).
-    last_quarter = set(sequence[-(TOTAL // 4) :])
-    assert last_quarter == {"rock", "pop"}, (
-        f"last 25 picks were single-genre: {sequence[-(TOTAL // 4) :]}"
+    # 2) Both genres must appear in the LAST HALF: guards against the inverse
+    #    failure (a long tail block). A genuine monogenre tail only happens
+    #    once one bucket is exhausted; with 50 songs each that can't happen
+    #    before pick 51 unless the first 50 picks were all one genre
+    #    (P ≈ 2^-49). We use the half rather than the quarter because, unlike a
+    #    uniform shuffle of the whole catalog, an equal-genre draw legitimately
+    #    leaves a short monogenre tail (~10-20 picks) when one genre runs out.
+    last_half = set(sequence[TOTAL // 2 :])
+    assert last_half == {"rock", "pop"}, (
+        f"last {TOTAL - TOTAL // 2} picks were single-genre: {sequence[TOTAL // 2 :]}"
     )
 
     # 3) Genre transitions must exceed a low bound. A monotone batched sequence
-    #    has exactly 1 transition; the expected value for a uniform random
-    #    shuffle of 50/50 is ~50. The bound here is loose enough that random
-    #    sampling never trips it but any per-genre batching does.
-    # zip without strict: the two iterables differ in length by 1 by design.
+    #    has exactly 1 transition; an equal-genre draw averages ~50 (one per
+    #    fair coin flip). The bound here is loose enough that random sampling
+    #    never trips it but any per-genre batching does.
     transitions = sum(1 for a, b in zip(sequence[:-1], sequence[1:], strict=True) if a != b)
     assert transitions >= 15, (
         f"only {transitions} genre transitions across {TOTAL} picks; "

--- a/tests/db/test_award_attempt.py
+++ b/tests/db/test_award_attempt.py
@@ -409,6 +409,76 @@ async def test_award_attempt_wrong_clears_lock(db: asyncpg.Connection) -> None:
     assert locked is None
 
 
+# ----- migration 019: refresh locked_at on a correct attempt -----------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "title_pts, artist_pts",
+    [(10, 0), (0, 5), (10, 5)],
+    ids=["title", "artist", "both"],
+)
+async def test_award_attempt_correct_refreshes_locked_at(
+    db: asyncpg.Connection, title_pts: int, artist_pts: int
+) -> None:
+    """A correct attempt keeps the buzzing team on the floor but bumps
+    locked_at so the clients' answer countdown restarts for the other token."""
+    game_code = await create_test_game(db, status="playing")
+    team_id = await create_test_team(db, game_code)
+    round_id = await _start_round_and_buzz(db, game_code, team_id)
+
+    # Make locked_at stale so the refresh is observable.
+    await db.execute(
+        "UPDATE active_games SET locked_at = now() - interval '30 seconds' "
+        "WHERE game_code = $1",
+        game_code,
+    )
+
+    await db.execute(
+        "SELECT award_attempt($1, $2, $3, $4, 0)",
+        game_code,
+        round_id,
+        title_pts,
+        artist_pts,
+    )
+
+    row = await db.fetchrow(
+        "SELECT buzzed_team_id, locked_at, "
+        "locked_at >= now() - interval '5 seconds' AS fresh "
+        "FROM active_games WHERE game_code = $1",
+        game_code,
+    )
+    assert row["buzzed_team_id"] == team_id  # same team keeps the floor
+    assert row["locked_at"] is not None
+    assert row["fresh"] is True              # locked_at was refreshed to ~now()
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_noop_continue_leaves_lock_untouched(
+    db: asyncpg.Connection,
+) -> None:
+    """A no-toggle, no-wrong call neither clears nor refreshes the lock."""
+    game_code = await create_test_game(db, status="playing")
+    team_id = await create_test_team(db, game_code)
+    round_id = await _start_round_and_buzz(db, game_code, team_id)
+
+    await db.execute(
+        "UPDATE active_games SET locked_at = now() - interval '30 seconds' "
+        "WHERE game_code = $1",
+        game_code,
+    )
+    await db.execute("SELECT award_attempt($1, $2, 0, 0, 0)", game_code, round_id)
+
+    row = await db.fetchrow(
+        "SELECT buzzed_team_id, "
+        "locked_at < now() - interval '20 seconds' AS still_stale "
+        "FROM active_games WHERE game_code = $1",
+        game_code,
+    )
+    assert row["buzzed_team_id"] == team_id
+    assert row["still_stale"] is True
+
+
 @pytest.mark.asyncio
 async def test_release_buzz_lock_clears_held_buzz(db: asyncpg.Connection) -> None:
     """release_buzz_lock is the explicit unlock path used by POST /continue."""


### PR DESCRIPTION
## Summary

Five gameplay/UX follow-ups from live playtesting:

1. **Answer timer resets on a correct verdict.** Migration `019_refresh_locked_at_on_correct.sql`: `award_attempt` now sets `locked_at = now()` on the title / artist / title_artist branches (the wrong branch still clears it; the no-op branch still leaves it). The buzzing team keeps the floor for the other token as before, but its 10-second answer countdown (team + display pages, derived from `locked_at`) restarts.
2. **Wrong resumes the song.** `handleWrong()` in `ManagerConsolePage.tsx` now calls `playerRef.current?.play()` after the attempt succeeds — same as `handleContinueRound()`. No separate "Continue round" press needed to un-pause.
3. **Verdict buttons stay live after marking a correct answer.** The frontend was already migration-018-aware; the symptom on prod is that migration 018's `award_attempt` (lock kept on a correct verdict) wasn't applied. Migration 019 re-asserts those semantics via `CREATE OR REPLACE`. **Requires applying migrations to hosted Supabase — see checklist below.**
4. **Bigger BUZZ button on the team screen.** `BuzzButton.module.css`: phones now use `min(94vw, 420px)` (was `min(85vw, 320px)` / `min(90vw, 280px)`); base bumped to `min(86vw, 400px)`, desktop to 460px.
5. **Songs mix evenly across selected genres.** `song_picker.py` now picks a random *eligible* genre first, then a random unplayed song within it — equal genre weighting, so a game with several genres no longer front-loads whichever genre is largest in the catalog. (Per-game even mixing; no cross-game memory — games stay ephemeral.) The pre-existing `test_song_picker_genre_mixing.py` already encoded the interleaving requirement; its "last quarter" assertion is relaxed to "last half" because an equal-genre draw legitimately leaves a short monogenre tail when one genre runs out.

Docs (`rpc-functions.md`, `game-rules.md`) updated for the `award_attempt` change and to bring the §3/§4/§9 prose in line with the 018+019 flow (the per-button-fires-`award_attempt` / `Continue Round = release_buzz_lock` model and the 10-second answer countdown were already shipped but undocumented).

## Test plan

- `frontend`: `npm run lint`, `npm run typecheck`, `npm run test:run` (204 pass), `npm run test:coverage` (95.16% lines) — green. New `ManagerConsolePage` tests assert Wrong resumes / doesn't-resume-on-failure.
- `backend`: `ruff check`, `ruff format --check`, `mypy app` — green.
- `pytest -c pyproject.toml --rootdir=. ../tests/db/test_award_attempt.py ../tests/db/test_migrations_idempotent.py ../tests/backend/test_song_picker_genre_mixing.py ../tests/backend/test_games_select_song.py ../tests/backend/test_games_attempt.py` → **64 passed** (incl. the new `award_attempt` `locked_at`-refresh tests and migration 019 re-applied twice). Full-suite local run hit a transient `ConnectionRefusedError` from the per-module testcontainer partway through (Docker flake, not a code failure); CI runs the full suite cleanly.
- Manual (3 tabs): team buzzes → 10s countdown; manager clicks Correct Song → countdown jumps back to 10s, team still "YOU BUZZED", other teams still locked, Correct Artist/Wrong/Continue still enabled, Correct Song disabled; manager clicks Wrong → buzzers re-arm AND song resumes with no extra click; create a game with 4 genres → ~12 Next-round picks visibly span all four genres; BUZZ button noticeably larger on a phone viewport.

## Deploy checklist (before/at merge)

- [ ] Apply `db/migrations/016_multi_buzz_rounds.sql`, `017_free_guess_flag.sql`, `018_split_attempt_release.sql` (whichever are missing) **and** `019_refresh_locked_at_on_correct.sql` to **both** Supabase projects — prod `jvfddxuaqcsrguibkymp`, preview `vriljyhpxfcwpqwshajv`. All idempotent. (See `.claude/rules/lessons-learned.md`.)
