### PR TITLE
Lock backend-only RPCs down from the anon key (migration 020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ This project does not currently cut versioned releases; every change lands direc
 - 2026-05-09: Removed the per-team "Kick" button from the manager console. To get rid of a team, the host can end the game and start a fresh one.
 - 2026-05-07: Removed the "Rounds" picker from the Create-Game form. Games now run for as many rounds as the host wants and end only when the host clicks "End game"; round counters across the team page, display, and manager console show "Round N" without a denominator.
 
+### Security
+
+- 2026-05-12: Hardened the database so the host-only round actions (scoring a buzz, awarding a bonus, starting/ending a round, ending the game) can only be performed through the backend's manager-token gate — they can no longer be invoked directly with the public anon key. (`buzz_in`, the team buzzer, is unchanged.)
+
 ## 2026-05-07: Phase 7 cutover
 
 `https://soundclash.org` cut over from the legacy AWS stack to the new free-tier Supabase + Render + Cloudflare Pages stack. AWS resources torn down; bill drops to $0/month. See `docs/roadmap.md` §7.

--- a/db/migrations/020_lock_down_backend_rpcs.sql
+++ b/db/migrations/020_lock_down_backend_rpcs.sql
@@ -1,0 +1,58 @@
+-- 020_lock_down_backend_rpcs.sql
+-- Defense in depth: keep the backend-only RPCs off the public anon key.
+--
+-- start_round / end_round / award_attempt / award_bonus / release_buzz_lock /
+-- end_game are called only by FastAPI (with the service-role key, behind the
+-- per-game manager_token gate); cleanup_expired_games is called only by
+-- pg_cron. buzz_in is the one RPC the browser may call directly, and keeps its
+-- anon GRANT (see migration 006).
+--
+-- Earlier migrations did `REVOKE ALL ... FROM PUBLIC` on these functions, which
+-- is enough on a vanilla Postgres. It is NOT enough on hosted Supabase: the
+-- Supabase project bootstrap grants EXECUTE on every function in `public`
+-- *directly* to anon / authenticated / service_role, and a REVOKE FROM PUBLIC
+-- doesn't touch those direct grants. So a browser holding the public anon key
+-- could call award_attempt / award_bonus / start_round / end_game / ... via
+-- PostgREST RPC, bypassing FastAPI's X-Manager-Token check. Here we revoke
+-- EXECUTE explicitly from anon and authenticated, and (re-)assert it for
+-- service_role so FastAPI keeps working.
+--
+-- `authenticated` is created defensively the same way migration 006 creates
+-- `anon` / `service_role` -- a no-op on hosted Supabase (it exists natively),
+-- and lets this migration apply on the bare Postgres used by the DB tests.
+--
+-- Idempotent: defensive CREATE ROLE; REVOKE / GRANT are naturally idempotent;
+-- the loop simply skips any function that doesn't exist (e.g. award_points,
+-- retired by migration 016).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  fn regprocedure;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname IN (
+         'start_round',
+         'end_round',
+         'award_attempt',
+         'award_bonus',
+         'release_buzz_lock',
+         'end_game',
+         'cleanup_expired_games',
+         'award_points'  -- retired by 016; revoked here too if still present
+       )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM anon, authenticated', fn);
+    EXECUTE format('GRANT  EXECUTE ON FUNCTION %s TO service_role', fn);
+  END LOOP;
+END $$;

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -13,7 +13,7 @@ Every interaction with Postgres happens as one of two principals:
 | **anon** | Supabase anon key (public) | Whatever RLS allows | Browser |
 | **service_role** | Supabase service-role key (secret) | Bypass RLS; everything | FastAPI on Render |
 
-There are no other roles in MVP. No `authenticated`, no per-user scoping, no JWTs from Supabase Auth. This is by design (matches today's behavior: anonymous teams + per-game manager tokens for hosts + a single admin password for the durable song catalog).
+There are no other application principals in MVP. No per-user scoping, no JWTs from Supabase Auth. This is by design (matches today's behavior: anonymous teams + per-game manager tokens for hosts + a single admin password for the durable song catalog). The `authenticated` role exists on hosted Supabase but nothing connects as it; migration 020 still revokes EXECUTE from it on the backend-only RPCs purely defensively.
 
 The anon key ships in the frontend bundle; it's not a secret. RLS policies prevent it from being abused.
 
@@ -47,10 +47,14 @@ Two distinct shared secrets gate FastAPI endpoints. Both checked with `secrets.c
 |---|---|---|
 | `buzz_in`               | ✅ | ✅ |
 | `start_round`           | ❌ | ✅ |
-| `award_points`          | ❌ | ✅ |
+| `award_attempt`         | ❌ | ✅ |
+| `end_round`             | ❌ | ✅ |
 | `award_bonus`           | ❌ | ✅ |
+| `release_buzz_lock`     | ❌ | ✅ |
 | `end_game`              | ❌ | ✅ |
-| `cleanup_expired_games` | ❌ | ✅ |
+| `cleanup_expired_games` | ❌ | ✅ (called by `pg_cron`, not FastAPI) |
+
+Only `buzz_in` is reachable from the browser. The `❌` rows are enforced by an explicit `REVOKE EXECUTE ... FROM anon, authenticated` (migration `020_lock_down_backend_rpcs.sql`) **in addition to** the `REVOKE ALL ... FROM PUBLIC` the creating migrations already do: on hosted Supabase the project bootstrap grants EXECUTE on every `public` function directly to `anon`/`authenticated`/`service_role`, so a `REVOKE FROM PUBLIC` alone leaves anon able to call them. Migration 020 also re-asserts `GRANT EXECUTE ... TO service_role` so FastAPI keeps working.
 
 ### Why anon can SELECT any game
 
@@ -79,10 +83,18 @@ No `INSERT`, `UPDATE`, or `DELETE` policies are created for `anon` → all write
 ### Function grants
 
 ```sql
+-- buzz_in: the only browser-callable RPC.
 REVOKE ALL ON FUNCTION buzz_in(char, uuid) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION buzz_in(char, uuid) TO anon;
 
--- All other functions: no GRANT to anon. Only service_role can call.
+-- Backend-only RPCs: the creating migrations REVOKE FROM PUBLIC; migration 020
+-- additionally revokes the direct anon/authenticated grants that hosted
+-- Supabase adds, and re-asserts the grant for service_role.
+--   start_round, end_round, award_attempt, award_bonus, release_buzz_lock,
+--   end_game, cleanup_expired_games  (+ award_points if still present)
+-- e.g.:
+REVOKE EXECUTE ON FUNCTION award_attempt(text, uuid, integer, integer, integer) FROM anon, authenticated;
+GRANT  EXECUTE ON FUNCTION award_attempt(text, uuid, integer, integer, integer) TO service_role;
 ```
 
 ## 3. Realtime Subscriptions

--- a/tests/db/test_rls_function_grants.py
+++ b/tests/db/test_rls_function_grants.py
@@ -95,3 +95,59 @@ async def test_anon_cannot_execute_cleanup_expired_games(
 ) -> None:
     with pytest.raises(asyncpg.InsufficientPrivilegeError):
         await anon_conn.execute("SELECT cleanup_expired_games()")
+
+
+# ----- migration 020: explicit grant state on the backend-only RPCs ----------
+#
+# On hosted Supabase a `REVOKE ... FROM PUBLIC` is not enough, because the
+# project bootstrap grants EXECUTE on every public function directly to
+# anon / authenticated / service_role. Migration 020 revokes from anon and
+# authenticated explicitly and re-asserts the grant for service_role. These
+# tests pin the resulting grant matrix (they run on the bare Postgres used by
+# the DB suite, where 020's REVOKE-from-anon is a no-op but the GRANT-to-
+# service_role is not).
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "proname",
+    [
+        "start_round",
+        "end_round",
+        "award_attempt",
+        "award_bonus",
+        "release_buzz_lock",
+        "end_game",
+        "cleanup_expired_games",
+    ],
+)
+async def test_backend_rpc_grant_matrix(db: asyncpg.Connection, proname: str) -> None:
+    rows = await db.fetch(
+        """
+        SELECT has_function_privilege('anon', p.oid, 'execute')          AS anon_exec,
+               has_function_privilege('authenticated', p.oid, 'execute') AS auth_exec,
+               has_function_privilege('service_role', p.oid, 'execute')  AS svc_exec
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname = $1
+        """,
+        proname,
+    )
+    assert rows, f"function {proname} not found"
+    for r in rows:
+        assert r["anon_exec"] is False, f"{proname}: anon must not have EXECUTE"
+        assert r["auth_exec"] is False, f"{proname}: authenticated must not have EXECUTE"
+        assert r["svc_exec"] is True, f"{proname}: service_role must keep EXECUTE"
+
+
+@pytest.mark.asyncio
+async def test_buzz_in_remains_anon_executable(db: asyncpg.Connection) -> None:
+    """The one RPC the browser calls directly stays anon-executable."""
+    can = await db.fetchval(
+        """
+        SELECT bool_and(has_function_privilege('anon', p.oid, 'execute'))
+          FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname = 'buzz_in'
+        """
+    )
+    assert can is True


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #72 (noticed while validating migration 019 on hosted Supabase).

**The gap:** the backend-only RPCs — `start_round`, `end_round`, `award_attempt`, `award_bonus`, `release_buzz_lock`, `end_game` (called by FastAPI behind the per-game `X-Manager-Token` gate) and `cleanup_expired_games` (called by `pg_cron`) — were directly callable by a browser using the public anon key, bypassing FastAPI's token check. A player in a game (who can read `current_round_id` via RLS) could, while their team holds the buzz, call `award_attempt` to hand themselves +15, repeatedly `award_bonus`, skip songs, or end the game.

**Why `REVOKE ALL ... FROM PUBLIC` (already in migrations 005/014/016/018) wasn't enough:** on hosted Supabase the project bootstrap grants `EXECUTE` on every `public` function *directly* to `anon` / `authenticated` / `service_role`, and a `REVOKE FROM PUBLIC` doesn't touch those direct grants. Verified on both projects — every RPC showed `has_function_privilege('anon', …, 'execute') = true` before this change. (The DB test suite runs on bare Postgres where `REVOKE FROM PUBLIC` *is* sufficient, so `test_rls_function_grants.py` passed and never caught this.)

**The fix** — `db/migrations/020_lock_down_backend_rpcs.sql`: `REVOKE EXECUTE … FROM anon, authenticated` on the seven backend-only RPCs (and `award_points` if still present), plus `GRANT EXECUTE … TO service_role` so FastAPI keeps working. `authenticated` is created defensively the same way migration 006 creates `anon`/`service_role` (no-op on Supabase; needed so the migration applies on the bare Postgres the DB tests use). Idempotent; loop skips any missing function. `buzz_in` keeps its anon GRANT — it's the browser hot path.

Also updated `docs/security-rls.md` §2 (the RPC grant table was stale anyway — listed retired `award_points`, missing `award_attempt`/`end_round`/`release_buzz_lock`) and added a `### Security` CHANGELOG entry.

## Already applied to hosted Supabase

Applied + validated on **both** projects (prod `jvfddxuaqcsrguibkymp`, preview `vriljyhpxfcwpqwshajv`) via `supabase db query --linked -f db/migrations/020_lock_down_backend_rpcs.sql` (run twice each — idempotent). Post-state on both:

| | `anon` EXECUTE | `authenticated` EXECUTE | `service_role` EXECUTE |
|---|---|---|---|
| `buzz_in` | ✅ (unchanged) | ✅ | ✅ |
| the 7 backend RPCs | ❌ | ❌ | ✅ |

Functional probes on preview: `SET ROLE service_role; SELECT award_attempt('NOPE12', …)` → `P0002 round_not_found` (function ran — FastAPI access intact); `SET ROLE anon; SELECT award_attempt(…)` → `42501 permission denied for function award_attempt`; `SET ROLE anon; SELECT … FROM buzz_in('NOPE12', …)` → ran (no permission error).

## Test plan

- `pytest -c pyproject.toml --rootdir=. ../tests/db/test_rls_function_grants.py ../tests/db/test_migrations_idempotent.py ../tests/db/test_rls_anon.py` → **37 passed** (incl. migration 020 applied twice for idempotency, and a new parametrized `test_backend_rpc_grant_matrix` pinning `anon`/`authenticated` = no EXECUTE, `service_role` = EXECUTE on the seven RPCs, plus `test_buzz_in_remains_anon_executable`).
- `ruff check` / `ruff format --check` on the touched test file — clean. (Migration is SQL; mypy untouched.)

## Notes

- Independent of #72; can merge in either order. Numeric gap (018 → 020) on this branch closes once #72's migration 019 lands on `main`.
- No code changes — purely a grant change + tests + docs.
