### PR TITLE
Bump frontend build tooling: vite 8, @vitejs/plugin-react 6, eslint 10, react-hooks 7

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -57,6 +57,13 @@ export default [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
+      // react-hooks v7 ships a new `set-state-in-effect` rule in its
+      // recommended preset. It flags a handful of intentional
+      // setState-inside-useEffect spots (hydration flags, audio cues,
+      // server-clock ticks) that aren't bugs. Off for now; revisit as a
+      // dedicated cleanup if we want to chase the React "you might not need
+      // an effect" guidance.
+      "react-hooks/set-state-in-effect": "off",
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,22 +28,23 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.3",
-    "@typescript-eslint/eslint-plugin": "^8.15.0",
-    "@typescript-eslint/parser": "^8.15.0",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@typescript-eslint/eslint-plugin": "^8.59.3",
+    "@typescript-eslint/parser": "^8.59.3",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
-    "eslint": "^9.15.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint": "^10.3.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.1.1",
     "prettier": "^3.3.3",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11",
+    "vite": "^8.0.12",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary

Coordinated replacement for the four individual Dependabot frontend-tooling PRs (#66 `@vitejs/plugin-react` 4→6, #67 `eslint` 9→10, #68 `eslint-plugin-react-hooks` 5→7, #69 `vite` 5→8). Each of those fails CI on its own because the bumps are interdependent — e.g. `npm install` ERESOLVEs vite 8 against `@vitejs/plugin-react@4` (peer `vite: ^4 || ^5 || ^6 || ^7`), and eslint 10 needs a typescript-eslint that supports it. Doing them together resolves cleanly.

Changes (`frontend/package.json`):
- `vite` `^5.4.11` → `^8.0.12`
- `@vitejs/plugin-react` `^4.3.3` → `^6.0.1`
- `eslint` `^9.15.0` → `^10.3.0`
- `eslint-plugin-react-hooks` `^5.0.0` → `^7.1.1`
- `@typescript-eslint/eslint-plugin` & `/parser` `^8.15.0` → `^8.59.3` (latest v8 — declares eslint 10 in peers)
- **new dep:** `@eslint/js` `^10.0.1` — was a transitive dep of `eslint` 9; eslint 10 no longer re-exports it, so `eslint.config.js`'s `import js from "@eslint/js"` needs it listed explicitly. (It's eslint's own first-party package, not added bloat.)

`frontend/eslint.config.js`: disabled the one new error-level rule that `eslint-plugin-react-hooks` v7's recommended preset adds — `react-hooks/set-state-in-effect`. It flags 8 pre-existing, intentional `setState`-inside-`useEffect` spots (hydration flags, audio cues, server-clock ticks) that aren't bugs. Left a comment; chasing the React "you might not need an effect" guidance can be a separate cleanup. No other new lint errors.

`react-router-dom` is **not** touched here (that's #70 — a runtime dep, separate concern).

## Test plan

Local, on this branch (frontend lockfile is gitignored, so `npm install` from scratch — same as CI):
- `npm install` → resolves clean, 0 vulnerabilities, no ERESOLVE.
- `npm run typecheck` (`tsc --noEmit`) → clean
- `npm run lint` (`eslint .`) → clean, exit 0
- `npm run build` (`tsc -b && vite build`) → builds (vite 8.0.12 + plugin-react 6.0.1)
- `npm run test:coverage` (`vitest run --coverage`) → 23 files / 204 tests pass; 95.16% lines, 91.15% statements (above thresholds)

Playwright e2e not run locally (needs the full local stack; CI runs it on `main` after merge).

## Note

If you merge this, close #66 / #67 / #68 / #69 — superseded.
