### PR TITLE
Pre-mount YT iframe so postMessage warm-up warning stops firing

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -39,6 +39,7 @@ export default [
         HTMLElement: "readonly",
         HTMLButtonElement: "readonly",
         HTMLDivElement: "readonly",
+        HTMLIFrameElement: "readonly",
         HTMLInputElement: "readonly",
         KeyboardEvent: "readonly",
         Event: "readonly",

--- a/frontend/src/components/YouTubePlayer.test.tsx
+++ b/frontend/src/components/YouTubePlayer.test.tsx
@@ -57,6 +57,23 @@ beforeEach(() => {
     .forEach((el) => el.remove());
 });
 
+// In jsdom the iframe never actually navigates, so the `load` event the
+// production mount effect awaits before constructing the YT.Player has to
+// be dispatched manually. In real browsers the iframe genuinely loads once
+// at youtube-nocookie.com and emits `load` itself.
+async function flushIframeLoad(container: HTMLElement): Promise<void> {
+  // Yield to the microtask queue so the effect's `await loadApi()` resolves
+  // and the `addEventListener('load', ...)` call has run before we dispatch.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  const iframe = container.querySelector("iframe");
+  if (!iframe) return;
+  await act(async () => {
+    iframe.dispatchEvent(new Event("load"));
+  });
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -64,14 +81,16 @@ afterEach(() => {
 describe("YouTubePlayer", () => {
   it("constructs a player when YT API is already available", async () => {
     installFakeYT();
-    render(<YouTubePlayer />);
+    const { container } = render(<YouTubePlayer />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastPlayer).not.toBeNull());
   });
 
   it("forwards loadVideoById, play, pause, stop on the imperative handle", async () => {
     installFakeYT();
     const ref = createRef<YouTubePlayerHandle>();
-    render(<YouTubePlayer ref={ref} />);
+    const { container } = render(<YouTubePlayer ref={ref} />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastPlayer).not.toBeNull());
     ref.current?.loadVideoById("abcdefghijk", 12);
     ref.current?.play();
@@ -89,7 +108,8 @@ describe("YouTubePlayer", () => {
   it("calls onReady when the YT player fires onReady", async () => {
     installFakeYT();
     const onReady = vi.fn();
-    render(<YouTubePlayer onReady={onReady} />);
+    const { container } = render(<YouTubePlayer onReady={onReady} />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     act(() => {
       lastConfig?.events?.onReady?.();
@@ -100,7 +120,8 @@ describe("YouTubePlayer", () => {
   it("renders an error message and invokes onError when YT fires onError", async () => {
     installFakeYT();
     const onError = vi.fn();
-    const { findByRole } = render(<YouTubePlayer onError={onError} />);
+    const { findByRole, container } = render(<YouTubePlayer onError={onError} />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     act(() => {
       lastConfig?.events?.onError?.({ data: 150 });
@@ -112,7 +133,8 @@ describe("YouTubePlayer", () => {
 
   it("keeps the overlay visible on error even when hideOverlay is true", async () => {
     installFakeYT();
-    const { findByRole } = render(<YouTubePlayer hideOverlay />);
+    const { findByRole, container } = render(<YouTubePlayer hideOverlay />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     act(() => {
       lastConfig?.events?.onReady?.();
@@ -128,6 +150,7 @@ describe("YouTubePlayer", () => {
     installFakeYT();
     const ref = createRef<YouTubePlayerHandle>();
     const { container } = render(<YouTubePlayer ref={ref} hideOverlay />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     // After ready the cover is hidden so the video is visible.
     act(() => {
@@ -151,6 +174,7 @@ describe("YouTubePlayer", () => {
     installFakeYT();
     const ref = createRef<YouTubePlayerHandle>();
     const { container } = render(<YouTubePlayer ref={ref} hideOverlay />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     act(() => {
       lastConfig?.events?.onReady?.();
@@ -169,6 +193,7 @@ describe("YouTubePlayer", () => {
   it("non-ENDED state changes do not bring the cover back", async () => {
     installFakeYT();
     const { container } = render(<YouTubePlayer hideOverlay />);
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastConfig).not.toBeNull());
     act(() => {
       lastConfig?.events?.onReady?.();
@@ -184,7 +209,7 @@ describe("YouTubePlayer", () => {
   });
 
   it("loads the iframe API script when YT is not yet on window", async () => {
-    render(<YouTubePlayer />);
+    const { container } = render(<YouTubePlayer />);
     await waitFor(() =>
       expect(
         document.querySelector('script[src="https://www.youtube.com/iframe_api"]'),
@@ -197,6 +222,7 @@ describe("YouTubePlayer", () => {
         .onYouTubeIframeAPIReady;
       cb?.();
     });
+    await flushIframeLoad(container);
     await waitFor(() => expect(lastPlayer).not.toBeNull());
   });
 });

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -82,11 +82,27 @@ function loadApi(): Promise<YTNamespace> {
   });
 }
 
+// Force English UI strings (hl=en) on the iframe chrome so a host whose
+// browser is set to e.g. Hebrew doesn't see "הפעלת הסרטון" / "סרטונים נוספים"
+// in the player overlay. `origin` lets the iframe validate inbound messages.
+const EMBED_SRC =
+  "https://www.youtube-nocookie.com/embed/?" +
+  new URLSearchParams({
+    enablejsapi: "1",
+    origin: window.location.origin,
+    modestbranding: "1",
+    rel: "0",
+    controls: "0",
+    disablekb: "1",
+    playsinline: "1",
+    hl: "en",
+  }).toString();
+
 export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function YouTubePlayer(
   { hideOverlay, coverWhilePaused, onReady, onError },
   ref,
 ) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLIFrameElement | null>(null);
   const playerRef = useRef<YTPlayer | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [errorCode, setErrorCode] = useState<number | null>(null);
@@ -107,34 +123,34 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     onErrorRef.current = onError;
   });
 
+  // We render the iframe ourselves (rather than letting YT.Player replace a
+  // div) and wait for its `load` event before attaching the API. Otherwise
+  // www-widgetapi.js starts a postMessage poll targeted at youtube-nocookie.com
+  // while the iframe is still at about:blank, and every ping logs a
+  // "target origin does not match" warning until the iframe finishes
+  // navigating. Privacy-enhanced mode (youtube-nocookie) also suppresses the
+  // doubleclick conversion-pixel CORS errors that the regular youtube.com
+  // host emits once a video plays.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       const YT = await loadApi();
       if (cancelled || !containerRef.current) return;
-      playerRef.current = new YT.Player(containerRef.current, {
-        width: "100%",
-        height: "100%",
-        // Privacy-enhanced mode: iframe is created at youtube-nocookie.com
-        // instead of youtube.com, which suppresses the doubleclick conversion
-        // pixels that otherwise CORS-spam the console once the video plays.
-        host: "https://www.youtube-nocookie.com",
-        playerVars: {
-          modestbranding: 1,
-          rel: 0,
-          controls: 0,
-          disablekb: 1,
-          playsinline: 1,
-          // Force English UI strings on the iframe chrome so a host whose
-          // browser is set to e.g. Hebrew doesn't see "הפעלת הסרטון" /
-          // "סרטונים נוספים" in the player overlay.
-          hl: "en",
-          // Pre-declare the parent origin so the IFrame API can validate
-          // postMessage targets up-front, which mitigates the warm-up
-          // "target origin does not match" warning fired by www-widgetapi.js
-          // before the iframe finishes navigating.
-          origin: window.location.origin,
-        },
+      const iframe = containerRef.current;
+      await new Promise<void>((resolve) => {
+        if (iframe.dataset.ytLoaded === "1") {
+          resolve();
+          return;
+        }
+        const onLoad = (): void => {
+          iframe.removeEventListener("load", onLoad);
+          iframe.dataset.ytLoaded = "1";
+          resolve();
+        };
+        iframe.addEventListener("load", onLoad);
+      });
+      if (cancelled) return;
+      playerRef.current = new YT.Player(iframe, {
         events: {
           onReady: () => {
             setErrorCode(null);
@@ -188,7 +204,14 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
   const showLabel = errorCode !== null || ended || !loaded;
   return (
     <div className={styles.wrapper} data-testid="youtube-player" data-ready={loaded}>
-      <div ref={containerRef} className={styles.player} />
+      <iframe
+        ref={containerRef}
+        className={styles.player}
+        src={EMBED_SRC}
+        title="YouTube player"
+        allow="autoplay; encrypted-media"
+        allowFullScreen
+      />
       <div
         className={`${styles.cover} ${overlayHidden ? styles.coverHidden : ""}`}
         role={errorCode !== null ? "alert" : undefined}


### PR DESCRIPTION
## Summary
- The YouTube IFrame API's `www-widgetapi.js` starts a postMessage polling loop the moment `new YT.Player(div, { host: 'https://www.youtube-nocookie.com' })` is called. Until the new iframe finishes navigating to youtube-nocookie.com, its contentWindow origin is still soundclash.org, and the browser blocks every early ping with `Failed to execute 'postMessage' on 'DOMWindow': The target origin ... does not match the recipient window's origin`. The existing `origin` playerVar only governs *inbound* validation, not these outbound pings.
- `YouTubePlayer.tsx` now renders the iframe itself with the canonical `youtube-nocookie.com/embed/?enablejsapi=1&origin=...&hl=en&...` URL, waits for the iframe's `load` event, and only then constructs `new YT.Player(iframe, { events })`. The poll starts against an iframe that is already at the matching origin, so no warning fires. Privacy-enhanced mode (youtube-nocookie) is preserved, so the doubleclick conversion-pixel CORS errors that 2026-05-10 traded away stay suppressed.
- `host`, `width`, `height`, and `playerVars` are gone from the `YT.Player` config (their values now live on the iframe `src`). Public component API (`YouTubePlayerHandle`, `Props`) is unchanged.
- Unit tests updated with a `flushIframeLoad()` helper that dispatches `load` in `act()` since jsdom does not navigate iframes. ESLint globals get `HTMLIFrameElement` (the ref type changed from div).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run` (204/204)
- [ ] `tests/e2e/manager_cleanup_yt_csp.spec.ts` — covers post-`start_round` iframe title load + the 20s idle-traffic guard
- [ ] Three-tab manual smoke (manager + team + display): start round, buzz, score, next round; confirm the postMessage warning is gone and the doubleclick CORS errors stay gone