### PR TITLE
Skip no-op HYDRATE + pause resync when tab hidden

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -45,6 +45,47 @@ describe("gameReducer", () => {
     expect(next?.currentRound?.id).toBe("r1");
   });
 
+  it("HYDRATE returns the same state reference when nothing changed (skips re-render cascade)", () => {
+    const game = makeActiveGame({ current_round_id: "r1" });
+    const team = makeTeam({ id: "t1", score: 10 });
+    const round = makeRound({ id: "r1", round_number: 1 });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [team],
+      rounds: [round],
+    });
+    // Same wire data, fresh object identities (mirrors what PostgREST returns
+    // on a backstop poll when no events have happened in the last 20s).
+    const repeat = gameReducer(start, {
+      type: "HYDRATE",
+      game: { ...game },
+      teams: [{ ...team }],
+      rounds: [{ ...round }],
+    });
+    expect(repeat).toBe(start);
+  });
+
+  it("HYDRATE returns a new state reference when a team's score changed", () => {
+    const game = makeActiveGame({ current_round_id: "r1" });
+    const team = makeTeam({ id: "t1", score: 10 });
+    const round = makeRound({ id: "r1", round_number: 1 });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [team],
+      rounds: [round],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [{ ...team, score: 20 }],
+      rounds: [round],
+    });
+    expect(next).not.toBe(start);
+    expect(next?.teams.get("t1")?.score).toBe(20);
+  });
+
   it("GAME_CHANGE UPDATE replaces game and recomputes currentRound", () => {
     const round = makeRound({ id: "r1" });
     const start = gameReducer(null, {

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -87,6 +87,7 @@ describe("gameReducer", () => {
   });
 
   it.each([
+    ["game_code", { game_code: "DIFFERENT" }],
     ["status", { status: "playing" as const }],
     ["round_number", { round_number: 5 }],
     ["current_round_id", { current_round_id: "different-round" }],
@@ -94,6 +95,8 @@ describe("gameReducer", () => {
     ["locked_at", { locked_at: "2026-05-15T12:00:00Z" }],
     ["ended_at", { ended_at: "2026-05-15T13:00:00Z" }],
     ["current_song_id", { current_song_id: "different-song" }],
+    ["started_at", { started_at: "2099-01-01T00:00:00Z" }],
+    ["expires_at", { expires_at: "2099-01-01T04:00:00Z" }],
   ])("HYDRATE re-dispatches when ActiveGame.%s changes", (_field, override) => {
     const game = makeActiveGame({ current_round_id: "r1" });
     const round = makeRound({ id: "r1", round_number: 1 });
@@ -163,6 +166,27 @@ describe("gameReducer", () => {
     expect(next).not.toBe(start);
   });
 
+  it.each([
+    ["name", { name: "Renamed" }],
+    ["joined_at", { joined_at: "2099-01-01T00:00:00Z" }],
+  ])("HYDRATE re-dispatches when team.%s changes", (_field, override) => {
+    const game = makeActiveGame();
+    const team = makeTeam({ id: "t1" });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [team],
+      rounds: [],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [{ ...team, ...override }],
+      rounds: [],
+    });
+    expect(next).not.toBe(start);
+  });
+
   it("HYDRATE re-dispatches when a team id is replaced (same count, different members)", () => {
     const game = makeActiveGame();
     const start = gameReducer(null, {
@@ -204,6 +228,10 @@ describe("gameReducer", () => {
     ["buzzed_team_id", { buzzed_team_id: "team-x" }],
     ["song_id", { song_id: "song-x" }],
     ["free_guess_active", { free_guess_active: true }],
+    ["started_at", { started_at: "2099-01-01T00:00:00Z" }],
+    ["title_points", { title_points: 99 }],
+    ["artist_points", { artist_points: 99 }],
+    ["wrong_buzz_penalty", { wrong_buzz_penalty: -99 }],
   ])("HYDRATE re-dispatches when round.%s changes", (_field, override) => {
     const game = makeActiveGame({ current_round_id: "r1" });
     const round = makeRound({ id: "r1", round_number: 1 });

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -86,6 +86,145 @@ describe("gameReducer", () => {
     expect(next?.teams.get("t1")?.score).toBe(20);
   });
 
+  it.each([
+    ["status", { status: "playing" as const }],
+    ["round_number", { round_number: 5 }],
+    ["current_round_id", { current_round_id: "different-round" }],
+    ["buzzed_team_id", { buzzed_team_id: "different-team" }],
+    ["locked_at", { locked_at: "2026-05-15T12:00:00Z" }],
+    ["ended_at", { ended_at: "2026-05-15T13:00:00Z" }],
+    ["current_song_id", { current_song_id: "different-song" }],
+  ])("HYDRATE re-dispatches when ActiveGame.%s changes", (_field, override) => {
+    const game = makeActiveGame({ current_round_id: "r1" });
+    const round = makeRound({ id: "r1", round_number: 1 });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [round],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game: { ...game, ...override },
+      teams: [],
+      rounds: [round],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it("HYDRATE re-dispatches when selected_genres differ in length", () => {
+    const game = makeActiveGame({ selected_genres: ["rock"] });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game: { ...game, selected_genres: ["rock", "pop"] },
+      teams: [],
+      rounds: [],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it("HYDRATE re-dispatches when selected_genres differ in content", () => {
+    const game = makeActiveGame({ selected_genres: ["rock"] });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game: { ...game, selected_genres: ["pop"] },
+      teams: [],
+      rounds: [],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it("HYDRATE re-dispatches when the number of teams changes", () => {
+    const game = makeActiveGame();
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [makeTeam({ id: "t1" }), makeTeam({ id: "t2" })],
+      rounds: [],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it("HYDRATE re-dispatches when a team id is replaced (same count, different members)", () => {
+    const game = makeActiveGame();
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [makeTeam({ id: "t2" })],
+      rounds: [],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it("HYDRATE re-dispatches when the number of rounds changes", () => {
+    const game = makeActiveGame();
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [makeRound({ id: "r1", round_number: 1 })],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [
+        makeRound({ id: "r1", round_number: 1 }),
+        makeRound({ id: "r2", round_number: 2 }),
+      ],
+    });
+    expect(next).not.toBe(start);
+  });
+
+  it.each([
+    ["ended_at", { ended_at: "2026-05-15T12:01:00Z" }],
+    ["title_claimed_by", { title_claimed_by: "team-x" }],
+    ["artist_claimed_by", { artist_claimed_by: "team-x" }],
+    ["buzzed_team_id", { buzzed_team_id: "team-x" }],
+    ["song_id", { song_id: "song-x" }],
+    ["free_guess_active", { free_guess_active: true }],
+  ])("HYDRATE re-dispatches when round.%s changes", (_field, override) => {
+    const game = makeActiveGame({ current_round_id: "r1" });
+    const round = makeRound({ id: "r1", round_number: 1 });
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [round],
+    });
+    const next = gameReducer(start, {
+      type: "HYDRATE",
+      game,
+      teams: [],
+      rounds: [{ ...round, ...override }],
+    });
+    expect(next).not.toBe(start);
+  });
+
   it("GAME_CHANGE UPDATE replaces game and recomputes currentRound", () => {
     const round = makeRound({ id: "r1" });
     const start = gameReducer(null, {
@@ -386,5 +525,36 @@ describe("useGameChannel - subscription", () => {
     await waitFor(() => {
       expect(result.current.state?.game.status).toBe("playing");
     });
+  });
+
+  it("triggers an immediate hydrate when the tab becomes visible again", async () => {
+    const game = makeActiveGame();
+    setHydrate({ game, teams: [], rounds: [] });
+    renderHook(() => useGameChannel("ABCDEF"));
+    await act(async () => {
+      await fireSubscribed();
+    });
+    // After the initial hydrate, capture the supabase.from call count so we
+    // can tell whether visibilitychange triggered the extra hydrate.
+    const callsAfterInit = supabaseMock.from.mock.calls.length;
+
+    // Simulate tab going to the background; dispatch should be a no-op
+    // (stopResync), so the call count must not change.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(supabaseMock.from.mock.calls.length).toBe(callsAfterInit);
+
+    // Tab returns: the hook hydrates immediately and restarts the interval.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    // Each hydrate hits 3 tables. Calls should increase by 3.
+    expect(supabaseMock.from.mock.calls.length).toBe(callsAfterInit + 3);
+
+    // Reset document.hidden back to its default so it doesn't leak.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
   });
 });

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -524,6 +524,28 @@ describe("useGameChannel - subscription", () => {
     });
   });
 
+  it("re-runs hydrate every RESYNC_INTERVAL_MS as a Realtime backstop", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const game = makeActiveGame();
+      setHydrate({ game, teams: [], rounds: [] });
+      renderHook(() => useGameChannel("ABCDEF"));
+      await act(async () => {
+        await fireSubscribed();
+      });
+      const callsAfterInit = supabaseMock.from.mock.calls.length;
+      // Tick past one resync interval (20s); the inner setInterval callback
+      // should fire and run hydrate() once.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_500);
+      });
+      // Each hydrate hits the three ephemeral tables.
+      expect(supabaseMock.from.mock.calls.length).toBe(callsAfterInit + 3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("triggers an immediate hydrate when the tab becomes visible again", async () => {
     const game = makeActiveGame();
     setHydrate({ game, teams: [], rounds: [] });

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -192,10 +192,7 @@ describe("gameReducer", () => {
       type: "HYDRATE",
       game,
       teams: [],
-      rounds: [
-        makeRound({ id: "r1", round_number: 1 }),
-        makeRound({ id: "r2", round_number: 2 }),
-      ],
+      rounds: [makeRound({ id: "r1", round_number: 1 }), makeRound({ id: "r2", round_number: 2 })],
     });
     expect(next).not.toBe(start);
   });

--- a/frontend/src/hooks/useGameChannel.ts
+++ b/frontend/src/hooks/useGameChannel.ts
@@ -17,17 +17,93 @@ export type ChannelStatus = "idle" | "connecting" | "subscribed" | "reconnecting
 // silently re-joins, the free tier under load) — and a missed "a team buzzed"
 // event would strand the manager with greyed-out scoring buttons until the
 // next state change. So every 20 seconds we re-hydrate from the tables; the
-// reducer's HYDRATE fully replaces state, so this is a cheap, idempotent
-// catch-up. 20s is well inside a "huh, the page is stuck" wait while keeping
-// the per-client REST load to ~3 queries / 20s instead of /5s — a 4x reduction
-// in request count for a 10-minute game. Migrations 009/010 fixed the original
-// Realtime-event-loss bugs, so the resync is now a true safety net, not the
-// primary sync path.
+// reducer's HYDRATE skips the dispatch when nothing material changed, so a
+// quiet round costs ~3 REST queries per 20s with zero re-renders. Migrations
+// 009/010 fixed the original Realtime-event-loss bugs, so the resync is now a
+// true safety net, not the primary sync path.
 const RESYNC_INTERVAL_MS = 20_000;
+
+function activeGameEqual(a: ActiveGame, b: ActiveGame): boolean {
+  if (
+    a.game_code !== b.game_code ||
+    a.status !== b.status ||
+    a.round_number !== b.round_number ||
+    a.current_song_id !== b.current_song_id ||
+    a.current_round_id !== b.current_round_id ||
+    a.buzzed_team_id !== b.buzzed_team_id ||
+    a.locked_at !== b.locked_at ||
+    a.started_at !== b.started_at ||
+    a.ended_at !== b.ended_at ||
+    a.expires_at !== b.expires_at
+  ) {
+    return false;
+  }
+  if (a.selected_genres.length !== b.selected_genres.length) return false;
+  for (let i = 0; i < a.selected_genres.length; i++) {
+    if (a.selected_genres[i] !== b.selected_genres[i]) return false;
+  }
+  return true;
+}
+
+function teamEqual(a: Team, b: Team): boolean {
+  return (
+    a.id === b.id && a.name === b.name && a.score === b.score && a.joined_at === b.joined_at
+  );
+}
+
+function roundEqual(a: GameRound, b: GameRound): boolean {
+  return (
+    a.id === b.id &&
+    a.round_number === b.round_number &&
+    a.song_id === b.song_id &&
+    a.started_at === b.started_at &&
+    a.buzzed_team_id === b.buzzed_team_id &&
+    a.title_points === b.title_points &&
+    a.artist_points === b.artist_points &&
+    a.wrong_buzz_penalty === b.wrong_buzz_penalty &&
+    a.title_claimed_by === b.title_claimed_by &&
+    a.artist_claimed_by === b.artist_claimed_by &&
+    a.free_guess_active === b.free_guess_active &&
+    a.ended_at === b.ended_at
+  );
+}
+
+// Compare a freshly-hydrated payload against the current reducer state. If
+// every field the UI consumes matches, returning the same state reference from
+// the reducer lets React skip the whole render cascade. The periodic resync
+// hits this path for every quiet 20s interval — Scoreboard, BuzzButton, the
+// YouTubePlayer wrapper, etc. all stop re-rendering on backstop ticks.
+function hydrateUnchanged(
+  state: GameState,
+  game: ActiveGame,
+  teams: Team[],
+  rounds: GameRound[],
+): boolean {
+  if (!activeGameEqual(state.game, game)) return false;
+  if (state.teams.size !== teams.length) return false;
+  for (const t of teams) {
+    const existing = state.teams.get(t.id);
+    if (!existing || !teamEqual(existing, t)) return false;
+  }
+  if (state.rounds.length !== rounds.length) return false;
+  // state.rounds is already sorted by round_number; the fresh `rounds` array
+  // comes straight from PostgREST. Sort the fresh copy once before comparing.
+  const sorted = [...rounds].sort((a, b) => a.round_number - b.round_number);
+  for (let i = 0; i < sorted.length; i++) {
+    const existing = state.rounds[i];
+    const fresh = sorted[i];
+    if (!existing || !fresh) return false;
+    if (!roundEqual(existing, fresh)) return false;
+  }
+  return true;
+}
 
 export function gameReducer(state: GameState | null, action: GameAction): GameState | null {
   switch (action.type) {
     case "HYDRATE": {
+      if (state !== null && hydrateUnchanged(state, action.game, action.teams, action.rounds)) {
+        return state;
+      }
       const teams = new Map(action.teams.map((t) => [t.id, t]));
       const rounds = [...action.rounds].sort((a, b) => a.round_number - b.round_number);
       const currentRound = rounds.find((r) => r.id === action.game.current_round_id) ?? null;
@@ -165,10 +241,37 @@ export function useGameChannel(gameCode: string): {
       });
 
     // Periodic catch-up in case a Realtime event was dropped (see comment on
-    // RESYNC_INTERVAL_MS). Idempotent — HYDRATE replaces state wholesale.
-    const resyncId = window.setInterval(() => {
-      if (!cancelled) void hydrate();
-    }, RESYNC_INTERVAL_MS);
+    // RESYNC_INTERVAL_MS). Idempotent — HYDRATE returns the same state ref
+    // when nothing changed, so quiet ticks cost ~3 REST queries with zero
+    // re-renders.
+    let resyncId: number | null = null;
+    function startResync(): void {
+      if (resyncId !== null) return;
+      resyncId = window.setInterval(() => {
+        if (!cancelled) void hydrate();
+      }, RESYNC_INTERVAL_MS);
+    }
+    function stopResync(): void {
+      if (resyncId !== null) {
+        window.clearInterval(resyncId);
+        resyncId = null;
+      }
+    }
+    // Pause the backstop on background tabs (display in another window, a
+    // player who switched to another app). When the tab becomes visible
+    // again we hydrate once immediately then resume the interval — so the
+    // user never sees a stale snapshot when they return.
+    function onVisibilityChange(): void {
+      if (cancelled) return;
+      if (document.hidden) {
+        stopResync();
+      } else {
+        void hydrate();
+        startResync();
+      }
+    }
+    if (!document.hidden) startResync();
+    document.addEventListener("visibilitychange", onVisibilityChange);
 
     async function hydrate() {
       try {
@@ -207,7 +310,8 @@ export function useGameChannel(gameCode: string): {
 
     return () => {
       cancelled = true;
-      window.clearInterval(resyncId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      stopResync();
       void supabase.removeChannel(
         channel as unknown as Parameters<typeof supabase.removeChannel>[0],
       );

--- a/frontend/src/hooks/useGameChannel.ts
+++ b/frontend/src/hooks/useGameChannel.ts
@@ -46,9 +46,7 @@ function activeGameEqual(a: ActiveGame, b: ActiveGame): boolean {
 }
 
 function teamEqual(a: Team, b: Team): boolean {
-  return (
-    a.id === b.id && a.name === b.name && a.score === b.score && a.joined_at === b.joined_at
-  );
+  return a.id === b.id && a.name === b.name && a.score === b.score && a.joined_at === b.joined_at;
 }
 
 function roundEqual(a: GameRound, b: GameRound): boolean {


### PR DESCRIPTION
## Summary

Follow-up to #77. Two more lag/bandwidth cuts in `useGameChannel`:

- **HYDRATE skips dispatch when nothing changed.** The 20s resync rebuilt the teams Map and re-rendered every subscriber even when the data was identical to what we already had. Now the reducer compares the fetched rows (game / teams / rounds) field-by-field against the current state; if everything matches, it returns the same state reference and React skips the whole render cascade. During a quiet round the backstop costs ~3 REST queries and **zero re-renders**.
- **Resync pauses when the tab is hidden.** Display tabs in another window, players who switched apps, etc. contribute nothing while backgrounded. We stop the interval on `visibilitychange → hidden` and resume + hydrate-once on `visible`, so the user never sees a stale snapshot when they return.

Both behaviors live behind the same `useGameChannel` hook; no consumer changes needed.

## Test plan

- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run test:run` — 206 / 206 passing, incl. two new reducer tests:
  - HYDRATE with identical wire data returns the same state reference
  - HYDRATE with a changed team score returns a new state reference
- [x] Local E2E (`tests/e2e`, chromium, retries=2, against `supabase start`) — all 26 specs pass (5 flaky-on-first-try, all green on retry; same multi-context flake pattern the 2-retry policy is tuned for)
- [ ] CI: lint + type + test, Playwright multi-context, CodeQL