### PR TITLE
Playtest fixes: persistent QR, instant bonus, YT error recovery, no manager cover, End-Game in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-05-15: Display screen now keeps the join QR (and game code) visible at the bottom of the page for the whole game — late players can scan and join mid-round instead of being locked out the moment the first team appears.
 - 2026-05-10: Team's own phone now shows a "+10 / −3" pill the instant their score changes — same look as the projector toast — so a player gets immediate feedback on the device they're already looking at.
 - 2026-05-10: Display screen now reveals the song title and artist name in a dedicated panel once the manager confirms the corresponding correct answer. Unrevealed halves show "???" so the audience can see what's still secret. Token chips below still show which team claimed each.
 - 2026-05-10: Display screen now pops a small floating pill ("Alpha +10", "Bravo -3") whenever a team's score changes, so the audience watching the projector can see *who* just got points and how many without having to re-read the scoreboard.
@@ -15,6 +16,9 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-15: Manager Bonus button now feels instant: the team picker closes and the "+4 bonus to <team>" toast appears the moment a team is clicked. The score still arrives on the display via Realtime as before; the manager just isn't waiting on the round-trip anymore.
+- 2026-05-15: Manager YouTube player no longer overlays loading / "Song ended" / "Video unavailable" covers on the iframe — the raw YouTube player is visible the whole game. Errors are surfaced as a toast instead so the host knows to pick a different song.
+- 2026-05-15: Manager End-Game button moved from the top header to a footer at the bottom of the page. It's a once-per-game action; no need for it to compete with round controls.
 - 2026-05-15: Cut per-client REST traffic during a game by ~4x. The Realtime backstop that re-fetches game / teams / rounds rows now runs every 20s instead of every 5s; a 10-round game drops from ~360 backstop requests to ~90. A missed Realtime event still self-heals well inside any "huh, the page is stuck" wait.
 - 2026-05-12: When the host marks a Correct Song / Correct Artist, the buzzed team keeps control of the round for the other token (as before) **and** its 10-second answer countdown restarts — so the team that got one half right gets a fresh window to also guess the missing half.
 - 2026-05-12: The manager's Wrong button now also resumes the song immediately (in addition to re-arming the buzzers) — no separate Continue round press needed to un-pause playback.
@@ -40,6 +44,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-15: Manager YouTube player no longer gets stuck showing "Video unavailable" on every subsequent song after a single failed video. The error state now clears whenever a new song is loaded, so a transient YouTube hiccup on round 1 no longer breaks rounds 2-N.
 - 2026-05-15: Reduced per-second re-rendering on the team and display screens during a buzz. The round countdown now ticks in its own small component so the surrounding scoreboard, buzz button, and YouTube player don't re-render every second — smoother gameplay on lower-end phones and TVs.
 - 2026-05-12: Song selection now mixes the selected genres evenly. Each round picks a random genre among those chosen, then a random unplayed song within it, so a game with several genres no longer front-loads whichever genre happens to have the most songs in the catalog.
 - 2026-05-12: The host's Correct Song / Correct Artist buttons no longer go inactive a moment after a click — the answering team keeps control of the round for the other token until the host presses Continue round or Wrong.

--- a/frontend/src/components/YouTubePlayer.test.tsx
+++ b/frontend/src/components/YouTubePlayer.test.tsx
@@ -208,6 +208,65 @@ describe("YouTubePlayer", () => {
     expect(lastPlayer?.stopVideo).not.toHaveBeenCalled();
   });
 
+  it("loadVideoById clears a previous onError so the next song doesn't inherit 'Video unavailable'", async () => {
+    installFakeYT();
+    const ref = createRef<YouTubePlayerHandle>();
+    const { container, findByRole, queryByRole } = render(<YouTubePlayer ref={ref} hideOverlay />);
+    await flushIframeLoad(container);
+    await waitFor(() => expect(lastConfig).not.toBeNull());
+    act(() => {
+      lastConfig?.events?.onReady?.();
+    });
+    // First song fails: YT fires onError -> cover shows the error.
+    act(() => {
+      lastConfig?.events?.onError?.({ data: 150 });
+    });
+    expect((await findByRole("alert")).textContent).toContain("Video unavailable");
+    // Manager clicks Next round: loadVideoById must reset errorCode so the
+    // next song's load doesn't keep the old error overlay on screen.
+    act(() => {
+      ref.current?.loadVideoById("xxxxxxxxxxx", 0);
+    });
+    expect(queryByRole("alert")).toBeNull();
+  });
+
+  it("noCover prop renders only the iframe with no overlay element", async () => {
+    installFakeYT();
+    const ref = createRef<YouTubePlayerHandle>();
+    const { container, queryByRole, queryByText } = render(<YouTubePlayer ref={ref} noCover />);
+    await flushIframeLoad(container);
+    await waitFor(() => expect(lastConfig).not.toBeNull());
+    // Even after all the events that would normally surface a cover, none
+    // of the cover labels should render in noCover mode.
+    act(() => {
+      lastConfig?.events?.onReady?.();
+    });
+    act(() => {
+      lastConfig?.events?.onError?.({ data: 150 });
+    });
+    act(() => {
+      lastConfig?.events?.onStateChange?.({ data: 0 });
+    });
+    expect(queryByRole("alert")).toBeNull();
+    expect(queryByText(/video unavailable/i)).toBeNull();
+    expect(queryByText(/song ended/i)).toBeNull();
+    expect(queryByText(/loading player/i)).toBeNull();
+    // The iframe itself is still mounted and the imperative handle still works.
+    expect(container.querySelector("iframe")).not.toBeNull();
+  });
+
+  it("noCover still invokes the onError callback so parents can react", async () => {
+    installFakeYT();
+    const onError = vi.fn();
+    const { container } = render(<YouTubePlayer noCover onError={onError} />);
+    await flushIframeLoad(container);
+    await waitFor(() => expect(lastConfig).not.toBeNull());
+    act(() => {
+      lastConfig?.events?.onError?.({ data: 150 });
+    });
+    expect(onError).toHaveBeenCalledWith(150);
+  });
+
   it("loads the iframe API script when YT is not yet on window", async () => {
     const { container } = render(<YouTubePlayer />);
     await waitFor(() =>

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -9,10 +9,17 @@ export interface YouTubePlayerHandle {
 }
 
 interface Props {
+  // When true, render only the iframe — no cover element, no loading / ended /
+  // error / buzz-pause overlay. The host loses the anti-spoiler protection of
+  // the cover (YouTube's own "more videos" UI may briefly show between songs)
+  // in exchange for an always-visible video. Errors surface via `onError` so
+  // the parent can react inline (e.g. toast).
+  noCover?: boolean;
   hideOverlay?: boolean;
   // When true, keep the cover visible even while the video is loaded (used by
   // the manager view during a buzz / scoring pause so YouTube's pause-state
-  // "more videos" tiles can't leak song titles to the room).
+  // "more videos" tiles can't leak song titles to the room). Ignored when
+  // `noCover` is true.
   coverWhilePaused?: boolean;
   onReady?: () => void;
   onError?: (code: number) => void;
@@ -99,7 +106,7 @@ const EMBED_SRC =
   }).toString();
 
 export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function YouTubePlayer(
-  { hideOverlay, coverWhilePaused, onReady, onError },
+  { noCover, hideOverlay, coverWhilePaused, onReady, onError },
   ref,
 ) {
   const containerRef = useRef<HTMLIFrameElement | null>(null);
@@ -182,6 +189,10 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     () => ({
       loadVideoById: (videoId, startSeconds) => {
         setEnded(false);
+        // Clear any error from a previous song so the cover (when in
+        // covered mode) doesn't keep showing "Video unavailable" for what
+        // is now a different, valid video.
+        setErrorCode(null);
         playerRef.current?.loadVideoById({
           videoId,
           startSeconds: startSeconds ?? 0,
@@ -196,6 +207,24 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     }),
     [],
   );
+
+  if (noCover) {
+    // No-cover mode: just the iframe. Parents handle error UX themselves via
+    // the onError callback (e.g. surface a toast). data-testid + data-ready
+    // are preserved because E2E specs assert on them.
+    return (
+      <div className={styles.wrapper} data-testid="youtube-player" data-ready={loaded}>
+        <iframe
+          ref={containerRef}
+          className={styles.player}
+          src={EMBED_SRC}
+          title="YouTube player"
+          allow="autoplay; encrypted-media"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
 
   const overlayHidden = hideOverlay && loaded && errorCode === null && !ended && !coverWhilePaused;
   // When the video is loaded but the parent is covering it during a buzz

--- a/frontend/src/pages/DisplayPage.module.css
+++ b/frontend/src/pages/DisplayPage.module.css
@@ -350,6 +350,15 @@
   margin-top: 1.25rem;
 }
 
+.joinFooter {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
 .emptyBoardTitle {
   margin: 0;
   font-size: 2rem;

--- a/frontend/src/pages/DisplayPage.tsx
+++ b/frontend/src/pages/DisplayPage.tsx
@@ -294,14 +294,7 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
         {teams.length === 0 ? (
           <div className={styles.emptyBoard}>
             <p className={styles.emptyBoardTitle}>Waiting for teams</p>
-            <p className={styles.emptyBoardHint}>Scan to join, or enter the code on your phone.</p>
-            <div className={styles.emptyBoardQR}>
-              <QRPanel
-                gameCode={gameCode}
-                joinUrl={`${window.location.origin}/join/${gameCode}`}
-                size={420}
-              />
-            </div>
+            <p className={styles.emptyBoardHint}>Scan the code below or enter it on your phone.</p>
           </div>
         ) : (
           <ol className={styles.bigList}>
@@ -321,6 +314,17 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
           </ol>
         )}
       </div>
+
+      {/* Always-visible join footer so a late player can scan after the round
+          has started. (Hidden on the end-game podium via the early-return
+          above when game.status === "ended".) */}
+      <footer className={styles.joinFooter}>
+        <QRPanel
+          gameCode={gameCode}
+          joinUrl={`${window.location.origin}/join/${gameCode}`}
+          size={200}
+        />
+      </footer>
     </main>
   );
 }

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -83,6 +83,14 @@
   align-items: center;
 }
 
+.endGameFooter {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
 .column {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -222,16 +222,17 @@ export function ManagerConsolePage() {
   }
 
   async function handleBonus(teamId: string, teamName: string) {
-    if (busy || !managerToken) return;
-    setBusy(true);
+    if (!managerToken) return;
+    // Close the picker and toast immediately so the manager's UI feels
+    // instant. The team's new score arrives via Realtime once the backend
+    // commits; we don't gate the picker or other action buttons on the
+    // round-trip. If the API rejects (rare), surface an error toast then.
+    setBonusOpen(false);
+    toast(`+4 bonus to ${teamName}`, { variant: "success" });
     try {
       await awardBonus(gameCode, managerToken, { team_id: teamId });
-      toast(`+4 bonus to ${teamName}`, { variant: "success" });
-      setBonusOpen(false);
     } catch (err) {
       reportError(err);
-    } finally {
-      setBusy(false);
     }
   }
 
@@ -342,24 +343,18 @@ export function ManagerConsolePage() {
         <div className={styles.headerMeta}>
           <span className="muted">Round {game.round_number}</span>
         </div>
-        <div className={styles.headerActions}>
-          <button
-            className="btn btn-danger"
-            onClick={() => setEndConfirmOpen(true)}
-            disabled={busy}
-            data-testid="end-game"
-          >
-            End game
-          </button>
-        </div>
       </header>
 
       <div className={styles.column}>
         <YouTubePlayer
           ref={playerRef}
-          hideOverlay
-          coverWhilePaused={lockedTeam != null}
+          noCover
           onReady={onPlayerReady}
+          onError={() =>
+            toast("Video unavailable — click Next round to pick a different song.", {
+              variant: "error",
+            })
+          }
         />
 
         <section className={styles.card}>
@@ -497,6 +492,17 @@ export function ManagerConsolePage() {
           </div>
         </section>
       </div>
+
+      <footer className={styles.endGameFooter}>
+        <button
+          className="btn btn-danger"
+          onClick={() => setEndConfirmOpen(true)}
+          disabled={busy}
+          data-testid="end-game"
+        >
+          End game
+        </button>
+      </footer>
 
       <ConfirmDialog
         open={endConfirmOpen}


### PR DESCRIPTION
## Summary

Five fixes from the user's first playtest after the recent network/lag improvements.

### 1. Display QR stays visible all game (#1)

`DisplayPage.tsx` previously rendered the QR only inside the `teams.length === 0` empty state — once the first team joined, the QR was replaced by the scoreboard and late players had no easy way in. The QR now lives in a persistent footer at the bottom of the page (full-width band, `size={200}`), visible the whole game. Hidden only on the end-game podium (which has its own early-return).

### 2. Bonus button feels instant (#2)

`handleBonus` used to `setBusy(true)` then `await awardBonus()` before closing the picker and toasting — the manager stared at the open picker until the round-trip + Realtime fan-out completed. Now the picker closes and the "+4 bonus to <team>" toast appears on click; `awardBonus` runs in the background, and an error toast is surfaced only if it rejects. The team's new score still arrives on the display via Realtime as before.

### 3. YouTube error no longer persists across rounds (#3)

`YouTubePlayer.tsx`'s imperative `loadVideoById` reset `ended` but never reset `errorCode`. After a single `onError` event (transient YT issue, region-locked video, network blip), the "Video unavailable" cover stuck around for every subsequent song. Now `setErrorCode(null)` runs alongside `setEnded(false)` on each `loadVideoById`, so a fresh song clears the previous failure state.

### 4. Manager YouTube player shows only the raw iframe (#4)

New prop `noCover` on `YouTubePlayer`. When set, the cover element is not rendered at all — no loading splash, no "Song ended" cover, no buzz-pause cover. ManagerConsolePage passes `noCover` and handles errors via a toast through the existing `onError` callback. Tradeoff (accepted by the user): YouTube's own pause-state "more videos" UI can briefly leak song titles between rounds; in exchange, the iframe is always visible.

### 5. End-Game button moved to a footer (#5)

The End-Game button used to sit prominently in the manager's header. It's a once-per-game action; it now lives in a small `<footer>` below the round controls, separated by a top border. The `data-testid="end-game"` is preserved so `tests/e2e/full_game.spec.ts` still finds it.

## Test plan

- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run test:run` — **241 / 241 passing**, including 3 new YouTubePlayer tests:
  - `loadVideoById clears a previous onError so the next song doesn't inherit 'Video unavailable'`
  - `noCover prop renders only the iframe with no overlay element`
  - `noCover still invokes the onError callback so parents can react`
- [x] CI: lint + type + test, Playwright multi-context, CodeQL
- [x] Manual smoke against local stack: confirm QR visible during play, bonus instant, YT recovers after errors, no manager cover, End-Game at bottom