### PR TITLE
Round controls match scoring grid, tighter End-Game, home copy mirrors 'Host a game'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-15: Manager Continue / Next-round buttons now match the size and grid of the four scoring buttons above them — equal-width 2-column row instead of right-aligned text buttons — so the round-controls block reads as one coherent surface.
+- 2026-05-15: Home page button copy: "Join as Team" → "Join a game" (mirrors "Host a game"), and "Display Screen" → "Display screen" so all three role buttons share the same sentence case.
 - 2026-05-15: Manager Bonus button now feels instant: the team picker closes and the "+4 bonus to <team>" toast appears the moment a team is clicked. The score still arrives on the display via Realtime as before; the manager just isn't waiting on the round-trip anymore.
 - 2026-05-15: Manager YouTube player no longer overlays loading / "Song ended" / "Video unavailable" covers on the iframe — the raw YouTube player is visible the whole game. Errors are surfaced as a toast instead so the host knows to pick a different song.
 - 2026-05-15: Manager End-Game button moved from the top header to a footer at the bottom of the page. It's a once-per-game action; no need for it to compete with round controls.

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -11,7 +11,7 @@ describe("HomePage", () => {
       </MemoryRouter>,
     );
     const host = screen.getByRole("link", { name: /host a game/i });
-    const join = screen.getByRole("link", { name: /join as team/i });
+    const join = screen.getByRole("link", { name: /join a game/i });
     const display = screen.getByRole("link", { name: /display screen/i });
     expect(host).toHaveAttribute("href", "/manager/create");
     expect(join).toHaveAttribute("href", "/join");

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -52,7 +52,7 @@ export function HomePage() {
                   <TeamIcon />
                 </span>
                 <span className={styles.roleContent}>
-                  <span className={styles.roleTitle}>Join as Team</span>
+                  <span className={styles.roleTitle}>Join a game</span>
                   <span className={styles.roleSubtitle}>Play on your phone</span>
                 </span>
               </Link>
@@ -62,7 +62,7 @@ export function HomePage() {
                   <DisplayIcon />
                 </span>
                 <span className={styles.roleContent}>
-                  <span className={styles.roleTitle}>Display Screen</span>
+                  <span className={styles.roleTitle}>Display screen</span>
                   <span className={styles.roleSubtitle}>Show scoreboard</span>
                 </span>
               </Link>

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -86,8 +86,8 @@
 .endGameFooter {
   display: flex;
   justify-content: center;
-  margin-top: 2rem;
-  padding-top: 1rem;
+  margin-top: 1rem;
+  padding-top: 0.5rem;
   border-top: 1px solid var(--color-border);
 }
 
@@ -434,22 +434,32 @@
   gap: 0.5rem;
 }
 
+/* Continue / Next-round sit below the four scoring buttons and now match
+   their grid: a 2-column row of equal-sized cells so the two rows feel
+   like one coherent control surface. min-height + padding mirror the
+   .scoreBtn dimensions; the per-button gradients stay below. */
 .actionsInline {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.6rem;
-  justify-content: flex-end;
 }
 
-/* On narrow screens stack the two big-action buttons so each gets full
-   width and is comfortably tappable. The sticky bottom bar that used to
-   take over on mobile was removed; these inline buttons are the only
-   round-control surface now. */
 @media (max-width: 480px) {
   .actionsInline {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: 1fr;
   }
+}
+
+.awardBtn,
+.continueBtn {
+  min-height: 64px;
+  padding: 12px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
 }
 
 .awardBtn {


### PR DESCRIPTION
## Summary

Three UI polish items from playtest feedback.

### 1. Continue / Next-round buttons match the scoring grid

The two round-control buttons used generic `.btn` styling (right-aligned, text-only, full-width on mobile) while the four scoring buttons above used a 4-column grid of label+points cards. Visually they looked like two unrelated bands.

Now `.actionsInline` is a 2-column grid (1-column on mobile) and `.awardBtn` / `.continueBtn` share the same `min-height: 64px` + `12px 10px` padding as `.scoreBtn`, while keeping their distinctive green / cyan gradients. The round-controls block reads as one coherent surface.

### 2. End-Game footer tighter

`margin-top` 2rem → 1rem and `padding-top` 1rem → 0.5rem. Still has the divider border so it reads as a footer, just hugs the round-controls a bit more.

### 3. Home page button copy

| Before | After |
|---|---|
| Host a game | Host a game *(unchanged)* |
| **Join as Team** | **Join a game** |
| **Display Screen** | **Display screen** |

`Join as Team` was awkward (missing article, title-case in a sentence-case context). `Join a game` parallels `Host a game` exactly — the "team" role detail still lives in the subtitle "Play on your phone". `Display Screen` lowercase-s for consistency with the other two.

## Test plan

- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run test:run` — **241 / 241 passing** (HomePage test updated to match the new "Join a game" label)
- [ ] CI: lint + type + test, Playwright multi-context, CodeQL
- [ ] Manual smoke: home page reads naturally, manager round controls feel like one block, End-Game button has a small but clear footer gap