### PR TITLE
Polish repo metadata: badges, CODEOWNERS, prune dead config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — auto-requests @BenArtzi4 as a reviewer on every PR.
+# Solo maintainer for now; this file scales if collaborators are ever added.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @BenArtzi4

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,7 @@
-# This file goes in the new repo at: .github/ISSUE_TEMPLATE/config.yml
-# Disables blank issues; forces use of templates above.
+# Disables blank issues; forces use of the bug_report / feature_request templates.
 
 blank_issues_enabled: false
 contact_links:
   - name: Security issue
     url: mailto:benartzi4@gmail.com?subject=%5BSECURITY%5D%20Sound%20Clash
     about: Please email security issues privately rather than opening a public issue.
-  - name: Question / discussion
-    url: https://github.com/BenArtzi4/Sound-Clash/discussions
-    about: For open-ended questions, use Discussions instead of Issues.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,26 +36,10 @@ updates:
           - "patch"
         applies-to: version-updates
 
-  # npm (frontend)
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "frontend"
-    commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
-      include: "scope"
-    groups:
-      frontend-minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-        applies-to: version-updates
+  # npm (frontend) -- intentionally omitted: frontend/package-lock.json is
+  # gitignored (see frontend.yml comment + commit 888a5ab on the npm 10
+  # esbuild optional-deps bug). Dependabot for npm requires a tracked lockfile,
+  # so this ecosystem is a no-op until the lockfile lands.
 
   # npm (e2e tests)
   - package-ecosystem: "npm"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ See [`docs/local-development.md`](docs/local-development.md). TL;DR: `supabase s
 1. Open against `main`.
 2. Fill in the PR template (auto-loaded from `.github/pull_request_template.md`).
 3. CI must be green: `backend.yml`, `frontend.yml`, and `e2e.yml` (if labeled `run-e2e`).
-4. At least one approval. Solo maintainer admin override is acceptable for trivial changes.
+4. While the project has a single maintainer, PRs don't require an approving review, but `main` is branch-protected: every change must go through a PR (direct pushes are blocked, including for the maintainer), conversations must be resolved, and force-pushes / deletions are denied.
 5. Squash-merge by default. Merge commits only for substantial multi-commit features where individual commits matter.
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Real-time multiplayer music-trivia buzzer game. Host a room, share the code, rac
 
 [![Backend CI](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/backend.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/backend.yml)
 [![Frontend CI](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/frontend.yml)
+[![E2E](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/e2e.yml/badge.svg)](https://github.com/BenArtzi4/Sound-Clash/actions/workflows/e2e.yml)
 [![codecov](https://codecov.io/gh/BenArtzi4/Sound-Clash/branch/main/graph/badge.svg)](https://codecov.io/gh/BenArtzi4/Sound-Clash)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ![Sound Clash home page](.github/assets/hero.png)
 


### PR DESCRIPTION
## Summary

Small repo-presentation cleanups, no runtime impact. Pairs with the new `main` branch protection (PR required, 0 approvals, admins enforced).

- Add **E2E** and **License: MIT** badges to README; keeps the badge row scannable while reflecting the full CI surface.
- Update `CONTRIBUTING.md` §Pull-requests bullet 4 — old text claimed "at least one approval, solo maintainer admin override is acceptable," which contradicts the new protection (admins enforced, 0 required reviews). New wording describes reality: PR-only merges, conversations resolved, no force-push or deletion.
- Trim `.github/ISSUE_TEMPLATE/config.yml`: drop the "Question / discussion" contact link — `has_discussions=false` on this repo, so the URL would 404.
- Trim `.github/dependabot.yml`: drop the `/frontend` npm block. `frontend/package-lock.json` is intentionally gitignored (npm 10 esbuild optional-deps bug, commit 888a5ab) and Dependabot for npm requires a tracked lockfile, so that block was a no-op. Other ecosystems (pip, github-actions, e2e npm, backend docker) are unchanged.
- Add `.github/CODEOWNERS` pointing every path to @BenArtzi4 so review requests auto-route; scales trivially if collaborators are added later.

## Test plan

- [x] No code changes — Backend / Frontend / E2E CI workflows are path-filtered to source directories, so none should trigger on this PR.
- [x] `git diff --stat` confirms only meta files touched.
- [ ] Render the README on GitHub and confirm the new badges resolve and link correctly.
- [ ] Open the issue-template picker on a throwaway tab to confirm the Discussions row is gone.