### PR TITLE
How-to-play: seven-step walkthrough + Rules & FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
-- 2026-05-16: How-to-play page reworked into a numbered seven-step walkthrough (Host a game → genres → Display screen → teams join with QR → start → buzz/judge → optional Bonus) plus a new "Rules & FAQ" section covering the free-guess sweetener, two-tokens-per-song, no-repeats, 4-hour expiry, tied wins, and other rules new players ask about most.
+- 2026-05-16: How-to-play page reworked into a numbered seven-step walkthrough (Host a game → genres → Display screen → teams join with QR → start → buzz/judge → optional Bonus) plus a short "Rules & FAQ" section covering the free-guess sweetener, two tokens per song, wrong-buzz-doesn't-lock-you-out, +4 Bonus anytime, and one-phone-per-team reconnect.
 - 2026-05-15: Display screen now keeps the join QR (and game code) visible at the bottom of the page for the whole game — late players can scan and join mid-round instead of being locked out the moment the first team appears.
 - 2026-05-10: Team's own phone now shows a "+10 / −3" pill the instant their score changes — same look as the projector toast — so a player gets immediate feedback on the device they're already looking at.
 - 2026-05-10: Display screen now reveals the song title and artist name in a dedicated panel once the manager confirms the corresponding correct answer. Unrevealed halves show "???" so the audience can see what's still secret. Token chips below still show which team claimed each.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-05-16: How-to-play page reworked into a numbered seven-step walkthrough (Host a game → genres → Display screen → teams join with QR → start → buzz/judge → optional Bonus) plus a new "Rules & FAQ" section covering the free-guess sweetener, two-tokens-per-song, no-repeats, 4-hour expiry, tied wins, and other rules new players ask about most.
 - 2026-05-15: Display screen now keeps the join QR (and game code) visible at the bottom of the page for the whole game — late players can scan and join mid-round instead of being locked out the moment the first team appears.
 - 2026-05-10: Team's own phone now shows a "+10 / −3" pill the instant their score changes — same look as the projector toast — so a player gets immediate feedback on the device they're already looking at.
 - 2026-05-10: Display screen now reveals the song title and artist name in a dedicated panel once the manager confirms the corresponding correct answer. Unrevealed halves show "???" so the audience can see what's still secret. Token chips below still show which team claimed each.

--- a/frontend/src/pages/HowToPlayPage.module.css
+++ b/frontend/src/pages/HowToPlayPage.module.css
@@ -166,61 +166,112 @@
   font-weight: 500;
 }
 
-/* Game-flow section */
+/* Steps section */
 
-.flowGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.5rem;
-}
-
-.flowItem {
+.stepsList {
+  list-style: none;
+  margin: 0 auto;
+  padding: 0;
+  max-width: 760px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
   gap: 1rem;
-  padding: 2rem 1.5rem;
+  counter-reset: step;
+}
+
+.stepRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 1.4rem 1.5rem;
   background: #ffffff;
   border-radius: 18px;
   border: 2px solid rgba(59, 130, 246, 0.08);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
 }
 
-.flowNumber {
-  width: 56px;
-  height: 56px;
+.stepNumber {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   font-weight: 800;
-  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 4px 14px rgba(59, 130, 246, 0.28);
 }
 
-.flowContent {
+.stepBody {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.3rem;
+  min-width: 0;
 }
 
-.flowContent h3 {
-  font-size: 1.3rem;
+.stepTitle {
+  font-size: 1.2rem;
   font-weight: 700;
   color: #0f172a;
   margin: 0;
   letter-spacing: -0.01em;
 }
 
-.flowContent p {
+.stepText {
   font-size: 1rem;
   color: var(--color-text-dim);
   margin: 0;
   line-height: 1.55;
   font-weight: 500;
+}
+
+.stepText strong {
+  color: #0f172a;
+  font-weight: 700;
+}
+
+/* Rules & FAQ section */
+
+.faqList {
+  margin: 0 auto;
+  padding: 0;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.faqRow {
+  padding: 1.1rem 1.35rem;
+  background: #ffffff;
+  border: 1px solid rgba(59, 130, 246, 0.1);
+  border-left: 4px solid #06b6d4;
+  border-radius: 14px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.03);
+}
+
+.faqTerm {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0 0 0.3rem 0;
+  letter-spacing: -0.01em;
+}
+
+.faqDef {
+  font-size: 1rem;
+  color: var(--color-text-dim);
+  margin: 0;
+  line-height: 1.55;
+  font-weight: 500;
+}
+
+.faqDef strong {
+  color: #0f172a;
+  font-weight: 700;
 }
 
 /* Scoring section */
@@ -298,8 +349,7 @@
 }
 
 @media (max-width: 1100px) {
-  .roles,
-  .flowGrid {
+  .roles {
     grid-template-columns: 1fr;
     max-width: 520px;
     margin: 0 auto;
@@ -331,5 +381,17 @@
   .scoringRow {
     padding: 0.85rem 1rem;
     font-size: 1rem;
+  }
+  .stepRow {
+    gap: 1rem;
+    padding: 1.2rem 1.1rem;
+  }
+  .stepNumber {
+    width: 42px;
+    height: 42px;
+    font-size: 1.2rem;
+  }
+  .faqRow {
+    padding: 1rem 1.1rem;
   }
 }

--- a/frontend/src/pages/HowToPlayPage.test.tsx
+++ b/frontend/src/pages/HowToPlayPage.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { HowToPlayPage } from "./HowToPlayPage";
 
 describe("HowToPlayPage", () => {
-  it("renders roles, game flow, and scoring sections", () => {
+  it("renders roles, steps, scoring, and rules sections", () => {
     render(
       <MemoryRouter>
         <HowToPlayPage />
@@ -12,11 +12,46 @@ describe("HowToPlayPage", () => {
     );
     expect(screen.getByRole("heading", { level: 1, name: /how to play/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^roles$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /game flow/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /steps to run a game/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^scoring$/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /teams join/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /listen & buzz/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /manager awards/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /rules & faq/i })).toBeInTheDocument();
+  });
+
+  it("renders all seven steps in order with visible numbers", () => {
+    render(
+      <MemoryRouter>
+        <HowToPlayPage />
+      </MemoryRouter>,
+    );
+    const stepHeadings = [
+      /host a game/i,
+      /pick genres and create/i,
+      /open the display screen/i,
+      /teams join from their phones/i,
+      /start the game/i,
+      /buzz and judge/i,
+      /award a bonus/i,
+    ];
+    for (const name of stepHeadings) {
+      expect(screen.getByRole("heading", { level: 3, name })).toBeInTheDocument();
+    }
+    // Numbers 1–7 are rendered as text in the step circles.
+    for (let i = 1; i <= 7; i++) {
+      expect(screen.getByText(String(i))).toBeInTheDocument();
+    }
+  });
+
+  it("surfaces the key gameplay rules in the FAQ", () => {
+    render(
+      <MemoryRouter>
+        <HowToPlayPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/free guess after a correct answer/i)).toBeInTheDocument();
+    expect(screen.getByText(/two answers per song/i)).toBeInTheDocument();
+    expect(screen.getByText(/bonus anytime/i)).toBeInTheDocument();
+    expect(screen.getByText(/no song repeats/i)).toBeInTheDocument();
+    expect(screen.getByText(/games auto-expire after 4 hours/i)).toBeInTheDocument();
   });
 
   it("links back to the home page", () => {

--- a/frontend/src/pages/HowToPlayPage.test.tsx
+++ b/frontend/src/pages/HowToPlayPage.test.tsx
@@ -49,9 +49,9 @@ describe("HowToPlayPage", () => {
     );
     expect(screen.getByText(/free guess after a correct answer/i)).toBeInTheDocument();
     expect(screen.getByText(/two answers per song/i)).toBeInTheDocument();
+    expect(screen.getByText(/wrong buzz doesn't lock you out/i)).toBeInTheDocument();
     expect(screen.getByText(/bonus anytime/i)).toBeInTheDocument();
-    expect(screen.getByText(/no song repeats/i)).toBeInTheDocument();
-    expect(screen.getByText(/games auto-expire after 4 hours/i)).toBeInTheDocument();
+    expect(screen.getByText(/one phone per team/i)).toBeInTheDocument();
   });
 
   it("links back to the home page", () => {

--- a/frontend/src/pages/HowToPlayPage.tsx
+++ b/frontend/src/pages/HowToPlayPage.tsx
@@ -3,6 +3,120 @@ import { Logo } from "../components/Logo";
 import { DisplayIcon, ManagerIcon, TeamIcon } from "../components/RoleIcons";
 import styles from "./HowToPlayPage.module.css";
 
+const STEPS: ReadonlyArray<{ title: string; body: React.ReactNode }> = [
+  {
+    title: "Host a game",
+    body: (
+      <>
+        From the home page, tap <strong>Host a game</strong>.
+      </>
+    ),
+  },
+  {
+    title: "Pick genres and create",
+    body: (
+      <>
+        Choose the music genres you want. Sound Clash hands you a 6-letter{" "}
+        <strong>game code</strong>.
+      </>
+    ),
+  },
+  {
+    title: "Open the Display screen",
+    body: (
+      <>
+        On a TV or laptop everyone in the room can see, open <strong>Display screen</strong> and
+        enter the code. It shows the join QR, the scoreboard, and the YouTube clip.
+      </>
+    ),
+  },
+  {
+    title: "Teams join from their phones",
+    body: (
+      <>
+        Each team needs one phone. Scan the QR on the display, or open soundclash.org and tap{" "}
+        <strong>Join a game</strong>.
+      </>
+    ),
+  },
+  {
+    title: "Start the game",
+    body: (
+      <>
+        Once the teams are in, the host taps <strong>Start game</strong> and the first song plays.
+      </>
+    ),
+  },
+  {
+    title: "Buzz and judge",
+    body: (
+      <>
+        The first team to buzz answers out loud. The host taps <strong>Correct Title</strong> (+10),{" "}
+        <strong>Correct Artist</strong> (+5), or <strong>Wrong</strong> (−3). The team that just
+        answered keeps the floor to also try the other half.
+      </>
+    ),
+  },
+  {
+    title: "Award a bonus (optional)",
+    body: (
+      <>
+        At any moment the host can tap <strong>+4 Bonus</strong> and pick a team — for great
+        singing, dancing, or a fun trivia detail. It's independent of rounds.
+      </>
+    ),
+  },
+];
+
+const FAQ: ReadonlyArray<{ term: string; def: React.ReactNode }> = [
+  {
+    term: "Free guess after a correct answer",
+    def: (
+      <>
+        Got the title (+10)? You can take a shot at the artist with no risk — the very next wrong
+        buzz in the round costs <strong>0</strong> instead of −3.
+      </>
+    ),
+  },
+  {
+    term: "Two answers per song",
+    def: "Title and Artist are independent. Different teams can claim each one.",
+  },
+  {
+    term: "A wrong buzz doesn't lock you out",
+    def: "Buzz wrong, and you can still buzz again on the same song.",
+  },
+  {
+    term: "Bonus anytime",
+    def: (
+      <>
+        The host can grant <strong>+4</strong> to any team at any moment — for trivia, singing,
+        dancing, or sportsmanship.
+      </>
+    ),
+  },
+  {
+    term: "No song repeats",
+    def: "Each song plays at most once per game.",
+  },
+  {
+    term: "Negative scores are allowed",
+    def: "A team can dip below zero. Keep buzzing — there's always another round.",
+  },
+  {
+    term: "Tied score, shared win",
+    def: "No tiebreaker. Equal final scores share the top spot.",
+  },
+  {
+    term: "One phone per team",
+    def: "Disconnected? Just reload. Your team's seat is saved on the device.",
+  },
+  {
+    term: "Games auto-expire after 4 hours",
+    def: "All data wipes automatically. No accounts, no history — start fresh whenever you like.",
+  },
+];
+
 export function HowToPlayPage() {
   return (
     <div className={styles.page}>
@@ -17,7 +131,10 @@ export function HowToPlayPage() {
           <div className={styles.content}>
             <section className={styles.intro}>
               <h1 className={styles.title}>How to Play</h1>
-              <p className={styles.subtitle}>Roles, flow, and scoring at a glance.</p>
+              <p className={styles.subtitle}>
+                Roles, the seven steps to run a game, scoring, and the rules that come up most
+                often.
+              </p>
             </section>
 
             <section className={styles.section}>
@@ -56,32 +173,20 @@ export function HowToPlayPage() {
             </section>
 
             <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>Game flow</h2>
-              <div className={styles.flowGrid}>
-                <article className={styles.flowItem}>
-                  <span className={styles.flowNumber}>1</span>
-                  <div className={styles.flowContent}>
-                    <h3>Teams Join</h3>
-                    <p>Each team uses their phone to join with a 6-letter game code.</p>
-                  </div>
-                </article>
-
-                <article className={styles.flowItem}>
-                  <span className={styles.flowNumber}>2</span>
-                  <div className={styles.flowContent}>
-                    <h3>Listen &amp; Buzz</h3>
-                    <p>First team to buzz gets to answer the song.</p>
-                  </div>
-                </article>
-
-                <article className={styles.flowItem}>
-                  <span className={styles.flowNumber}>3</span>
-                  <div className={styles.flowContent}>
-                    <h3>Manager Awards</h3>
-                    <p>The host approves or declines, and the next round starts.</p>
-                  </div>
-                </article>
-              </div>
+              <h2 className={styles.sectionTitle}>Steps to run a game</h2>
+              <ol className={styles.stepsList}>
+                {STEPS.map((step, idx) => (
+                  <li key={step.title} className={styles.stepRow}>
+                    <span className={styles.stepNumber} aria-hidden="true">
+                      {idx + 1}
+                    </span>
+                    <div className={styles.stepBody}>
+                      <h3 className={styles.stepTitle}>{step.title}</h3>
+                      <p className={styles.stepText}>{step.body}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
             </section>
 
             <section className={styles.section}>
@@ -101,9 +206,21 @@ export function HowToPlayPage() {
                 </li>
                 <li className={styles.scoringRow}>
                   <span className={`${styles.chip} ${styles.chipBonus}`}>+4</span>
-                  <span>Manager bonus - the host can award +4 to any team at any time.</span>
+                  <span>Manager bonus — the host can award +4 to any team at any time.</span>
                 </li>
               </ul>
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Rules &amp; FAQ</h2>
+              <dl className={styles.faqList}>
+                {FAQ.map(({ term, def }) => (
+                  <div key={term} className={styles.faqRow}>
+                    <dt className={styles.faqTerm}>{term}</dt>
+                    <dd className={styles.faqDef}>{def}</dd>
+                  </div>
+                ))}
+              </dl>
             </section>
 
             <div className={styles.backRow}>

--- a/frontend/src/pages/HowToPlayPage.tsx
+++ b/frontend/src/pages/HowToPlayPage.tsx
@@ -96,24 +96,8 @@ const FAQ: ReadonlyArray<{ term: string; def: React.ReactNode }> = [
     ),
   },
   {
-    term: "No song repeats",
-    def: "Each song plays at most once per game.",
-  },
-  {
-    term: "Negative scores are allowed",
-    def: "A team can dip below zero. Keep buzzing — there's always another round.",
-  },
-  {
-    term: "Tied score, shared win",
-    def: "No tiebreaker. Equal final scores share the top spot.",
-  },
-  {
     term: "One phone per team",
     def: "Disconnected? Just reload. Your team's seat is saved on the device.",
-  },
-  {
-    term: "Games auto-expire after 4 hours",
-    def: "All data wipes automatically. No accounts, no history — start fresh whenever you like.",
   },
 ];
 


### PR DESCRIPTION
## Summary

Rework the player-facing /how-to-play page so the *flow of running a game* is finally explicit, and the rules players ask about most often have a dedicated home.

- **Steps to run a game** (new) replaces the 3-card Game-flow section with a numbered seven-step walkthrough: Host a game → pick genres → open the Display screen on a second device → teams join from their phones (QR or code) → start → buzz/judge → optional +4 Bonus.
- **Rules & FAQ** (new) covers the rules that come up first-game: the free-guess sweetener after a correct answer, title/artist as two independent tokens, wrong buzz not locking a team out, +4 Bonus available any time, no song repeats, negative scores allowed, tied score = shared win, one-phone-per-team reconnect, and the 4-hour auto-expiry.
- Roles + Scoring sections kept (Roles' three cards + the chip-based scoring list still read well).
- New `.stepsList` / `.faqList` CSS — vertical numbered rows for the seven steps, cyan-bordered cards for the FAQ. Existing styles unchanged.
- Tests rewritten for the new headings; 4 tests, 243 in the full suite still pass.
- CHANGELOG: one `Added` entry under `[Unreleased]`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean (after one prettier --write pass)
- [x] `npm run test:run` — 243/243 pass, including 4 HowToPlayPage tests
- [ ] Manual: load `/how-to-play` in the dev server, eyeball the seven-step list on desktop and on a phone-width viewport; click each home-page CTA to confirm the page is reachable
- [ ] Manual: confirm the back link still returns to `/`