### PR TITLE
Manager console: stack song info, drop Round controls heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-16: Manager console: song title and artist now sit above the token-state chips on their own line, and the "Round controls" heading was removed. Easier to read on phones.
 - 2026-05-15: Manager Continue / Next-round buttons now match the size and grid of the four scoring buttons above them — equal-width 2-column row instead of right-aligned text buttons — so the round-controls block reads as one coherent surface.
 - 2026-05-15: Home page button copy: "Join as Team" → "Join a game" (mirrors "Host a game"), and "Display Screen" → "Display screen" so all three role buttons share the same sentence case.
 - 2026-05-15: Manager Bonus button now feels instant: the team picker closes and the "+4 bonus to <team>" toast appears the moment a team is clicked. The score still arrives on the display via Realtime as before; the manager just isn't waiting on the round-trip anymore.

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -118,27 +118,8 @@
   opacity: 0.85;
 }
 
-.cardTitle {
-  display: block;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--color-text-dim);
-  font-weight: 700;
-  margin-bottom: 0.6rem;
-}
-
-.roundHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.25rem;
-  margin-bottom: 1rem;
-}
-
-.roundHeaderInfo {
-  flex: 1;
-  min-width: 0;
+.songBlock {
+  margin-bottom: 0.85rem;
 }
 
 .songLine {
@@ -518,6 +499,7 @@
   flex-wrap: wrap;
   gap: 0.4rem;
   align-items: center;
+  margin-bottom: 1rem;
 }
 
 .tokenChip {

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -164,8 +164,8 @@ describe("ManagerConsolePage", () => {
         artist: "Queen",
         youtube_id: "abcdefghijk",
         start_time: 0,
-        is_soundtrack: false,
-        source: null,
+        is_soundtrack: true,
+        source: "Wayne's World",
       },
     });
     renderConsole();
@@ -179,6 +179,8 @@ describe("ManagerConsolePage", () => {
     fireEvent.click(screen.getByRole("button", { name: /start game/i }));
     await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
     await waitFor(() => expect(screen.getByText("Bohemian Rhapsody")).toBeInTheDocument());
+    // The source string (e.g. soundtrack origin) renders alongside the artist name.
+    expect(screen.getByText(/queen.*wayne's world/i)).toBeInTheDocument();
   });
 
   it("score buttons enable only when a team is buzzed", async () => {
@@ -503,6 +505,24 @@ describe("ManagerConsolePage", () => {
     expect(screen.getByTestId("score-title")).toBeDisabled();
     expect(screen.getByTestId("score-artist")).toBeEnabled();
     expect(screen.getByTestId("score-wrong")).toBeEnabled();
+  });
+
+  it("artist chip flips to the claimed state when artist_claimed_by is set", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t2",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1", name: "Alpha" }), makeTeam({ id: "t2", name: "Bravo" })],
+      rounds: [makeRound({ id: "r1", artist_claimed_by: "t1" })],
+    });
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    expect(screen.getByTestId("token-chip-artist")).toHaveTextContent(/artist\s+✓/i);
+    expect(screen.getByTestId("score-artist")).toBeDisabled();
   });
 
   it("Bonus opens a team picker and posts to awardBonus", async () => {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -358,42 +358,38 @@ export function ManagerConsolePage() {
         />
 
         <section className={styles.card}>
-          <div className={styles.roundHeader}>
-            <div className={styles.roundHeaderInfo}>
-              <span className={styles.cardTitle}>Round controls</span>
-              {currentSong ? (
-                <>
-                  <p className={styles.songLine}>{currentSong.title}</p>
-                  <p className={styles.songMeta}>
-                    {currentSong.artist}
-                    {currentSong.source ? ` - ${currentSong.source}` : ""}
-                  </p>
-                </>
-              ) : (
-                <p className={styles.songMeta}>No round started yet.</p>
-              )}
+          {currentSong ? (
+            <div className={styles.songBlock}>
+              <p className={styles.songLine}>{currentSong.title}</p>
+              <p className={styles.songMeta}>
+                {currentSong.artist}
+                {currentSong.source ? ` - ${currentSong.source}` : ""}
+              </p>
             </div>
-            {round && game.status === "playing" ? (
-              <div className={styles.tokenChips} aria-label="Round token state">
-                <span
-                  className={`${styles.tokenChip} ${
-                    titleClaimedById ? styles.tokenChipClaimed : ""
-                  }`}
-                  data-testid="token-chip-title"
-                >
-                  Song {titleClaimedById ? "✓" : "open"}
-                </span>
-                <span
-                  className={`${styles.tokenChip} ${
-                    artistClaimedById ? styles.tokenChipClaimed : ""
-                  }`}
-                  data-testid="token-chip-artist"
-                >
-                  Artist {artistClaimedById ? "✓" : "open"}
-                </span>
-              </div>
-            ) : null}
-          </div>
+          ) : (
+            <p className={styles.songMeta}>No round started yet.</p>
+          )}
+
+          {round && game.status === "playing" ? (
+            <div className={styles.tokenChips} aria-label="Round token state">
+              <span
+                className={`${styles.tokenChip} ${
+                  titleClaimedById ? styles.tokenChipClaimed : ""
+                }`}
+                data-testid="token-chip-title"
+              >
+                Song {titleClaimedById ? "✓" : "open"}
+              </span>
+              <span
+                className={`${styles.tokenChip} ${
+                  artistClaimedById ? styles.tokenChipClaimed : ""
+                }`}
+                data-testid="token-chip-artist"
+              >
+                Artist {artistClaimedById ? "✓" : "open"}
+              </span>
+            </div>
+          ) : null}
 
           {lockedTeam ? (
             <div className={styles.lockedBanner} role="status" aria-live="polite">

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -373,9 +373,7 @@ export function ManagerConsolePage() {
           {round && game.status === "playing" ? (
             <div className={styles.tokenChips} aria-label="Round token state">
               <span
-                className={`${styles.tokenChip} ${
-                  titleClaimedById ? styles.tokenChipClaimed : ""
-                }`}
+                className={`${styles.tokenChip} ${titleClaimedById ? styles.tokenChipClaimed : ""}`}
                 data-testid="token-chip-title"
               >
                 Song {titleClaimedById ? "✓" : "open"}

--- a/tests/e2e/manager_cleanup_yt_csp.spec.ts
+++ b/tests/e2e/manager_cleanup_yt_csp.spec.ts
@@ -23,10 +23,11 @@ test.describe("manager-cleanup-yt-csp branch", () => {
     const team = await joinAsTeam(browser, manager.gameCode, "Solo");
 
     // Wait for the manager page to be fully hydrated before negative
-    // assertions. The Round controls card is always present once the
-    // game row has loaded; the manager page no longer shows a Scoreboard
-    // or Teams list, so we can't wait on the team name to appear.
-    await expect(manager.page.getByText(/round controls/i)).toBeVisible({ timeout: 10_000 });
+    // assertions. The "Start game" / "Next round" button is always
+    // present once the round-controls card has mounted; the manager page
+    // no longer shows a Scoreboard or Teams list, so we can't wait on
+    // the team name to appear.
+    await expect(manager.page.getByTestId("start-round")).toBeVisible({ timeout: 10_000 });
 
     // #1: no "Invite Players" heading anywhere.
     await expect(
@@ -135,7 +136,7 @@ test.describe("manager-cleanup-yt-csp branch", () => {
       manager.page.getByText(/video unavailable/i),
     ).toHaveCount(0);
 
-    // The song title also has to appear in the Round controls card -
+    // The song title also has to appear in the round-controls card -
     // proves selectSong returned a Song and the manager UI rendered it.
     await expect(
       manager.page.locator("[class*='songLine']").first(),


### PR DESCRIPTION
## Summary

- Song title and artist now live on their own row at the top of the round-controls card; the "Song open" / "Artist open" token chips sit on a separate row below them. On iPhone widths the title no longer crowds the chips.
- Dropped the "ROUND CONTROLS" heading — the card's purpose is obvious from its contents (score buttons + chips), and on a narrow screen that line was buying nothing.
- E2E hydration sentinel in `manager_cleanup_yt_csp.spec.ts` switched from `getByText(/round controls/i)` to `getByTestId("start-round")`.

## Test plan

- [ ] `cd frontend && npm run typecheck` passes (already verified locally)
- [ ] `cd frontend && npm run lint` passes (already verified locally)
- [ ] Open `/manager/game/<code>` at iPhone (~390px) width: song title on its own line, artist below, then the two chips on their own row, then the locked banner / score buttons.
- [ ] Same page at desktop width: layout stacked and left-aligned, no awkward empty space.
- [ ] Buzz from a team, mark Correct Song — chip flips to green "✓" in its new position; score row stays usable.
- [ ] `cd tests/e2e && npm test manager_cleanup_yt_csp.spec.ts` against the local stack still passes.