### PR TITLE
Manager console: optimistic toasts on Continue/End/NextRound + YouTube preconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-16: Manager Continue / End game / Next round buttons now show their confirmation toast the instant the button is pressed, instead of after the network round-trip — the click feels immediate even on a slow connection. Browser also pre-warms the YouTube connection at app load so the first song's player mounts faster.
 - 2026-05-16: Manager Correct Song / Correct Artist / Wrong / Continue now feel snappy. They call Postgres directly (same pattern as the buzzer) instead of going through the Render-hosted backend, so the click no longer waits on a transatlantic API hop. Perceived end-to-end latency drops from ~400-600ms (with up to a 30s spike on a cold Render dyno) to ~150ms; the optimistic "+10 to <team>" toast appears the moment the button is pressed.
 - 2026-05-16: Manager console: song title and artist now sit above the token-state chips on their own line, and the "Round controls" heading was removed. Easier to read on phones.
 - 2026-05-15: Manager Continue / Next-round buttons now match the size and grid of the four scoring buttons above them — equal-width 2-column row instead of right-aligned text buttons — so the round-controls block reads as one coherent surface.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,15 @@
     <meta name="theme-color" content="#06b6d4" />
     <meta name="color-scheme" content="light" />
 
+    <!-- Warm DNS/TLS to YouTube before the IFrame Player mounts on the first
+         round. The script itself is still injected by YouTubePlayer.tsx; we
+         just shave the connection setup off the user-perceived song-start
+         latency. -->
+    <link rel="preconnect" href="https://www.youtube.com" crossorigin />
+    <link rel="preconnect" href="https://i.ytimg.com" crossorigin />
+    <link rel="dns-prefetch" href="https://www.youtube.com" />
+    <link rel="dns-prefetch" href="https://i.ytimg.com" />
+
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Sound Clash" />
     <meta

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -300,6 +300,8 @@ describe("ManagerConsolePage", () => {
     const continueBtn = screen.getByTestId("continue-round");
     await waitFor(() => expect(continueBtn).toBeEnabled());
     fireEvent.click(continueBtn);
+    // Optimistic toast fires before the RPC settles.
+    expect(screen.getByText(/round continued/i)).toBeInTheDocument();
     await waitFor(() => expect(releaseBuzzLockDirect).toHaveBeenCalledWith("ABCDEF", TOKEN));
     await waitFor(() => expect(lastHandle?.play).toHaveBeenCalled());
   });
@@ -520,6 +522,8 @@ describe("ManagerConsolePage", () => {
       onReadyHandler?.();
     });
     fireEvent.click(screen.getByTestId("start-round"));
+    // Optimistic toast fires before the network chain resolves.
+    expect(screen.getByText(/loading next round/i)).toBeInTheDocument();
     await waitFor(() => expect(endRound).toHaveBeenCalledWith("ABCDEF", TOKEN, "r1"));
     await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
     // Score buttons no longer pre-fire award_attempt on Next; that responsibility
@@ -563,6 +567,7 @@ describe("ManagerConsolePage", () => {
       onReadyHandler?.();
     });
     fireEvent.click(screen.getByTestId("start-round"));
+    expect(screen.getByText(/loading next round/i)).toBeInTheDocument();
     await waitFor(() => expect(endRound).toHaveBeenCalledWith("ABCDEF", TOKEN, "r1"));
     await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
     expect(awardAttemptDirect).not.toHaveBeenCalled();
@@ -698,6 +703,8 @@ describe("ManagerConsolePage", () => {
     const endDialog = await waitFor(() => screen.getByRole("dialog"));
     expect(endGame).not.toHaveBeenCalled();
     fireEvent.click(within(endDialog).getByRole("button", { name: /^end game$/i }));
+    // Optimistic toast fires before the RPC settles.
+    expect(screen.getByText(/ending game/i)).toBeInTheDocument();
     await waitFor(() => expect(endGame).toHaveBeenCalledWith("ABCDEF", TOKEN));
     await waitFor(() => expect(getManagerToken("ABCDEF")).toBeNull());
   });

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -175,6 +175,10 @@ export function ManagerConsolePage() {
 
   async function handleContinueRound() {
     if (busy || !managerToken) return;
+    // Optimistic toast fires before the RPC so the click feels instant; the
+    // Realtime UPDATE on active_games.buzzed_team_id is still the source of
+    // truth for re-arming the buzzers.
+    toast("Round continued", { variant: "info" });
     setBusy(true);
     try {
       await releaseBuzzLockDirect(gameCode, managerToken);
@@ -217,6 +221,10 @@ export function ManagerConsolePage() {
 
   async function handleNextRound() {
     if (busy || !managerToken) return;
+    // Optimistic toast confirms the click immediately. The two-hop network
+    // chain (endRound + selectSong) still costs ~500ms today; PR-B collapses
+    // it into a single direct RPC, but the toast helps regardless.
+    toast("Loading next round...", { variant: "info" });
     setBusy(true);
     try {
       const round = state?.currentRound;
@@ -259,12 +267,15 @@ export function ManagerConsolePage() {
 
   async function performEnd() {
     if (busy || !managerToken) return;
+    // Toast fires before the network call so the manager gets immediate
+    // feedback the click registered; if endGame() fails reportError() will
+    // surface the failure on top.
+    toast("Ending game...", { variant: "info" });
     setBusy(true);
     try {
       await endGame(gameCode, managerToken);
       playerRef.current?.stop();
       clearManagerToken(gameCode);
-      toast("Game ended", { variant: "info" });
     } catch (err) {
       reportError(err);
     } finally {


### PR DESCRIPTION
## Summary
- Continue round / End game / Next round handlers now fire their confirmation toast BEFORE the network await, matching the optimistic pattern that Correct Song / Correct Artist / Wrong / Bonus already use. The click feels instant even on a slow connection.
- `frontend/index.html` adds `<link rel=preconnect>` and `<link rel=dns-prefetch>` hints for `www.youtube.com` and `i.ytimg.com` so DNS/TLS to YouTube is warm before the IFrame Player mounts on the first round. The IFrame API script itself is still injected by `YouTubePlayer.tsx`; we just shave the connection setup off the user-perceived song-start latency.
- Pure frontend; no DB migration, no backend changes, no new dependencies.

## Test plan
- [x] `cd frontend && npm run typecheck` — green
- [x] `cd frontend && npm run lint` — green
- [x] `cd frontend && npm run test:run` — 252/252 pass
- [x] `npx prettier --check` on modified files — clean
- [ ] CI must stay green (backend + frontend + e2e)
- [ ] Manual smoke after merge: open manager console on prod, press Continue / Next round / End game and confirm the toast appears the instant the button is pressed (before the network response lands in DevTools Network panel)