### PR TITLE
Next round goes browser->Postgres direct (drop second Render hop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-16: Manager "Next round" / "Start game" buttons are now noticeably faster. The browser calls Postgres directly (same pattern as the buzzer and the scoring buttons) instead of going through the Render-hosted backend, and what used to be two chained transatlantic API hops collapses to a single round-trip. Perceived end-to-end latency drops from ~500-900ms (with up to a 30s spike on a cold Render dyno) to ~150ms; with the optimistic "Loading next round..." toast the click-to-feedback gap is effectively immediate.
 - 2026-05-16: Manager Continue / End game / Next round buttons now show their confirmation toast the instant the button is pressed, instead of after the network round-trip — the click feels immediate even on a slow connection. Browser also pre-warms the YouTube connection at app load so the first song's player mounts faster.
 - 2026-05-16: Manager Correct Song / Correct Artist / Wrong / Continue now feel snappy. They call Postgres directly (same pattern as the buzzer) instead of going through the Render-hosted backend, so the click no longer waits on a transatlantic API hop. Perceived end-to-end latency drops from ~400-600ms (with up to a 30s spike on a cold Render dyno) to ~150ms; the optimistic "+10 to <team>" toast appears the moment the button is pressed.
 - 2026-05-16: Manager console: song title and artist now sit above the token-state chips on their own line, and the "Round controls" heading was removed. Easier to read on phones.

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1,11 +1,22 @@
 """Game lifecycle endpoints; see ``docs/api-contracts.md §2``.
 
-The router never calls ``buzz_in``, ``award_attempt`` or ``release_buzz_lock``;
-those stay browser-direct via PostgREST to keep Python out of the host's
-hot path. Migration 021 moved their manager-token check into the PL/pgSQL
-function bodies; the browser passes the token as an RPC argument. The
-service-role-only RPCs dispatched here are ``start_round``, ``end_round``,
-``end_game``, and ``award_bonus``.
+The router never calls ``buzz_in``, ``award_attempt``, ``release_buzz_lock``,
+or ``select_next_song``; those stay browser-direct via PostgREST to keep
+Python out of the host's hot path. Migrations 021 and 022 moved each
+function's manager-token check into the PL/pgSQL body; the browser passes
+the token as an RPC argument.
+
+``POST /games/{code}/select-song`` and ``POST /games/{code}/end-round``
+stay in place as transitional plumbing: the browser no longer calls them
+after migration 022 (``select_next_song`` does the picker + start_round
+composition directly), but keeping the routes around makes the PR
+revertable in one step if the new path misbehaves on prod. A follow-up
+cleanup can drop them, the ``_start_round_blocking`` / ``_end_round_blocking``
+helpers, and ``backend/app/services/song_picker.py`` once the new flow
+has soaked in.
+
+The service-role-only RPCs the router still dispatches are ``start_round``,
+``end_round``, ``end_game``, and ``award_bonus``.
 """
 
 from __future__ import annotations

--- a/db/migrations/022_select_next_song_rpc.sql
+++ b/db/migrations/022_select_next_song_rpc.sql
@@ -1,0 +1,182 @@
+-- 022_select_next_song_rpc.sql
+-- Move the "Next round" / "Start game" hot path off the Render FastAPI hop
+-- and onto a single direct browser -> Supabase RPC, mirroring PR #87's
+-- pattern for award_attempt / release_buzz_lock.
+--
+-- Before: handleNextRound in the manager console did TWO chained HTTP
+-- requests through FastAPI on Render (US-West) to Supabase (Frankfurt):
+--   1. POST /games/{code}/end-round  -> RPC end_round
+--   2. POST /games/{code}/select-song -> python pick_random_song +
+--      RPC start_round
+-- Each hop is ~150-300ms warm and a 2-30s spike on Render cold starts. So
+-- the click feels stuck for ~500-900ms.
+--
+-- After: one direct supabase.rpc("select_next_song", ...). The PL/pgSQL
+-- function does the token check, picks a random unplayed song (or accepts
+-- a manually-specified one), and delegates round creation to the existing
+-- start_round() function (which already defensively closes any still-open
+-- prior round, so a separate end_round call is unnecessary). Latency drops
+-- to ~150ms; with the optimistic toast (PR #88) the perceived click ->
+-- feedback gap is ~10ms.
+--
+-- Security model: same as migration 021. The function takes p_manager_token
+-- as a *required* argument (NOT a DEFAULT, so PostgREST never picks this
+-- signature for callers that meant a different overload). The function
+-- (SECURITY DEFINER) reads active_games.manager_token under definer
+-- privileges, raises 'manager_token_required' (sqlstate 28000) on mismatch,
+-- and only then performs any work. UUID equality on a fixed 16-byte type
+-- is not a timing-attack vector. p_song_id IS allowed to have a DEFAULT
+-- because there is no existing select_next_song overload to clash with --
+-- the function name is brand new in this migration.
+--
+-- Backwards compatibility: the FastAPI POST /games/{code}/select-song
+-- endpoint stays in place. Once the new frontend has shipped and is stable
+-- on prod, a follow-up cleanup migration can drop the FastAPI route, the
+-- _start_round_blocking helper, and backend/app/services/song_picker.py.
+-- Keeping both paths means one-revert rollback if the new path misbehaves.
+--
+-- Idempotent: CREATE OR REPLACE on the function; GRANT EXECUTE is naturally
+-- idempotent.
+
+CREATE OR REPLACE FUNCTION select_next_song(
+  p_game_code      text,
+  p_manager_token  uuid,
+  p_song_id        uuid DEFAULT NULL  -- NULL = pick randomly; non-NULL = manual pick
+)
+RETURNS TABLE(
+  round_id      uuid,
+  round_number  integer,
+  song_id       uuid,
+  song_title    text,
+  song_artist   text,
+  youtube_id    text,
+  start_time    integer,
+  is_soundtrack boolean,
+  source        text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_expected_token uuid;
+  v_game_ended_at  timestamptz;
+  v_genres         uuid[];
+  v_chosen_song    uuid;
+  v_round_id       uuid;
+  v_round_number   integer;
+BEGIN
+  -- 1. Token + game-state gate. Same shape as award_attempt in migration 021.
+  --    Token check happens before any reads that could leak game state.
+  SELECT ag.manager_token, ag.ended_at, ag.selected_genres
+    INTO v_expected_token, v_game_ended_at, v_genres
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_game_ended_at IS NOT NULL THEN
+    RAISE EXCEPTION 'game_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_expected_token IS NULL
+     OR p_manager_token IS NULL
+     OR v_expected_token <> p_manager_token THEN
+    RAISE EXCEPTION 'manager_token_required' USING ERRCODE = '28000';
+  END IF;
+
+  IF v_genres IS NULL OR cardinality(v_genres) = 0 THEN
+    RAISE EXCEPTION 'no_genres_selected' USING ERRCODE = '22023';
+  END IF;
+
+  -- 2. Pick the song.
+  IF p_song_id IS NOT NULL THEN
+    -- Manual pick: caller supplied an exact song. Validate it exists; the
+    -- "no repeats" check is intentionally skipped to match the legacy REST
+    -- path (see docs/game-rules.md §11 -- Restart-song flow).
+    PERFORM 1 FROM songs WHERE id = p_song_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'song_not_found' USING ERRCODE = 'P0002';
+    END IF;
+    v_chosen_song := p_song_id;
+  ELSE
+    -- Random pick. Mirrors backend/app/services/song_picker.py:
+    --   * exclude songs already used in this game's game_rounds
+    --   * bucket eligible candidates by genre
+    --   * pick a random eligible genre (equal weight per genre, so small
+    --     genres aren't drowned out by large ones), then a random song
+    --     within that genre. A song that belongs to several selected genres
+    --     lands in multiple buckets, weighting it proportionally to its
+    --     genre-overlap -- same as the Python picker.
+    -- CTE columns are aliased away from "song_id" / "genre_id" because
+    -- those names collide with the function's RETURNS TABLE output and
+    -- with v_genres -- PL/pgSQL would raise "column reference ... is
+    -- ambiguous". We use sid/gid throughout the picker query.
+    WITH played AS (
+      SELECT gr.song_id AS sid
+        FROM game_rounds gr
+       WHERE gr.game_code = p_game_code
+         AND gr.song_id IS NOT NULL
+    ),
+    eligible AS (
+      SELECT sg.genre_id AS gid, sg.song_id AS sid
+        FROM song_genres sg
+       WHERE sg.genre_id = ANY (v_genres)
+         AND sg.song_id NOT IN (SELECT played.sid FROM played)
+    ),
+    chosen_genre AS (
+      SELECT eligible.gid
+        FROM eligible
+       GROUP BY eligible.gid
+       ORDER BY random()
+       LIMIT 1
+    )
+    SELECT e.sid INTO v_chosen_song
+      FROM eligible e
+      JOIN chosen_genre cg ON cg.gid = e.gid
+     ORDER BY random()
+     LIMIT 1;
+
+    IF v_chosen_song IS NULL THEN
+      RAISE EXCEPTION 'no_more_songs' USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  -- 3. Delegate round creation to start_round() (migration 016). It already
+  --    closes any still-open prior round defensively, advances round_number,
+  --    sets current_round_id / current_song_id, and clears the buzz lock --
+  --    so we don't need a separate end_round call. Its signature is
+  --    (char(6), uuid); cast the text game code accordingly.
+  v_round_id := start_round(p_game_code::char(6), v_chosen_song);
+
+  SELECT ag.round_number INTO v_round_number
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  -- songs.youtube_id is char(11) in the schema; the RETURNS TABLE declares
+  -- it as `text` (so the JSON over PostgREST renders cleanly with no
+  -- right-padding), so cast it explicitly here.
+  RETURN QUERY
+    SELECT v_round_id,
+           v_round_number,
+           s.id,
+           s.title,
+           s.artist,
+           s.youtube_id::text,
+           s.start_time,
+           s.is_soundtrack,
+           s.source
+      FROM songs s
+     WHERE s.id = v_chosen_song;
+END $$;
+
+-- Migration 020 explicitly revokes anon/authenticated EXECUTE on the backend-
+-- only RPC list it enumerates, but that loop runs once and doesn't catch new
+-- functions added later. select_next_song is anon-callable by design (token
+-- check is in the function body, same as buzz_in / award_attempt), so we
+-- grant EXECUTE explicitly to the three roles the browser and any future
+-- internal callers need.
+GRANT EXECUTE ON FUNCTION select_next_song(text, uuid, uuid)
+  TO anon, authenticated, service_role;

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -294,8 +294,51 @@ Behavior:
 
 ### Callers
 
-- FastAPI `POST /games/{code}/end-round`.
+- FastAPI `POST /games/{code}/end-round` (transitional rollback path; no
+  current caller in the deployed frontend).
 - Defensive cleanup inside `start_round` (closes any open prior round before inserting the new one).
+- Called from inside `select_next_song` to close any still-open prior round before a new one is started.
+
+## 3c. `select_next_song`: manager advances to the next round, direct from the browser
+
+Added in migration 022. Called **direct from the manager browser** when the host presses "Next round" or the initial "Start game". Replaces the legacy two-hop flow that went `browser -> FastAPI POST /end-round -> Render -> Supabase` then `browser -> FastAPI POST /select-song -> Render -> Supabase`; collapses it to one direct RPC for ~400ms of latency savings on every round transition.
+
+```sql
+CREATE OR REPLACE FUNCTION select_next_song(
+  p_game_code      text,
+  p_manager_token  uuid,
+  p_song_id        uuid DEFAULT NULL   -- NULL = random pick; non-NULL = manual
+) RETURNS TABLE(
+  round_id      uuid,
+  round_number  integer,
+  song_id       uuid,
+  song_title    text,
+  song_artist   text,
+  youtube_id    text,
+  start_time    integer,
+  is_soundtrack boolean,
+  source        text
+) LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public;
+```
+
+Behavior:
+- Token + game-state gate runs first (same shape as `award_attempt`): raises `game_not_found` / `game_ended` / `manager_token_required` before any reads of song / round state.
+- Then `no_genres_selected` (`22023`) if `selected_genres` is empty.
+- Random path: picks an unplayed song from `song_genres` constrained to `selected_genres`. Equal-weight per eligible genre, mirroring `backend/app/services/song_picker.py`. Raises `no_more_songs` (`22023`) when the pool is exhausted.
+- Manual path: caller supplies `p_song_id`; validates it exists in `songs`, raises `song_not_found` (`P0002`) otherwise. No "already played in this game" check (matches the legacy REST manual-pick semantics — Restart-song flow).
+- Delegates round creation to `start_round`, so the prior round is closed defensively, `round_number` advances, and `active_games.current_round_id` / `current_song_id` are wired up.
+- Returns one row with the new round + the picked song's metadata.
+
+### Idempotency
+
+Not idempotent on its own — every call inserts a new round. The composition relies on `start_round`'s defensive close-prior-round step so a stuck-open prior round doesn't block the call.
+
+### Callers
+
+- Manager browser → Supabase PostgREST RPC (`frontend/src/hooks/useSelectNextSong.ts::selectNextSongDirect`). Single caller in the deployed frontend.
+- The legacy FastAPI `POST /games/{code}/select-song` endpoint stays as a transitional rollback path; no current caller from the deployed frontend.
 
 ## 3a. `award_bonus`: host-discretion bonus to a chosen team
 
@@ -471,16 +514,16 @@ async def test_cleanup_deletes_expired(db):
 | `buzz_in` | ✅ | ✅ | Browser (team page) |
 | `award_attempt` | ✅ (token-gated) | ✅ | Browser (manager page) |
 | `release_buzz_lock` | ✅ (token-gated) | ✅ | Browser (manager page) |
-| `start_round` | ❌ | ✅ | FastAPI POST /games/.../select-song |
-| `end_round` | ❌ | ✅ | FastAPI POST /games/.../end-round |
+| `select_next_song` | ✅ (token-gated) | ✅ | Browser (manager page) |
+| `start_round` | ❌ | ✅ | Internal call from `select_next_song` |
+| `end_round` | ❌ | ✅ | Internal cleanup from `start_round`; FastAPI POST /games/.../end-round (transitional) |
 | `award_bonus` | ❌ | ✅ | FastAPI POST /games/.../bonus |
 | `end_game` | ❌ | ✅ | FastAPI POST /games/.../end |
 | `cleanup_expired_games` | ❌ | ✅ | pg_cron (hourly), manual ops |
 
-The three anon-callable functions all validate authentication inside the
-function body (`buzz_in` checks the game-code; `award_attempt` and
-`release_buzz_lock` check the per-game `manager_token`). This is what
-makes anon EXECUTE safe.
+The four anon-callable functions all validate authentication inside the
+function body (`buzz_in` checks the game-code; the other three check the
+per-game `manager_token`). This is what makes anon EXECUTE safe.
 
 ## 7. Why Functions, Not Just Direct UPDATEs?
 

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -48,13 +48,14 @@ Two distinct shared secrets gate FastAPI endpoints. Both checked with `secrets.c
 | `buzz_in`               | ✅ (no extra auth: knowing the game-code is the auth) | ✅ |
 | `award_attempt`         | ✅ (token-gated: validates `p_manager_token` in-body) | ✅ |
 | `release_buzz_lock`     | ✅ (token-gated: same as above) | ✅ |
+| `select_next_song`      | ✅ (token-gated: same as above; added in migration 022) | ✅ |
 | `start_round`           | ❌ | ✅ |
 | `end_round`             | ❌ | ✅ |
 | `award_bonus`           | ❌ | ✅ |
 | `end_game`              | ❌ | ✅ |
 | `cleanup_expired_games` | ❌ | ✅ (called by `pg_cron`, not FastAPI) |
 
-Three RPCs are reachable from the browser: `buzz_in` (the buzzer hot path), and `award_attempt` / `release_buzz_lock` (the manager hot path, since migration 021). All three perform their auth check inside the SECURITY DEFINER function body. The `❌` rows are enforced by an explicit `REVOKE EXECUTE ... FROM anon, authenticated` (migration `020_lock_down_backend_rpcs.sql`) **in addition to** the `REVOKE ALL ... FROM PUBLIC` the creating migrations already do: on hosted Supabase the project bootstrap grants EXECUTE on every `public` function directly to `anon`/`authenticated`/`service_role`, so a `REVOKE FROM PUBLIC` alone leaves anon able to call them. Migration 020 also re-asserts `GRANT EXECUTE ... TO service_role` so FastAPI keeps working for the remaining backend-only RPCs.
+Four RPCs are reachable from the browser: `buzz_in` (the buzzer hot path), `award_attempt` / `release_buzz_lock` (the manager scoring hot path, since migration 021), and `select_next_song` (the "Next round" / "Start game" hot path, since migration 022). All four perform their auth check inside the SECURITY DEFINER function body. The `❌` rows are enforced by an explicit `REVOKE EXECUTE ... FROM anon, authenticated` (migration `020_lock_down_backend_rpcs.sql`) **in addition to** the `REVOKE ALL ... FROM PUBLIC` the creating migrations already do: on hosted Supabase the project bootstrap grants EXECUTE on every `public` function directly to `anon`/`authenticated`/`service_role`, so a `REVOKE FROM PUBLIC` alone leaves anon able to call them. Migration 020 also re-asserts `GRANT EXECUTE ... TO service_role` so FastAPI keeps working for the remaining backend-only RPCs.
 
 ### Why anon can SELECT any game
 

--- a/frontend/src/hooks/useSelectNextSong.test.ts
+++ b/frontend/src/hooks/useSelectNextSong.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/supabase", async () => {
+  const mod = await import("../test/supabaseMock");
+  return { supabase: mod.supabaseMock };
+});
+
+import { selectNextSongDirect } from "./useSelectNextSong";
+import { RpcError } from "./useManagerActions";
+import { resetSupabaseMock, setRpcResponse, supabaseMock } from "../test/supabaseMock";
+
+const TOKEN = "11111111-1111-1111-1111-111111111111";
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    round_id: "r-1",
+    round_number: 1,
+    song_id: "s-1",
+    song_title: "Bohemian Rhapsody",
+    song_artist: "Queen",
+    youtube_id: "abcdefghijk",
+    start_time: 0,
+    is_soundtrack: true,
+    source: "Wayne's World",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetSupabaseMock();
+});
+
+describe("selectNextSongDirect", () => {
+  it("calls select_next_song with the manager token and a null p_song_id by default", async () => {
+    setRpcResponse({ data: [row()], error: null });
+
+    const result = await selectNextSongDirect("ABCDEF", TOKEN);
+
+    expect(result.round_id).toBe("r-1");
+    expect(result.round_number).toBe(1);
+    expect(result.song.id).toBe("s-1");
+    expect(result.song.title).toBe("Bohemian Rhapsody");
+    expect(result.song.artist).toBe("Queen");
+    expect(result.song.source).toBe("Wayne's World");
+    expect(supabaseMock.rpc).toHaveBeenCalledWith("select_next_song", {
+      p_game_code: "ABCDEF",
+      p_manager_token: TOKEN,
+      p_song_id: null,
+    });
+  });
+
+  it("forwards an explicit song id for the manual-pick path", async () => {
+    setRpcResponse({ data: [row({ song_id: "s-manual" })], error: null });
+    await selectNextSongDirect("ABCDEF", TOKEN, "s-manual");
+    expect(supabaseMock.rpc).toHaveBeenCalledWith("select_next_song", {
+      p_game_code: "ABCDEF",
+      p_manager_token: TOKEN,
+      p_song_id: "s-manual",
+    });
+  });
+
+  it("throws RpcError carrying the PL/pgSQL message and sqlstate on a wrong token", async () => {
+    setRpcResponse({
+      data: null,
+      error: { message: "manager_token_required", code: "28000" },
+    });
+    await expect(selectNextSongDirect("ABCDEF", "wrong-token")).rejects.toMatchObject({
+      name: "RpcError",
+      message: "manager_token_required",
+      sqlstate: "28000",
+    });
+  });
+
+  it("throws RpcError when the pool is exhausted (no_more_songs)", async () => {
+    setRpcResponse({
+      data: null,
+      error: { message: "no_more_songs", code: "22023" },
+    });
+    await expect(selectNextSongDirect("ABCDEF", TOKEN)).rejects.toMatchObject({
+      name: "RpcError",
+      message: "no_more_songs",
+    });
+  });
+
+  it("raises RpcError when PostgREST returns an empty array (no row from RETURNS TABLE)", async () => {
+    setRpcResponse({ data: [], error: null });
+    await expect(selectNextSongDirect("ABCDEF", TOKEN)).rejects.toBeInstanceOf(RpcError);
+  });
+
+  it("preserves null source on the returned Song shape", async () => {
+    setRpcResponse({ data: [row({ source: null, is_soundtrack: false })], error: null });
+    const result = await selectNextSongDirect("ABCDEF", TOKEN);
+    expect(result.song.source).toBeNull();
+    expect(result.song.is_soundtrack).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useSelectNextSong.ts
+++ b/frontend/src/hooks/useSelectNextSong.ts
@@ -1,0 +1,62 @@
+// Manager "Next round" / "Start game" action: select_next_song called direct
+// from the browser via Supabase PostgREST RPC, same pattern as useBuzzer and
+// useManagerActions. Migration 022 moved the song picker + start_round
+// composition (plus the manager-token check) into one PL/pgSQL function so
+// the FastAPI hop is no longer needed for the most-pressed manager button.
+//
+// Latency before: ~500-900ms warm (two chained Render -> Frankfurt round-
+// trips), 2-30s spike on a cold Render dyno.
+// Latency after:  ~150ms (one direct browser -> Supabase RPC). Combined with
+// the optimistic "Loading next round..." toast from PR #88 the perceived
+// click-to-feedback gap is ~10ms.
+
+import { supabase } from "../lib/supabase";
+import { RpcError } from "./useManagerActions";
+import type { SelectSongResponse } from "../lib/types";
+
+interface SelectNextSongRow {
+  round_id: string;
+  round_number: number;
+  song_id: string;
+  song_title: string;
+  song_artist: string;
+  youtube_id: string;
+  start_time: number;
+  is_soundtrack: boolean;
+  source: string | null;
+}
+
+export async function selectNextSongDirect(
+  gameCode: string,
+  managerToken: string,
+  songId?: string,
+): Promise<SelectSongResponse> {
+  const { data, error } = await supabase.rpc("select_next_song", {
+    p_game_code: gameCode,
+    p_manager_token: managerToken,
+    // null vs undefined matters: PostgREST drops undefined-valued keys, which
+    // would route the call to a 2-arg overload that doesn't exist. Always
+    // send p_song_id explicitly so we hit the 3-arg signature.
+    p_song_id: songId ?? null,
+  });
+  if (error) {
+    throw new RpcError(error.message, error.code);
+  }
+  const row = (Array.isArray(data) ? data[0] : data) as SelectNextSongRow | null;
+  if (!row) {
+    throw new RpcError("select_next_song returned no row");
+  }
+  return {
+    round_id: row.round_id,
+    round_number: row.round_number,
+    song: {
+      id: row.song_id,
+      title: row.song_title,
+      artist: row.song_artist,
+      youtube_id: row.youtube_id,
+      start_time: row.start_time,
+      is_soundtrack: row.is_soundtrack,
+      source: row.source,
+    },
+  };
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -8,14 +8,12 @@ import {
   createSong,
   deleteSong,
   endGame,
-  endRound,
   getHealth,
   getSong,
   joinTeam,
   kickTeam,
   listGenres,
   listSongs,
-  selectSong,
   updateSong,
 } from "./api";
 import type { SongWritePayload } from "./types";
@@ -125,43 +123,9 @@ describe("api - public routes", () => {
 describe("api - manager-token routes", () => {
   const TOKEN = "22222222-2222-2222-2222-222222222222";
 
-  it("selectSong sends X-Manager-Token", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, {
-        round_id: "r1",
-        round_number: 1,
-        song: {
-          id: "s1",
-          title: "T",
-          artist: "A",
-          youtube_id: "abcdefghijk",
-          start_time: 0,
-          is_soundtrack: false,
-          source: null,
-        },
-      }),
-    );
-    const res = await selectSong("ABCDEF", TOKEN);
-    expect(res.round_id).toBe("r1");
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://localhost:8000/games/ABCDEF/select-song");
-    const headers = init.headers as Record<string, string>;
-    expect(headers["X-Manager-Token"]).toBe(TOKEN);
-  });
-
-  it("endRound POSTs to /end-round with the round id + token", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { round_id: "r1", ended_at: "2026-05-10T12:00:00Z" }),
-    );
-    const res = await endRound("ABCDEF", TOKEN, "r1");
-    expect(res.ended_at).toBe("2026-05-10T12:00:00Z");
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://localhost:8000/games/ABCDEF/end-round");
-    expect(init.method).toBe("POST");
-    const headers = init.headers as Record<string, string>;
-    expect(headers["X-Manager-Token"]).toBe(TOKEN);
-    expect(JSON.parse(init.body as string)).toEqual({ round_id: "r1" });
-  });
+  // selectSong + endRound REST wrappers were removed when migration 022
+  // moved the "Next round" flow to direct browser->Postgres RPC; see
+  // frontend/src/hooks/useSelectNextSong.ts for the replacement.
 
   it("awardBonus posts to /bonus with the chosen team", async () => {
     fetchMock.mockResolvedValueOnce(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,9 +6,7 @@ import type {
   BulkImportSummary,
   CreateGameResponse,
   EndGameResponse,
-  EndRoundResponse,
   Genre,
-  SelectSongResponse,
   Song,
   SongListResponse,
   SongWritePayload,
@@ -126,28 +124,6 @@ export function joinTeam(gameCode: string, name: string): Promise<Team> {
 
 export function createGame(body: { selected_genres: string[] }): Promise<CreateGameResponse> {
   return request("POST", "/games", { body });
-}
-
-export function selectSong(
-  gameCode: string,
-  managerToken: string,
-  songId?: string,
-): Promise<SelectSongResponse> {
-  return request("POST", `/games/${gameCode}/select-song`, {
-    managerToken,
-    body: songId ? { song_id: songId } : {},
-  });
-}
-
-export function endRound(
-  gameCode: string,
-  managerToken: string,
-  roundId: string,
-): Promise<EndRoundResponse> {
-  return request("POST", `/games/${gameCode}/end-round`, {
-    managerToken,
-    body: { round_id: roundId },
-  });
 }
 
 export function awardBonus(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -123,11 +123,6 @@ export interface AttemptResponse {
   artist_claimed_by: string | null;
 }
 
-export interface EndRoundResponse {
-  round_id: string;
-  ended_at: string;
-}
-
 export interface AwardBonusRequest {
   team_id: string;
   points?: number;

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -20,9 +20,7 @@ vi.mock("../lib/api", () => ({
       this.details = undefined;
     }
   },
-  selectSong: vi.fn(),
   awardBonus: vi.fn(),
-  endRound: vi.fn(),
   endGame: vi.fn(),
 }));
 
@@ -36,6 +34,10 @@ vi.mock("../hooks/useManagerActions", () => ({
   },
   awardAttemptDirect: vi.fn(),
   releaseBuzzLockDirect: vi.fn(),
+}));
+
+vi.mock("../hooks/useSelectNextSong", () => ({
+  selectNextSongDirect: vi.fn(),
 }));
 
 interface MockHandle {
@@ -66,8 +68,9 @@ vi.mock("../components/YouTubePlayer", () => ({
   }),
 }));
 
-import { awardBonus, endGame, endRound, selectSong } from "../lib/api";
+import { awardBonus, endGame } from "../lib/api";
 import { awardAttemptDirect, releaseBuzzLockDirect } from "../hooks/useManagerActions";
+import { selectNextSongDirect } from "../hooks/useSelectNextSong";
 import { ToastProvider } from "../context/ToastContext";
 import { setManagerToken, getManagerToken } from "../lib/managerToken";
 import {
@@ -89,10 +92,9 @@ beforeEach(() => {
   setManagerToken("ABCDEF", TOKEN);
   onReadyHandler = null;
   lastHandle = null;
-  vi.mocked(selectSong).mockReset();
+  vi.mocked(selectNextSongDirect).mockReset();
   vi.mocked(awardAttemptDirect).mockReset();
   vi.mocked(releaseBuzzLockDirect).mockReset();
-  vi.mocked(endRound).mockReset();
   vi.mocked(awardBonus).mockReset();
   vi.mocked(endGame).mockReset();
 });
@@ -160,13 +162,13 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(startBtn).toBeEnabled());
   });
 
-  it("calls selectSong with the manager token when Start is pressed", async () => {
+  it("calls selectNextSongDirect with the manager token when Start is pressed", async () => {
     setHydrate({
       game: makeActiveGame({ status: "waiting" }),
       teams: [],
       rounds: [],
     });
-    vi.mocked(selectSong).mockResolvedValueOnce({
+    vi.mocked(selectNextSongDirect).mockResolvedValueOnce({
       round_id: "r1",
       round_number: 1,
       song: {
@@ -188,7 +190,9 @@ describe("ManagerConsolePage", () => {
     });
     await waitFor(() => expect(screen.getByRole("button", { name: /start game/i })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: /start game/i }));
-    await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
+    // Optimistic toast fires before the RPC settles.
+    expect(screen.getByText(/loading next round/i)).toBeInTheDocument();
+    await waitFor(() => expect(selectNextSongDirect).toHaveBeenCalledWith("ABCDEF", TOKEN));
     await waitFor(() => expect(screen.getByText("Bohemian Rhapsody")).toBeInTheDocument());
     // The source string (e.g. soundtrack origin) renders alongside the artist name.
     expect(screen.getByText(/queen.*wayne's world/i)).toBeInTheDocument();
@@ -487,7 +491,7 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(screen.getByText(/manager_token_required/i)).toBeInTheDocument());
   });
 
-  it("Next round with a held buzz ends the round and selects a new song (no auto-score)", async () => {
+  it("Next round with a held buzz selects a new song via the direct RPC (no auto-score)", async () => {
     setHydrate({
       game: makeActiveGame({
         status: "playing",
@@ -497,11 +501,7 @@ describe("ManagerConsolePage", () => {
       teams: [makeTeam({ id: "t1" })],
       rounds: [makeRound({ id: "r1" })],
     });
-    vi.mocked(endRound).mockResolvedValueOnce({
-      round_id: "r1",
-      ended_at: "2026-05-10T12:00:00Z",
-    });
-    vi.mocked(selectSong).mockResolvedValueOnce({
+    vi.mocked(selectNextSongDirect).mockResolvedValueOnce({
       round_id: "r2",
       round_number: 2,
       song: {
@@ -522,10 +522,12 @@ describe("ManagerConsolePage", () => {
       onReadyHandler?.();
     });
     fireEvent.click(screen.getByTestId("start-round"));
-    // Optimistic toast fires before the network chain resolves.
+    // Optimistic toast fires before the network resolves.
     expect(screen.getByText(/loading next round/i)).toBeInTheDocument();
-    await waitFor(() => expect(endRound).toHaveBeenCalledWith("ABCDEF", TOKEN, "r1"));
-    await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
+    // select_next_song (mig 022) closes the prior round inside the function
+    // via start_round, so we only call ONE RPC from the browser. The held
+    // buzz is cleared as a side effect.
+    await waitFor(() => expect(selectNextSongDirect).toHaveBeenCalledWith("ABCDEF", TOKEN));
     // Score buttons no longer pre-fire award_attempt on Next; that responsibility
     // belongs to the per-button click. Manager must explicitly score before
     // advancing or accept the no-points outcome.
@@ -542,11 +544,7 @@ describe("ManagerConsolePage", () => {
       teams: [makeTeam({ id: "t1" })],
       rounds: [makeRound({ id: "r1" })],
     });
-    vi.mocked(endRound).mockResolvedValueOnce({
-      round_id: "r1",
-      ended_at: "2026-05-10T12:00:00Z",
-    });
-    vi.mocked(selectSong).mockResolvedValueOnce({
+    vi.mocked(selectNextSongDirect).mockResolvedValueOnce({
       round_id: "r2",
       round_number: 2,
       song: {
@@ -568,8 +566,7 @@ describe("ManagerConsolePage", () => {
     });
     fireEvent.click(screen.getByTestId("start-round"));
     expect(screen.getByText(/loading next round/i)).toBeInTheDocument();
-    await waitFor(() => expect(endRound).toHaveBeenCalledWith("ABCDEF", TOKEN, "r1"));
-    await waitFor(() => expect(selectSong).toHaveBeenCalledWith("ABCDEF", TOKEN));
+    await waitFor(() => expect(selectNextSongDirect).toHaveBeenCalledWith("ABCDEF", TOKEN));
     expect(awardAttemptDirect).not.toHaveBeenCalled();
   });
 
@@ -753,16 +750,17 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(lastHandle?.loadVideoById).toHaveBeenCalledWith("abcdefghijk", 12));
   });
 
-  it("shows a clear toast when the song pool is exhausted", async () => {
+  it("shows a clear toast when the song pool is exhausted (RpcError no_more_songs)", async () => {
     setHydrate({
       game: makeActiveGame({ status: "playing", round_number: 1 }),
       teams: [],
       rounds: [],
     });
-    const { ApiError } = await import("../lib/api");
-    const exhausted = new ApiError("conflict", "no songs left", 409);
-    Object.assign(exhausted, { details: { reason: "no_more_songs" } });
-    vi.mocked(selectSong).mockRejectedValueOnce(exhausted);
+    // select_next_song (mig 022) raises 'no_more_songs' (sqlstate 22023) when
+    // the selected-genres pool is exhausted; the PL/pgSQL message bubbles
+    // up as RpcError.message in the browser.
+    const { RpcError } = await import("../hooks/useManagerActions");
+    vi.mocked(selectNextSongDirect).mockRejectedValueOnce(new RpcError("no_more_songs", "22023"));
     renderConsole();
     await act(async () => {
       await fireSubscribed();

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -7,8 +7,9 @@ import { YouTubePlayer, type YouTubePlayerHandle } from "../components/YouTubePl
 import { useToast } from "../context/useToast";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { usePlayerReady } from "../hooks/usePlayerReady";
-import { ApiError, awardBonus, endGame, endRound, selectSong } from "../lib/api";
+import { ApiError, awardBonus, endGame } from "../lib/api";
 import { awardAttemptDirect, releaseBuzzLockDirect, RpcError } from "../hooks/useManagerActions";
+import { selectNextSongDirect } from "../hooks/useSelectNextSong";
 import { clearManagerToken, getManagerToken } from "../lib/managerToken";
 import { supabase } from "../lib/supabase";
 import type { Song } from "../lib/types";
@@ -95,6 +96,17 @@ export function ManagerConsolePage() {
         err.message === "title_already_claimed" ||
         err.message === "artist_already_claimed"
       ) {
+        return;
+      }
+      // 'no_more_songs' is the friendly user-facing error from select_next_song
+      // when the selected-genres pool is exhausted. Mirror the ApiError text
+      // above so the manager sees the same wording regardless of which path
+      // surfaced it.
+      if (err.message === "no_more_songs") {
+        toast(
+          "All songs in your selected genres have been played. End the game or start a new one with more genres.",
+          { variant: "error" },
+        );
         return;
       }
       toast(err.message, { variant: "error" });
@@ -221,26 +233,16 @@ export function ManagerConsolePage() {
 
   async function handleNextRound() {
     if (busy || !managerToken) return;
-    // Optimistic toast confirms the click immediately. The two-hop network
-    // chain (endRound + selectSong) still costs ~500ms today; PR-B collapses
-    // it into a single direct RPC, but the toast helps regardless.
+    // Optimistic toast confirms the click immediately. The single direct RPC
+    // (migration 022 -> select_next_song) replaces what used to be two
+    // chained Render hops (POST /end-round + POST /select-song), so the
+    // perceived latency is ~150ms instead of ~500-900ms. start_round, called
+    // inside the function, already closes any still-open prior round, so we
+    // don't need a separate end_round call.
     toast("Loading next round...", { variant: "info" });
     setBusy(true);
     try {
-      const round = state?.currentRound;
-      // Close the prior round (idempotent; safe even if start_round will close it).
-      if (round && state?.game.status === "playing") {
-        try {
-          await endRound(gameCode, managerToken, round.id);
-        } catch (err) {
-          // round_already_ended is fine; surface anything else.
-          if (!(err instanceof ApiError && err.status === 409)) {
-            reportError(err);
-            return;
-          }
-        }
-      }
-      const result = await selectSong(gameCode, managerToken);
+      const result = await selectNextSongDirect(gameCode, managerToken);
       setCurrentSong(result.song);
       await loadSongIntoPlayer(result.song);
     } catch (err) {

--- a/tests/db/test_rls_function_grants.py
+++ b/tests/db/test_rls_function_grants.py
@@ -2,12 +2,13 @@
 
 Spec: docs/security-rls.md §2.
 
-Three RPCs are callable by anon -- ``buzz_in`` (since migration 006), plus
-``award_attempt`` and ``release_buzz_lock`` (as of migration 021, which
-moved the manager-token check into the function bodies so the browser can
-call them directly without going through FastAPI). The remaining
-backend-only RPCs -- ``start_round``, ``end_round``, ``award_bonus``,
-``end_game``, ``cleanup_expired_games`` -- must still reject anon.
+Four RPCs are callable by anon -- ``buzz_in`` (since migration 006),
+``award_attempt`` and ``release_buzz_lock`` (as of migration 021), and
+``select_next_song`` (as of migration 022). Each does its own in-function
+manager-token check before performing any work, so the function-level
+EXECUTE grant is safe. The remaining backend-only RPCs -- ``start_round``,
+``end_round``, ``award_bonus``, ``end_game``, ``cleanup_expired_games`` --
+must still reject anon.
 """
 
 from __future__ import annotations
@@ -77,6 +78,25 @@ async def test_anon_can_execute_release_buzz_lock_but_token_check_runs(
     with pytest.raises(asyncpg.PostgresError) as exc:
         await anon_conn.execute(
             "SELECT release_buzz_lock($1, $2)", "ABCDEF", uuid.uuid4()
+        )
+    assert not isinstance(exc.value, asyncpg.InsufficientPrivilegeError)
+    assert exc.value.sqlstate in ("P0002", "28000")
+
+
+@pytest.mark.asyncio
+async def test_anon_can_execute_select_next_song_but_token_check_runs(
+    anon_conn: asyncpg.Connection,
+) -> None:
+    """Migration 022: anon CAN call select_next_song, but the in-function
+    manager_token check rejects forged calls. The error must be
+    ``manager_token_required`` (sqlstate 28000) or, if the game-code lookup
+    fires first, ``game_not_found`` (P0002). Either way the function ran --
+    it wasn't blocked at the grant gate."""
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await anon_conn.execute(
+            "SELECT select_next_song($1, $2, NULL::uuid)",
+            "ABCDEF",
+            uuid.uuid4(),
         )
     assert not isinstance(exc.value, asyncpg.InsufficientPrivilegeError)
     assert exc.value.sqlstate in ("P0002", "28000")
@@ -224,6 +244,14 @@ async def test_legacy_overloads_remain_locked(
             "p_artist integer, p_wrong_buzz integer, p_manager_token uuid",
         ),
         ("release_buzz_lock", "p_game_code text, p_manager_token uuid"),
+        # select_next_song: single tokenised signature added in migration 022.
+        # Migration 020's REVOKE loop pre-dates this function and doesn't
+        # touch it; the explicit GRANT in migration 022 is what makes anon
+        # EXECUTE land. The in-function token check provides the actual gate.
+        (
+            "select_next_song",
+            "p_game_code text, p_manager_token uuid, p_song_id uuid",
+        ),
     ],
 )
 async def test_anon_executable_rpc_grant_matrix(

--- a/tests/db/test_select_next_song.py
+++ b/tests/db/test_select_next_song.py
@@ -1,0 +1,296 @@
+"""select_next_song(): direct-RPC "Next round" / "Start game" path.
+
+Spec: docs/rpc-functions.md (§3b after this PR) and
+db/migrations/022_select_next_song_rpc.sql.
+
+The function takes (p_game_code text, p_manager_token uuid, p_song_id uuid)
+and returns one row describing the new round + song. p_song_id has a
+DEFAULT NULL; passing NULL means "pick a random unplayed song from the
+selected genres", passing a value means "use this exact song".
+
+Coverage:
+  * happy paths: random pick, manual pick
+  * token validation: right token, wrong token, null token
+  * game-state errors: game_not_found, game_ended, no_genres_selected
+  * song-pool errors: no_more_songs (random), song_not_found (manual)
+  * delegation behavior: closes any still-open prior round (start_round
+    already does this; we just confirm select_next_song composes correctly)
+  * genre filter: random pick never returns a song outside selected_genres
+    nor a song already played in this game
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import asyncpg
+import pytest
+
+from ._helpers import (
+    create_test_game,
+    create_test_song,
+    fetch_manager_token,
+)
+
+pytestmark = pytest.mark.needs_docker
+
+
+async def _genre_ids(conn: asyncpg.Connection, *slugs: str) -> list[uuid.UUID]:
+    rows = await conn.fetch(
+        "SELECT id FROM genres WHERE slug = ANY($1::text[]) ORDER BY slug", list(slugs)
+    )
+    return [r["id"] for r in rows]
+
+
+async def _attach_song_to_genre(
+    conn: asyncpg.Connection, song_id: uuid.UUID, genre_id: uuid.UUID
+) -> None:
+    await conn.execute(
+        "INSERT INTO song_genres (song_id, genre_id) VALUES ($1, $2) "
+        "ON CONFLICT (song_id, genre_id) DO NOTHING",
+        song_id,
+        genre_id,
+    )
+
+
+async def _set_selected_genres(
+    conn: asyncpg.Connection, game_code: str, genre_ids: list[uuid.UUID]
+) -> None:
+    await conn.execute(
+        "UPDATE active_games SET selected_genres = $1::uuid[] WHERE game_code = $2",
+        genre_ids,
+        game_code,
+    )
+
+
+async def _seed_game_with_one_song(
+    conn: asyncpg.Connection,
+    *,
+    status: str = "waiting",
+    extra_songs: int = 0,
+) -> tuple[str, list[uuid.UUID]]:
+    """Set up an active_games row + one genre + N+1 songs all in that genre.
+
+    Returns (game_code, [song_ids]). The conftest re-seeds genres on every
+    function-scoped fixture, so the canonical 'rock' slug is always present.
+    """
+    game_code = await create_test_game(conn, status=status)
+    rock = (await _genre_ids(conn, "rock"))[0]
+    await _set_selected_genres(conn, game_code, [rock])
+    songs: list[uuid.UUID] = []
+    for i in range(extra_songs + 1):
+        sid = await create_test_song(conn, youtube_id=uuid.uuid4().hex[:11])
+        await _attach_song_to_genre(conn, sid, rock)
+        songs.append(sid)
+    return game_code, songs
+
+
+async def _call(
+    conn: asyncpg.Connection,
+    game_code: str,
+    token: uuid.UUID,
+    song_id: uuid.UUID | None = None,
+) -> list[asyncpg.Record]:
+    return await conn.fetch(
+        "SELECT round_id, round_number, song_id, song_title, song_artist, "
+        "youtube_id, start_time, is_soundtrack, source "
+        "FROM select_next_song($1, $2, $3)",
+        game_code,
+        token,
+        song_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_random_pick_returns_a_song_in_selected_genres(db: asyncpg.Connection) -> None:
+    game_code, songs = await _seed_game_with_one_song(db, extra_songs=2)
+    token = await fetch_manager_token(db, game_code)
+
+    rows = await _call(db, game_code, token)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["song_id"] in songs
+    assert row["round_number"] == 1
+    assert row["round_id"] is not None
+
+    # active_games was advanced as a side effect (via start_round).
+    game = await db.fetchrow(
+        "SELECT status, round_number, current_round_id, current_song_id, "
+        "buzzed_team_id, locked_at FROM active_games WHERE game_code = $1",
+        game_code,
+    )
+    assert game["status"] == "playing"
+    assert game["round_number"] == 1
+    assert game["current_round_id"] == row["round_id"]
+    assert game["current_song_id"] == row["song_id"]
+    assert game["buzzed_team_id"] is None
+    assert game["locked_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_random_pick_excludes_already_played_songs(db: asyncpg.Connection) -> None:
+    """A song that was used in a prior round of this game must not be picked
+    again. Verified by seeding 2 songs, playing one, then asserting the next
+    random pick lands on the other."""
+    game_code, songs = await _seed_game_with_one_song(db, extra_songs=1)
+    token = await fetch_manager_token(db, game_code)
+    assert len(songs) == 2
+    first, second = songs
+
+    # Manually pick the first song.
+    rows = await _call(db, game_code, token, song_id=first)
+    assert rows[0]["song_id"] == first
+
+    # Random pick must now choose the only remaining unplayed song.
+    rows = await _call(db, game_code, token)
+    assert rows[0]["song_id"] == second
+    assert rows[0]["round_number"] == 2
+
+
+@pytest.mark.asyncio
+async def test_manual_pick_uses_supplied_song(db: asyncpg.Connection) -> None:
+    """Passing p_song_id forces that exact song, even if it's outside the
+    selected genres -- mirrors the legacy REST manual-pick semantics."""
+    game_code, _ = await _seed_game_with_one_song(db)
+    token = await fetch_manager_token(db, game_code)
+    # Create a song deliberately NOT attached to the rock genre.
+    detached = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11])
+
+    rows = await _call(db, game_code, token, song_id=detached)
+    assert rows[0]["song_id"] == detached
+
+
+@pytest.mark.asyncio
+async def test_random_pick_advances_round_number(db: asyncpg.Connection) -> None:
+    game_code, _ = await _seed_game_with_one_song(db, extra_songs=2)
+    token = await fetch_manager_token(db, game_code)
+
+    rows1 = await _call(db, game_code, token)
+    rows2 = await _call(db, game_code, token)
+    rows3 = await _call(db, game_code, token)
+    assert rows1[0]["round_number"] == 1
+    assert rows2[0]["round_number"] == 2
+    assert rows3[0]["round_number"] == 3
+    # Round ids are distinct.
+    assert len({r[0]["round_id"] for r in (rows1, rows2, rows3)}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Composition with start_round: prior open round is closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_closes_prior_open_round(db: asyncpg.Connection) -> None:
+    """start_round (called inside select_next_song) closes any still-open
+    prior round defensively. We assert that observed behavior to lock the
+    composition contract."""
+    game_code, _ = await _seed_game_with_one_song(db, extra_songs=2)
+    token = await fetch_manager_token(db, game_code)
+
+    rows1 = await _call(db, game_code, token)
+    prior_round = rows1[0]["round_id"]
+
+    # Advance without explicit end_round.
+    await _call(db, game_code, token)
+
+    ended_at = await db.fetchval("SELECT ended_at FROM game_rounds WHERE id = $1", prior_round)
+    assert ended_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Token validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_raises_manager_token_required(db: asyncpg.Connection) -> None:
+    game_code, _ = await _seed_game_with_one_song(db)
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, uuid.uuid4())
+    assert exc.value.sqlstate == "28000"
+    assert "manager_token_required" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_null_token_raises_manager_token_required(db: asyncpg.Connection) -> None:
+    game_code, _ = await _seed_game_with_one_song(db)
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await db.execute(
+            "SELECT select_next_song($1, NULL::uuid, NULL::uuid)",
+            game_code,
+        )
+    assert exc.value.sqlstate == "28000"
+
+
+# ---------------------------------------------------------------------------
+# Game-state errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_game_raises_game_not_found(db: asyncpg.Connection) -> None:
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, "ZZZZZZ", uuid.uuid4())
+    assert exc.value.sqlstate == "P0002"
+
+
+@pytest.mark.asyncio
+async def test_game_ended_raises_game_ended(db: asyncpg.Connection) -> None:
+    game_code, _ = await _seed_game_with_one_song(db)
+    await db.execute(
+        "UPDATE active_games SET ended_at = now(), status = 'ended' WHERE game_code = $1",
+        game_code,
+    )
+    token = await fetch_manager_token(db, game_code)
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert exc.value.sqlstate == "P0001"
+    assert "game_ended" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_no_genres_selected_raises(db: asyncpg.Connection) -> None:
+    game_code = await create_test_game(db)
+    # Default selected_genres is empty/null; do not set it.
+    token = await fetch_manager_token(db, game_code)
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert exc.value.sqlstate == "22023"
+    assert "no_genres_selected" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Song-pool errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_more_songs_raises_when_pool_exhausted(db: asyncpg.Connection) -> None:
+    """Seed exactly one song in the selected genre, play it, then the next
+    random pick must raise no_more_songs."""
+    game_code, songs = await _seed_game_with_one_song(db)
+    token = await fetch_manager_token(db, game_code)
+    assert len(songs) == 1
+
+    await _call(db, game_code, token)  # consumes the only song
+
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert exc.value.sqlstate == "22023"
+    assert "no_more_songs" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_manual_pick_with_unknown_song_raises(db: asyncpg.Connection) -> None:
+    game_code, _ = await _seed_game_with_one_song(db)
+    token = await fetch_manager_token(db, game_code)
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token, song_id=uuid.uuid4())
+    assert exc.value.sqlstate == "P0002"
+    assert "song_not_found" in str(exc.value)


### PR DESCRIPTION
## Summary
- New PL/pgSQL function `select_next_song(p_game_code text, p_manager_token uuid, p_song_id uuid DEFAULT NULL)` in `db/migrations/022_select_next_song_rpc.sql`. Token check (mirrors mig 021 pattern), then a SQL port of `backend/app/services/song_picker.py` (equal-weight per genre, excludes already-played), then delegates to the existing `start_round` (which already closes any prior open round). GRANT EXECUTE to anon/authenticated/service_role. Already applied to prod (`jvfddxuaqcsrguibkymp`); function verified in pg_proc with anon EXECUTE = true, SECURITY DEFINER = true.
- New frontend hook `frontend/src/hooks/useSelectNextSong.ts` mirroring `useManagerActions.ts`. `handleNextRound` in `ManagerConsolePage.tsx` collapses from the two-hop `endRound + selectSong` chain to one `selectNextSongDirect` call. The optimistic "Loading next round..." toast (added in PR #88) stays in place.
- Removed the now-unused `selectSong` / `endRound` REST wrappers from `frontend/src/lib/api.ts` and the corresponding tests. The FastAPI routes themselves (`POST /games/{code}/select-song` and `/end-round`) stay in place as a transitional rollback path; once this PR has soaked in, a follow-up cleanup can drop the routes, the `_start_round_blocking` / `_end_round_blocking` helpers, and `backend/app/services/song_picker.py`.
- Docs: `rpc-functions.md` gains a new §3c for `select_next_song` and the §6 Function ↔ Caller Reference Matrix is updated. `security-rls.md` adds the new RPC to the grants table.
- Expected latency: ~500-900ms warm (two chained Render -> Frankfurt round-trips, with a 2-30s spike on a cold Render dyno) → ~150ms (one direct browser -> Supabase RPC). Combined with the optimistic toast, click-to-feedback gap is effectively immediate.

## Test plan
- [x] Migration 022 applied to prod Supabase via `supabase db query --linked`; function inventory verified.
- [x] `cd backend && pytest tests/db/test_select_next_song.py tests/db/test_rls_function_grants.py tests/db/test_start_round.py tests/db/test_award_attempt.py --no-cov` — 66/66 pass.
- [x] `cd backend && pytest -m "not needs_docker and not stress" --no-cov` — 15/15 pass.
- [x] `cd frontend && npm run typecheck && npm run lint && npm run format:check && npm run test:run` — 256/256 vitest, no other errors.
- [x] `cd backend && ruff check app && ruff format --check app && mypy app` — clean.
- [ ] CI green on this PR (frontend + backend + e2e).
- [ ] Manual smoke after merge: in the manager console on prod, press "Start game" / "Next round" and confirm in DevTools Network panel the request now goes to `*.supabase.co/rest/v1/rpc/select_next_song` (not `api.soundclash.org/games/.../select-song`). Measure round-trip; expect a meaningful drop.
- [ ] Manual security check after merge: from the manager-tab DevTools console, call `await supabase.rpc('select_next_song', { p_game_code: '<code>', p_manager_token: '00000000-0000-0000-0000-000000000000', p_song_id: null })` and confirm it returns the `manager_token_required` error rather than picking a song.