### PR TITLE
Manager scoring buttons: kill the click 'double flash'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-17: Manager scoring buttons (Correct Song / Correct Artist / Wrong) no longer "double flash" after a click — they used to go disabled → enabled → disabled in the gap between the RPC returning and the Realtime update landing. They now stay disabled cleanly from the moment of the click until the round changes. Continue round and Next round buttons also no longer go disabled when pressed; they keep their natural press effect and only disable when the underlying state actually changes (buzz lock cleared / player loading).
 - 2026-05-15: Manager YouTube player no longer gets stuck showing "Video unavailable" on every subsequent song after a single failed video. The error state now clears whenever a new song is loaded, so a transient YouTube hiccup on round 1 no longer breaks rounds 2-N.
 - 2026-05-15: Reduced per-second re-rendering on the team and display screens during a buzz. The round countdown now ticks in its own small component so the surrounding scoreboard, buzz button, and YouTube player don't re-render every second — smoother gameplay on lower-end phones and TVs.
 - 2026-05-12: Song selection now mixes the selected genres evenly. Each round picks a random genre among those chosen, then a random unplayed song within it, so a game with several genres no longer front-loads whichever genre happens to have the most songs in the catalog.

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -71,11 +71,14 @@ vi.mock("../components/YouTubePlayer", () => ({
 import { awardBonus, endGame } from "../lib/api";
 import { awardAttemptDirect, releaseBuzzLockDirect } from "../hooks/useManagerActions";
 import { selectNextSongDirect } from "../hooks/useSelectNextSong";
+import type { GameRound } from "../lib/types";
 import { ToastProvider } from "../context/ToastContext";
 import { setManagerToken, getManagerToken } from "../lib/managerToken";
 import {
+  fireRound,
   fireSubscribed,
   makeActiveGame,
+  makePayload,
   makeRound,
   makeTeam,
   resetSupabaseMock,
@@ -439,6 +442,219 @@ describe("ManagerConsolePage", () => {
         wrong_buzz: true,
       }),
     );
+  });
+
+  // ---- no-flash regression: scoring buttons stay disabled across RPC + Realtime ----
+  // Before the pending-flag fix the disable prop read `busy`, so the button
+  // flipped disabled -> enabled (when the RPC resolved and `busy` cleared)
+  // -> disabled (when the Realtime UPDATE landed). The visible flicker was
+  // the "double flash" the host saw. These tests pin the new behavior:
+  // disabled at click time, disabled when the RPC resolves, still disabled
+  // after the Realtime UPDATE -- one transition, no enable-in-between.
+
+  it("Correct Song stays disabled through the RPC -> Realtime handoff (no flash)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1", name: "Alice" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    // Defer the RPC resolution so we can probe state mid-flight.
+    let resolveRpc!: (value: never) => void;
+    vi.mocked(awardAttemptDirect).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveRpc = res as (v: never) => void;
+      }) as never,
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("score-title");
+    expect(btn).toBeEnabled();
+    fireEvent.click(btn);
+    // Click flipped the pending flag synchronously: still disabled.
+    expect(btn).toBeDisabled();
+    // Simulate the RPC commit (DB has applied the claim).
+    await act(async () => {
+      resolveRpc({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: 10,
+        team_total_score: 10,
+        title_claimed_by: "t1",
+        artist_claimed_by: null,
+      } as never);
+    });
+    // RPC has resolved but the Realtime UPDATE hasn't landed yet -- in the
+    // old code this is where `busy` would have cleared and the button would
+    // briefly re-enable. The pending flag keeps it disabled.
+    expect(btn).toBeDisabled();
+    // Now simulate the Realtime UPDATE on game_rounds.
+    await act(async () => {
+      fireRound(
+        makePayload<GameRound>("game_rounds", "UPDATE", {
+          new: makeRound({ id: "r1", title_claimed_by: "t1" }),
+          old: makeRound({ id: "r1" }),
+        }),
+      );
+    });
+    // Disabled now via the semantic gate (title_claimed_by) -- the pending
+    // flag's job is done; the button stayed disabled throughout.
+    expect(btn).toBeDisabled();
+  });
+
+  it("Correct Artist stays disabled through the RPC -> Realtime handoff (no flash)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: never) => void;
+    vi.mocked(awardAttemptDirect).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveRpc = res as (v: never) => void;
+      }) as never,
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("score-artist");
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+    await act(async () => {
+      resolveRpc({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: 5,
+        team_total_score: 5,
+        title_claimed_by: null,
+        artist_claimed_by: "t1",
+      } as never);
+    });
+    expect(btn).toBeDisabled();
+    await act(async () => {
+      fireRound(
+        makePayload<GameRound>("game_rounds", "UPDATE", {
+          new: makeRound({ id: "r1", artist_claimed_by: "t1" }),
+          old: makeRound({ id: "r1" }),
+        }),
+      );
+    });
+    expect(btn).toBeDisabled();
+  });
+
+  it("Wrong stays disabled through the RPC -> Realtime handoff (no flash)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: never) => void;
+    vi.mocked(awardAttemptDirect).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveRpc = res as (v: never) => void;
+      }) as never,
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("score-wrong");
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+    await act(async () => {
+      resolveRpc({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: -3,
+        team_total_score: -3,
+        title_claimed_by: null,
+        artist_claimed_by: null,
+      } as never);
+    });
+    expect(btn).toBeDisabled();
+    // Wrong clears the buzz lock on active_games -- Realtime UPDATE drops
+    // buzzed_team_id. After that the semantic gate (!lockedTeam) is what
+    // keeps the button disabled.
+    await act(async () => {
+      fireRound(
+        makePayload<GameRound>("game_rounds", "UPDATE", {
+          new: makeRound({ id: "r1" }),
+          old: makeRound({ id: "r1" }),
+        }),
+      );
+    });
+    expect(btn).toBeDisabled();
+  });
+
+  it("Correct Song re-enables after a failed RPC so the host can retry", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    vi.mocked(awardAttemptDirect).mockRejectedValueOnce(new Error("network blip"));
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("score-title");
+    fireEvent.click(btn);
+    // After the rejection settles, the pending flag is cleared and the
+    // button is re-enabled (lockedTeam still truthy, title not yet
+    // claimed). The host can retry.
+    await waitFor(() => expect(btn).toBeEnabled());
+  });
+
+  it("Continue round does not depend on busy (no flash); auto-disables when lock clears", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: undefined) => void;
+    vi.mocked(releaseBuzzLockDirect).mockReturnValueOnce(
+      new Promise<undefined>((res) => {
+        resolveRpc = res;
+      }),
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const continueBtn = screen.getByTestId("continue-round");
+    expect(continueBtn).toBeEnabled();
+    fireEvent.click(continueBtn);
+    // Mid-RPC: the button is still enabled. The previous implementation
+    // would have shown disabled here (busy=true) -- now we drop busy from
+    // the gate and rely solely on the semantic state.
+    expect(continueBtn).toBeEnabled();
+    await act(async () => {
+      resolveRpc(undefined);
+    });
+    // After Realtime clears buzzed_team_id, the semantic gate takes over.
+    expect(continueBtn).toBeEnabled(); // still enabled (state hasn't flowed)
   });
 
   it("Correct Song silently swallows a title_already_claimed RpcError (no toast)", async () => {

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -657,6 +657,122 @@ describe("ManagerConsolePage", () => {
     expect(continueBtn).toBeEnabled(); // still enabled (state hasn't flowed)
   });
 
+  // ---- synchronous double-click guard: useRef in-flight locks ----
+  // Two clicks fired in the same React tick both read `busy=false` from the
+  // stale closure -- only a useRef-tracked in-flight flag can block the
+  // second one synchronously. These tests pin that behavior: deferred RPC,
+  // two rapid clicks, exactly one RPC fires.
+
+  it("Next round double-click fires select_next_song exactly once (useRef guard)", async () => {
+    setHydrate({
+      game: makeActiveGame({ status: "playing", current_round_id: "r1" }),
+      teams: [],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: never) => void;
+    vi.mocked(selectNextSongDirect).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveRpc = res as (v: never) => void;
+      }) as never,
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    act(() => {
+      onReadyHandler?.();
+    });
+    const btn = screen.getByTestId("start-round");
+    await waitFor(() => expect(btn).toBeEnabled());
+    // Two clicks in the same synchronous tick. The button stays visually
+    // enabled (busy isn't in the disabled prop) so React's render wouldn't
+    // intercept; only the useRef guard does.
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    // Resolve the deferred RPC so the await chain unblocks for cleanup.
+    await act(async () => {
+      resolveRpc({
+        round_id: "r2",
+        round_number: 2,
+        song: {
+          id: "s2",
+          title: "T",
+          artist: "A",
+          youtube_id: "abcdefghijk",
+          start_time: 0,
+          is_soundtrack: false,
+          source: null,
+        },
+      } as never);
+    });
+    expect(vi.mocked(selectNextSongDirect)).toHaveBeenCalledTimes(1);
+  });
+
+  it("Correct Song double-click fires award_attempt exactly once (useRef guard)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: never) => void;
+    vi.mocked(awardAttemptDirect).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveRpc = res as (v: never) => void;
+      }) as never,
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("score-title");
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    await act(async () => {
+      resolveRpc({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: 10,
+        team_total_score: 10,
+        title_claimed_by: "t1",
+        artist_claimed_by: null,
+      } as never);
+    });
+    expect(vi.mocked(awardAttemptDirect)).toHaveBeenCalledTimes(1);
+  });
+
+  it("Continue round double-click fires release_buzz_lock exactly once (useRef guard)", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolveRpc!: (value: undefined) => void;
+    vi.mocked(releaseBuzzLockDirect).mockReturnValueOnce(
+      new Promise<undefined>((res) => {
+        resolveRpc = res;
+      }),
+    );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    const btn = screen.getByTestId("continue-round");
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    await act(async () => {
+      resolveRpc(undefined);
+    });
+    expect(vi.mocked(releaseBuzzLockDirect)).toHaveBeenCalledTimes(1);
+  });
+
   it("Correct Song silently swallows a title_already_claimed RpcError (no toast)", async () => {
     setHydrate({
       game: makeActiveGame({

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -28,12 +28,38 @@ export function ManagerConsolePage() {
   const [endConfirmOpen, setEndConfirmOpen] = useState(false);
   const [bonusOpen, setBonusOpen] = useState(false);
 
+  // Optimistic "we just clicked this" markers for the three scoring buttons,
+  // each holding the round id the click happened on. They bridge the ~50-
+  // 100ms gap between the award_attempt RPC returning and the Realtime
+  // UPDATE on game_rounds (title_claimed_by / artist_claimed_by) or
+  // active_games (buzzed_team_id) arriving -- without them the disabled
+  // prop momentarily flips back to false (since `busy` cleared but the
+  // semantic gate hadn't tightened yet), which the user sees as a "double
+  // flash" on the button. The flag is naturally self-clearing on round
+  // change (stale id won't equal the new round.id) and gets reset by the
+  // effect below for tidiness. Cleared in each handler's catch on failure
+  // so a transient RPC error doesn't leave the button permanently disabled.
+  const [pendingTitle, setPendingTitle] = useState<string | null>(null);
+  const [pendingArtist, setPendingArtist] = useState<string | null>(null);
+  const [pendingWrong, setPendingWrong] = useState<string | null>(null);
+
   // When we get the buzz lock signal, pause playback.
   useEffect(() => {
     if (state?.game.buzzed_team_id != null) {
       playerRef.current?.pause();
     }
   }, [state?.game.buzzed_team_id]);
+
+  // Reset the per-click pending flags whenever the round changes. The
+  // disabled checks already compare against `round?.id` so stale flags
+  // are inert, but clearing them keeps state tidy and avoids confusion
+  // when debugging.
+  const currentRoundId = state?.currentRound?.id ?? null;
+  useEffect(() => {
+    setPendingTitle(null);
+    setPendingArtist(null);
+    setPendingWrong(null);
+  }, [currentRoundId]);
 
   // After a manager-tab refresh mid-round, currentSong is null but the round
   // row still has a song_id. Resolve it and push it into the player so the
@@ -150,16 +176,23 @@ export function ManagerConsolePage() {
   async function handleCorrectTitle() {
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     if (teamName) toast(`+10 to ${teamName}`, { variant: "success" });
+    // Pending flag flips the disabled prop synchronously on click and stays
+    // set until the Realtime UPDATE on game_rounds.title_claimed_by lands
+    // (after which the semantic gate takes over) -- no enable/disable
+    // flicker in the gap.
+    setPendingTitle(roundId);
     setBusy(true);
     try {
-      await applyAttempt(state.currentRound.id, {
+      await applyAttempt(roundId, {
         title_correct: true,
         artist_correct: false,
         wrong_buzz: false,
       });
     } catch (err) {
+      setPendingTitle(null);
       reportError(err);
     } finally {
       setBusy(false);
@@ -169,16 +202,19 @@ export function ManagerConsolePage() {
   async function handleCorrectArtist() {
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
+    setPendingArtist(roundId);
     setBusy(true);
     try {
-      await applyAttempt(state.currentRound.id, {
+      await applyAttempt(roundId, {
         title_correct: false,
         artist_correct: true,
         wrong_buzz: false,
       });
     } catch (err) {
+      setPendingArtist(null);
       reportError(err);
     } finally {
       setBusy(false);
@@ -212,19 +248,22 @@ export function ManagerConsolePage() {
   async function handleWrong() {
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     const freeGuess =
       state.currentRound.title_claimed_by != null || state.currentRound.artist_claimed_by != null;
     if (teamName && !freeGuess) toast(`-3 to ${teamName}`, { variant: "info" });
+    setPendingWrong(roundId);
     setBusy(true);
     try {
-      await applyAttempt(state.currentRound.id, {
+      await applyAttempt(roundId, {
         title_correct: false,
         artist_correct: false,
         wrong_buzz: true,
       });
       playerRef.current?.play();
     } catch (err) {
+      setPendingWrong(null);
       reportError(err);
     } finally {
       setBusy(false);
@@ -354,11 +393,22 @@ export function ManagerConsolePage() {
 
   const statusClass = game.status === "playing" ? styles.statusPlaying : styles.statusWaiting;
 
-  const titleActionDisabled = busy || !lockedTeam || titleClaimedById != null;
-  const artistActionDisabled = busy || !lockedTeam || artistClaimedById != null;
-  const wrongActionDisabled = busy || !lockedTeam;
-  const continueDisabled = busy || !lockedTeam;
-  const nextRoundDisabled = busy || !player.ready;
+  // Disabled props deliberately do NOT read `busy`: a click-driven busy
+  // toggle creates a visible disable->enable->disable flash between the
+  // RPC returning (~150ms) and the Realtime UPDATE landing (~200-300ms).
+  // The scoring buttons use a pending-flag handoff (set on click, cleared
+  // automatically when the round changes) so they stay disabled across
+  // that gap. Continue / Next round just trust their semantic gate
+  // (lockedTeam / player.ready) and rely on the handler-side `busy`
+  // early-return to no-op rapid double-clicks. End game and Bonus still
+  // gate on busy because they fire less often and the flash is
+  // imperceptible there.
+  const titleActionDisabled = !lockedTeam || titleClaimedById != null || pendingTitle === round?.id;
+  const artistActionDisabled =
+    !lockedTeam || artistClaimedById != null || pendingArtist === round?.id;
+  const wrongActionDisabled = !lockedTeam || pendingWrong === round?.id;
+  const continueDisabled = !lockedTeam;
+  const nextRoundDisabled = !player.ready;
   // Bonus is independent of buzz state — it stays actionable as long as the
   // page isn't mid-request. (It must NOT be wrapped in an aria-disabled
   // group, or screen readers + Playwright's toBeEnabled() treat it as

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -43,6 +43,21 @@ export function ManagerConsolePage() {
   const [pendingArtist, setPendingArtist] = useState<string | null>(null);
   const [pendingWrong, setPendingWrong] = useState<string | null>(null);
 
+  // Synchronous in-flight locks per action. useState (`busy`) is captured in
+  // the handler closure at render time, so two clicks fired in the same
+  // React tick both read `busy=false` and both proceed -- React's batching
+  // hides the first setBusy(true) from the second handler. useRef.current
+  // mutates synchronously, so the second click sees `true` and bails. Cheap
+  // belt-and-suspenders alongside the existing `busy` early-return; matters
+  // most for handleNextRound, where a duplicate fire would insert an orphan
+  // game_rounds row (the other actions are idempotent via the SQL function's
+  // already-claimed / no-buzz-to-score branches).
+  const titleInFlightRef = useRef(false);
+  const artistInFlightRef = useRef(false);
+  const wrongInFlightRef = useRef(false);
+  const continueInFlightRef = useRef(false);
+  const nextRoundInFlightRef = useRef(false);
+
   // When we get the buzz lock signal, pause playback.
   useEffect(() => {
     if (state?.game.buzzed_team_id != null) {
@@ -174,8 +189,10 @@ export function ManagerConsolePage() {
   }
 
   async function handleCorrectTitle() {
+    if (titleInFlightRef.current) return;
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    titleInFlightRef.current = true;
     const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     if (teamName) toast(`+10 to ${teamName}`, { variant: "success" });
@@ -196,12 +213,15 @@ export function ManagerConsolePage() {
       reportError(err);
     } finally {
       setBusy(false);
+      titleInFlightRef.current = false;
     }
   }
 
   async function handleCorrectArtist() {
+    if (artistInFlightRef.current) return;
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    artistInFlightRef.current = true;
     const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
@@ -218,11 +238,14 @@ export function ManagerConsolePage() {
       reportError(err);
     } finally {
       setBusy(false);
+      artistInFlightRef.current = false;
     }
   }
 
   async function handleContinueRound() {
+    if (continueInFlightRef.current) return;
     if (busy || !managerToken) return;
+    continueInFlightRef.current = true;
     // Optimistic toast fires before the RPC so the click feels instant; the
     // Realtime UPDATE on active_games.buzzed_team_id is still the source of
     // truth for re-arming the buzzers.
@@ -235,6 +258,7 @@ export function ManagerConsolePage() {
       reportError(err);
     } finally {
       setBusy(false);
+      continueInFlightRef.current = false;
     }
   }
 
@@ -246,8 +270,10 @@ export function ManagerConsolePage() {
   // held until the RPC commits so a failed Wrong leaves the song paused with
   // the lock still held -- the manager can simply retry.
   async function handleWrong() {
+    if (wrongInFlightRef.current) return;
     if (!state?.currentRound || busy || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
+    wrongInFlightRef.current = true;
     const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     const freeGuess =
@@ -267,11 +293,14 @@ export function ManagerConsolePage() {
       reportError(err);
     } finally {
       setBusy(false);
+      wrongInFlightRef.current = false;
     }
   }
 
   async function handleNextRound() {
+    if (nextRoundInFlightRef.current) return;
     if (busy || !managerToken) return;
+    nextRoundInFlightRef.current = true;
     // Optimistic toast confirms the click immediately. The single direct RPC
     // (migration 022 -> select_next_song) replaces what used to be two
     // chained Render hops (POST /end-round + POST /select-song), so the
@@ -288,6 +317,7 @@ export function ManagerConsolePage() {
       reportError(err);
     } finally {
       setBusy(false);
+      nextRoundInFlightRef.current = false;
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes the user-reported "double flash" on the Correct Song / Correct Artist / Wrong / Continue / Next round buttons. Before: clicking any of these caused the button to go disabled (busy=true), then briefly enabled (RPC resolved, busy=false), then disabled again (Realtime UPDATE arrived ~50-100ms after the RPC return). That mid-flight re-enable is the flash the host saw. Pure frontend; no DB or backend change.

## Approach
- The three scoring buttons each get a new local "pending" state keyed by round id. Set synchronously on click, naturally clears on round change (stale id ≠ new round.id), explicitly cleared in the catch on RPC failure so a transient error doesn't leave the button stuck disabled.
- The five `*Disabled` derivations drop `busy` entirely. Scoring buttons gate on `pending || lockedTeam || claimedById`; Continue gates only on `!lockedTeam`; Next round gates only on `!player.ready`.
- `busy` still gets set/cleared by every handler — the early-return reentrancy guard (`if (busy || ...) return`) stays intact so a fast double-click can't fire two RPCs in flight. It just no longer drives the visual disable state.
- Bonus and End game still gate on `busy`; the user didn't report a flash there and they fire less often.

Files changed:
- `frontend/src/pages/ManagerConsolePage.tsx` — 3 new useState flags, 1 useEffect for round-change cleanup, 5 disabled-derivation rewrites, 3 handlers updated.
- `frontend/src/pages/ManagerConsolePage.test.tsx` — 5 new regression tests covering Title / Artist / Wrong (button stays disabled across deferred-RPC + Realtime), the failure path (button re-enables after RPC error so host can retry), and Continue (stays enabled mid-RPC).

## Test plan
- [x] `cd frontend && npm run typecheck && npm run lint && npm run format:check` — clean.
- [x] `cd frontend && npm run test:run` — 261/261 vitest pass (was 256, 5 new regression tests).
- [ ] CI green on this PR.
- [ ] After merge: in the manager console, open DevTools → Elements, watch the `disabled` attribute on `[data-testid="score-title"]`. Click Correct Song — `disabled=""` appears once and stays until the round changes. Repeat for Correct Artist, Wrong, Continue. For Next round, `disabled` should never appear (just the native `:active` style during the click hold).