### PR TITLE
E2E: scope display team-name asserts by data-team-id

### DIFF
--- a/tests/e2e/full_game.spec.ts
+++ b/tests/e2e/full_game.spec.ts
@@ -19,7 +19,10 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
   const displayCtx = await browser.newContext();
   const display = await displayCtx.newPage();
   await display.goto(`/display/${code}`);
-  await expect(display.getByText("Solo")).toBeVisible();
+  // The team appears in the live scoreboard row on the display screen during
+  // play. After the game ends, the same name shows on the podium card AND in
+  // the new full-scoreboard list, so scope by data-team-id to stay unique.
+  await expect(display.locator(`[data-team-id]:has-text("Solo")`).first()).toBeVisible();
 
   type RoundPoints = { title: boolean; artist: boolean; expected: number };
   const rounds: RoundPoints[] = [
@@ -69,7 +72,12 @@ test("3-round game: award accumulates and podium renders on display", async ({ b
 
   await expect(endScreenHeading).toBeVisible({ timeout: 15_000 });
   await expect(display.getByText("WINNER")).toBeVisible();
-  await expect(display.getByText("Solo")).toBeVisible();
+  // "Solo" appears twice on the EndScreen: on the gold podium card and in
+  // the always-on full-scoreboard list. Either one being visible proves the
+  // team rendered; scope to the scoreboard row for an unambiguous match.
+  await expect(
+    display.getByTestId("final-scoreboard").locator(`[data-team-id]:has-text("Solo")`),
+  ).toBeVisible();
 
   await expect(display.getByText(`${runningTotal}pts`).first()).toBeVisible({
     timeout: 5_000,


### PR DESCRIPTION
## Summary

- The post-merge E2E run on `main` for #95 failed Playwright strict mode: `display.getByText("Solo")` on the Final Results page now matches two elements (the podium card and the new full-scoreboard row).
- Scope both team-name visibility asserts to `[data-team-id]:has-text(...)` so each match is unambiguous.
- No app behavior change — just selector tightening.

## Test plan

- [ ] CI `E2E / Playwright multi-context` passes (the previously failing job).
- [x] No production code changed; full game still plays end-to-end (verified manually on #95: 4-team / 10-round game with distinct scores rendered correctly).
- [x] `npm run test:run` + `npm run typecheck` + `npm run lint` clean on the parent change.