### PR TITLE
Drop five empty genres from catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Removed
 
+- 2026-05-23: Dropped five unused genres from the catalog (Classical, Country, Jazz, Metal, R&B). They were seeded but never had songs attached, so the host's "Pick genres" picker and the admin filter no longer offer them. The remaining ten genres cover everything in the catalog.
 - 2026-05-16: Retired the legacy `POST /games/{code}/select-song` and `POST /games/{code}/end-round` REST endpoints, the Python song-picker service, and the un-tokenised legacy overloads of `award_attempt` / `release_buzz_lock` in the database. None of these had a caller in the running stack after the direct-RPC migrations (021, 022) stabilised. No user-visible behaviour change; the cleanup is dead-code hygiene.
 - 2026-05-10: One-buzz-per-round model is gone, along with the `/award-points` endpoint. Replaced by the multi-buzz model with `/attempt` (per-buzz scoring) + `/end-round` (close the round explicitly).
 - 2026-05-10: Removed the "Home" and "Restart song" buttons from the manager console. The header trims to just "End game"; the round-controls toolbar trims to "End round" + "Next round" / "Start game".

--- a/db/migrations/024_drop_empty_genres.sql
+++ b/db/migrations/024_drop_empty_genres.sql
@@ -1,0 +1,18 @@
+-- 024_drop_empty_genres.sql
+-- Drop five genres that have zero songs attached and aren't planned to
+-- receive any: Classical, Country, Jazz, Metal, R&B. They've been in the
+-- seed since migration 008 but the catalog's actual music is Israeli /
+-- mainstream-pop / rock / hip-hop / soundtrack / electronic, so these
+-- five just clutter the manager's genre picker.
+--
+-- Safe because the audit on 2026-05-23 confirmed all five had zero
+-- song_genres rows. If a future operator decides to reintroduce one,
+-- amend the seed (migrations 008/013) and let ON CONFLICT (slug) DO
+-- NOTHING reinsert it.
+--
+-- Idempotent: DELETE WHERE slug IN (...) is a no-op once the rows are
+-- gone. ON DELETE CASCADE on song_genres would clean up any stragglers
+-- if a row had been linked after the audit (none expected, but defensive).
+
+DELETE FROM genres
+WHERE slug IN ('classical', 'country', 'jazz', 'metal', 'rnb');


### PR DESCRIPTION
## Summary

- Adds `db/migrations/024_drop_empty_genres.sql` — idempotent `DELETE FROM genres WHERE slug IN ('classical','country','jazz','metal','rnb')`. All five had zero `song_genres` rows on prod (audited 2026-05-23) so the delete is a no-op for the catalog and just removes clutter from the host's "Pick genres" picker and the admin filter.
- Migration already applied to prod (Frankfurt project `jvfddxuaqcsrguibkymp`) via service-role REST — verified post-state has 10 genres remaining, the ten that actually have songs.
- Preview project (`vriljyhpxfcwpqwshajv`) no longer exists in DNS — appears to have been paused / decommissioned. The migration will apply cleanly to any rebuild.
- CHANGELOG entry under `[Unreleased]` ### Removed.

## Test plan

- [ ] Open https://soundclash.org as host → "Pick genres" → confirm the five genres no longer appear (only Electronic / Hip-Hop / Israeli Cover / Israeli Pop / Israeli Rap / Hip-Hop / Israeli Rock / Pop / Mizrahit / Pop / Rock / Soundtrack remain).
- [ ] Open https://soundclash.org/admin/songs → confirm the genre filter dropdown no longer offers the five.
- [ ] Migration idempotency: re-running 024 against prod is a no-op (DELETE on already-gone rows).