### PR TITLE
Admin Songs: Start time + Genres columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-23: Admin Songs page now shows two extra columns at a glance — **Start time** (seconds, or `—` when 0) and **Genres** (chips, including "Soundtrack" when the song is flagged as one even if it's not tagged with the Soundtrack genre). The edit form also now preselects the song's current genres so the operator doesn't have to re-check them on every edit.
 - 2026-05-23: Team BUZZ button is now a full-screen rounded rectangle and fires the instant a finger touches it (not on tap-release), so fast presses and finger-slides no longer fail to register. Also disables the iOS double-tap-zoom delay.
 - 2026-05-16: Manager "Next round" / "Start game" buttons are now noticeably faster. The browser calls Postgres directly (same pattern as the buzzer and the scoring buttons) instead of going through the Render-hosted backend, and what used to be two chained transatlantic API hops collapses to a single round-trip. Perceived end-to-end latency drops from ~500-900ms (with up to a 30s spike on a cold Render dyno) to ~150ms; with the optimistic "Loading next round..." toast the click-to-feedback gap is effectively immediate.
 - 2026-05-16: Manager Continue / End game / Next round buttons now show their confirmation toast the instant the button is pressed, instead of after the network round-trip — the click feels immediate even on a slow connection. Browser also pre-warms the YouTube connection at app load so the first song's player mounts faster.

--- a/backend/app/models/songs.py
+++ b/backend/app/models/songs.py
@@ -13,6 +13,14 @@ SongArtist = Annotated[str, StringConstraints(min_length=1, max_length=200)]
 SongSource = Annotated[str, StringConstraints(min_length=1, max_length=200)]
 
 
+class GenreRef(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: UUID
+    name: str
+    slug: str
+
+
 class SongPayload(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -23,6 +31,7 @@ class SongPayload(BaseModel):
     start_time: int
     is_soundtrack: bool
     source: str | None = None
+    genres: list[GenreRef] = Field(default_factory=list)
 
 
 class SongCreate(BaseModel):

--- a/backend/app/routers/admin_songs.py
+++ b/backend/app/routers/admin_songs.py
@@ -30,6 +30,36 @@ router = APIRouter(
 SONG_COLUMNS = "id,title,artist,youtube_id,start_time,is_soundtrack,source"
 
 
+def _attach_genres(client: SupabaseClientLike, songs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Mutate each song dict in place to add a `genres: list[dict]` field.
+
+    Two extra round-trips instead of a PostgREST embed: keeps the admin list
+    sane against the fake-supabase test harness (which lowers the select
+    string straight into raw SQL and would choke on embed syntax). For an
+    admin-only page that serves at most 50 rows per request, the extra
+    latency is in the noise.
+    """
+    if not songs:
+        return songs
+    ids = [s["id"] for s in songs]
+    sg_resp = client.table("song_genres").select("song_id,genre_id").in_("song_id", ids).execute()
+    sg_rows = sg_resp.data or []
+    gids = sorted({r["genre_id"] for r in sg_rows}, key=str)
+    if gids:
+        g_resp = client.table("genres").select("id,name,slug").in_("id", gids).execute()
+        gmap = {row["id"]: row for row in (g_resp.data or [])}
+    else:
+        gmap = {}
+    by_song: dict[Any, list[dict[str, Any]]] = {}
+    for r in sg_rows:
+        meta = gmap.get(r["genre_id"])
+        if meta:
+            by_song.setdefault(r["song_id"], []).append(meta)
+    for s in songs:
+        s["genres"] = by_song.get(s["id"], [])
+    return songs
+
+
 def _list_blocking(
     client: SupabaseClientLike,
     *,
@@ -56,12 +86,14 @@ def _list_blocking(
         query = query.ilike("title", f"%{search}%")
 
     resp = query.order("title").execute()
-    rows = list(resp.data or [])
+    rows = [dict(r) for r in (resp.data or [])]
     total = len(rows)
     start = max(0, (page - 1) * per_page)
     end = start + per_page
+    page_rows = rows[start:end]
+    _attach_genres(client, page_rows)
     return {
-        "items": rows[start:end],
+        "items": page_rows,
         "page": page,
         "per_page": per_page,
         "total": total,
@@ -73,7 +105,9 @@ def _fetch_song_blocking(client: SupabaseClientLike, song_id: str) -> dict[str, 
     rows = resp.data or []
     if not rows:
         raise NotFoundError(f"song {song_id} not found")
-    return dict(rows[0])
+    row = dict(rows[0])
+    _attach_genres(client, [row])
+    return row
 
 
 def _create_song_blocking(client: SupabaseClientLike, body: SongCreate) -> dict[str, Any]:
@@ -90,13 +124,14 @@ def _create_song_blocking(client: SupabaseClientLike, body: SongCreate) -> dict[
     rows = resp.data or []
     if not rows:
         raise NotFoundError("song insert returned no row")
-    song: dict[str, Any] = dict(rows[0])
+    song_id = str(rows[0]["id"])
 
-    joins = [{"song_id": song["id"], "genre_id": str(g)} for g in body.genre_ids]
+    joins = [{"song_id": song_id, "genre_id": str(g)} for g in body.genre_ids]
     if joins:
         with mapped_postgrest_errors():
             client.table("song_genres").insert(joins).execute()
-    return song
+    # Re-fetch via the embed so the response includes the genres just attached.
+    return _fetch_song_blocking(client, song_id)
 
 
 def _update_song_blocking(
@@ -112,16 +147,15 @@ def _update_song_blocking(
         "source": body.source,
     }
     with mapped_postgrest_errors():
-        resp = client.table("songs").update(payload).eq("id", song_id).execute()
-    rows = resp.data or []
-    song = rows[0] if rows else _fetch_song_blocking(client, song_id)
+        client.table("songs").update(payload).eq("id", song_id).execute()
 
     client.table("song_genres").delete().eq("song_id", song_id).execute()
     joins = [{"song_id": song_id, "genre_id": str(g)} for g in body.genre_ids]
     if joins:
         with mapped_postgrest_errors():
             client.table("song_genres").insert(joins).execute()
-    return song
+    # Re-fetch via the embed so the response reflects the new genres.
+    return _fetch_song_blocking(client, song_id)
 
 
 def _delete_song_blocking(client: SupabaseClientLike, song_id: str) -> None:

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -49,6 +49,10 @@ export interface Song {
   start_time: number;
   is_soundtrack: boolean;
   source: string | null;
+  // Optional because the `select_next_song` RPC returns Song-shaped rows
+  // without joined genres. The admin list/get/create/update endpoints
+  // populate it; in-game callers can ignore it.
+  genres?: Genre[];
 }
 
 export interface Genre {

--- a/frontend/src/pages/AdminSongsPage.module.css
+++ b/frontend/src/pages/AdminSongsPage.module.css
@@ -92,6 +92,28 @@
   color: var(--color-text-dim);
 }
 
+.startTime {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-dim);
+  white-space: nowrap;
+}
+
+.genreList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.genreTag {
+  font-size: 0.78rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-elev);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-dim);
+  white-space: nowrap;
+}
+
 .rowActions {
   display: flex;
   gap: var(--space-xs);

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -50,6 +50,7 @@ const SONG_A: Song = {
   start_time: 0,
   is_soundtrack: false,
   source: null,
+  genres: [{ id: "g1", name: "Rock", slug: "rock" }],
 };
 
 const SONG_B: Song = {
@@ -60,6 +61,7 @@ const SONG_B: Song = {
   start_time: 12,
   is_soundtrack: true,
   source: "Some film",
+  genres: [{ id: "g2", name: "Pop", slug: "pop" }],
 };
 
 beforeEach(() => {
@@ -145,6 +147,22 @@ describe("AdminSongsPage: list", () => {
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
     expect(screen.getByText("aaaaaaaaaaa")).toBeInTheDocument();
+  });
+
+  it("renders start_time and genre columns; soundtrack flag adds 'Soundtrack' tag", async () => {
+    renderPage();
+    await signIn();
+    // Alpha: start_time=0 renders as em-dash; one genre tag (Rock).
+    const alphaRow = screen.getByText("Alpha").closest("tr") as HTMLElement;
+    expect(within(alphaRow).getByText("—")).toBeInTheDocument();
+    expect(within(alphaRow).getByText("Rock")).toBeInTheDocument();
+    expect(within(alphaRow).queryByText("Soundtrack")).not.toBeInTheDocument();
+    // Bravo: start_time=12 renders as "12s"; is_soundtrack=true prepends "Soundtrack"
+    // to the Pop tag.
+    const bravoRow = screen.getByText("Bravo").closest("tr") as HTMLElement;
+    expect(within(bravoRow).getByText("12s")).toBeInTheDocument();
+    expect(within(bravoRow).getByText("Pop")).toBeInTheDocument();
+    expect(within(bravoRow).getByText("Soundtrack")).toBeInTheDocument();
   });
 
   it("shows the empty state when there are no songs", async () => {
@@ -276,6 +294,7 @@ describe("AdminSongsPage: create + edit + delete", () => {
 
     expect(screen.getByDisplayValue("Alpha")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: "Alpha v2" } });
+    // Rock is already pre-checked (from SONG_A.genres); clicking Pop adds it.
     fireEvent.click(screen.getByLabelText(/^pop$/i));
 
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
@@ -285,7 +304,7 @@ describe("AdminSongsPage: create + edit + delete", () => {
     expect(id).toBe(SONG_A.id);
     expect(payload.title).toBe("Alpha v2");
     expect(payload.youtube_id).toBe(SONG_A.youtube_id);
-    expect(payload.genre_ids).toEqual(["g2"]);
+    expect([...payload.genre_ids].sort()).toEqual(["g1", "g2"]);
     expect(pw).toBe("letmein");
   });
 

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -26,6 +26,18 @@ import styles from "./AdminSongsPage.module.css";
 const PER_PAGE = 50;
 const YT_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 const SEARCH_DEBOUNCE_MS = 250;
+const SOUNDTRACK_LABEL = "Soundtrack";
+
+// Build the display list of genre names for a row. If `is_soundtrack` is on,
+// prepend "Soundtrack" so the column reflects the flag even when the song
+// isn't tagged with the soundtrack genre (e.g. a Rock soundtrack pick).
+function displayGenres(song: Song): string[] {
+  const names = (song.genres ?? []).map((g) => g.name);
+  if (song.is_soundtrack && !names.includes(SOUNDTRACK_LABEL)) {
+    names.unshift(SOUNDTRACK_LABEL);
+  }
+  return names;
+}
 
 type Mode = { kind: "list" } | { kind: "create" } | { kind: "edit"; song: Song };
 
@@ -239,8 +251,6 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
   const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
 
   const songToFilterEdit = useCallback((song: Song) => {
-    // Backend doesn't return genre links on the song row; preselect nothing.
-    // Operator can re-pick. (A future enhancement could add ?include=genres.)
     setMode({ kind: "edit", song });
   }, []);
 
@@ -356,7 +366,14 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
         <SongForm
           key={mode.kind === "edit" ? mode.song.id : "create"}
           genres={genres}
-          initial={mode.kind === "edit" ? songToForm(mode.song, []) : EMPTY_FORM}
+          initial={
+            mode.kind === "edit"
+              ? songToForm(
+                  mode.song,
+                  (mode.song.genres ?? []).map((g) => g.id),
+                )
+              : EMPTY_FORM
+          }
           submitLabel={mode.kind === "edit" ? "Save changes" : "Create song"}
           busy={busy}
           onCancel={() => setMode({ kind: "list" })}
@@ -371,6 +388,8 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
               <th>Title</th>
               <th>Artist</th>
               <th>YouTube ID</th>
+              <th>Start</th>
+              <th>Genres</th>
               <th aria-label="Actions" />
             </tr>
           </thead>
@@ -387,43 +406,68 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
                   <td>
                     <Skeleton width="100px" height={16} />
                   </td>
+                  <td>
+                    <Skeleton width="40px" height={16} />
+                  </td>
+                  <td>
+                    <Skeleton width="120px" height={16} />
+                  </td>
                   <td />
                 </tr>
               ))
             ) : songs.length === 0 ? (
               <tr>
-                <td colSpan={4} className={styles.empty}>
+                <td colSpan={6} className={styles.empty}>
                   No songs found.
                 </td>
               </tr>
             ) : (
-              songs.map((s) => (
-                <tr key={s.id}>
-                  <td>{s.title}</td>
-                  <td>{s.artist}</td>
-                  <td className={styles.ytId}>{s.youtube_id}</td>
-                  <td>
-                    <div className={styles.rowActions}>
-                      <button
-                        type="button"
-                        className="btn btn-ghost"
-                        onClick={() => songToFilterEdit(s)}
-                        disabled={busy}
-                      >
-                        Edit
-                      </button>
-                      <button
-                        type="button"
-                        className="btn btn-danger"
-                        onClick={() => setDeleteId(s.id)}
-                        disabled={busy}
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))
+              songs.map((s) => {
+                const genreNames = displayGenres(s);
+                return (
+                  <tr key={s.id}>
+                    <td>{s.title}</td>
+                    <td>{s.artist}</td>
+                    <td className={styles.ytId}>{s.youtube_id}</td>
+                    <td className={styles.startTime}>
+                      {s.start_time > 0 ? `${s.start_time}s` : "—"}
+                    </td>
+                    <td>
+                      <div className={styles.genreList}>
+                        {genreNames.length === 0 ? (
+                          <span className={styles.startTime}>—</span>
+                        ) : (
+                          genreNames.map((name) => (
+                            <span key={name} className={styles.genreTag}>
+                              {name}
+                            </span>
+                          ))
+                        )}
+                      </div>
+                    </td>
+                    <td>
+                      <div className={styles.rowActions}>
+                        <button
+                          type="button"
+                          className="btn btn-ghost"
+                          onClick={() => songToFilterEdit(s)}
+                          disabled={busy}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-danger"
+                          onClick={() => setDeleteId(s.id)}
+                          disabled={busy}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/tests/backend/test_admin_songs_crud.py
+++ b/tests/backend/test_admin_songs_crud.py
@@ -113,6 +113,46 @@ async def test_list_genre_filter_unknown_returns_empty(admin_client) -> None:
     assert resp.json()["total"] == 0
 
 
+async def test_list_response_includes_genres_per_song(admin_client, db) -> None:
+    await insert_song(db, title="GenresPing", genre_slugs=["rock", "pop"])
+    resp = await admin_client.get("/admin/songs?search=GenresPing")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) >= 1
+    row = next(s for s in items if s["title"] == "GenresPing")
+    slugs = sorted(g["slug"] for g in row["genres"])
+    assert slugs == ["pop", "rock"]
+    # Each embedded genre has the full id/name/slug shape the admin UI needs.
+    assert all({"id", "name", "slug"} <= g.keys() for g in row["genres"])
+
+
+async def test_get_song_includes_genres(admin_client, db) -> None:
+    song_id = await insert_song(db, genre_slugs=["rock"])
+    resp = await admin_client.get(f"/admin/songs/{song_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [g["slug"] for g in body["genres"]] == ["rock"]
+
+
+async def test_create_response_includes_attached_genres(admin_client, db) -> None:
+    rock, pop = await fetch_genre_ids(db, slugs=["rock", "pop"])
+    resp = await admin_client.post(
+        "/admin/songs",
+        json={
+            "title": "WithGenresCreate",
+            "artist": "X",
+            "youtube_id": "qqqqqqqqqqq",
+            "start_time": 0,
+            "is_soundtrack": False,
+            "source": None,
+            "genre_ids": [str(rock), str(pop)],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert sorted(g["slug"] for g in body["genres"]) == ["pop", "rock"]
+
+
 async def test_get_unknown_id_404(admin_client) -> None:
     resp = await admin_client.get(
         "/admin/songs/00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary

Adds two columns to `/admin/songs`:

- **Start time**: shows the song's `start_time` in seconds (`12s`), or an em-dash for the default `0`.
- **Genres**: chips listing every genre attached to the song. If `is_soundtrack` is true and the song isn't already tagged with the Soundtrack genre, "Soundtrack" is prepended so the flag is visible at a glance (catches the Gloria Gaynor "I Will Survive" case from the audit, where the flag and the genre disagreed).

Backend changes wire the genres through:

- `GET /admin/songs`, `GET /admin/songs/{id}`, `POST /admin/songs`, and `PUT /admin/songs/{id}` now include `genres: list[{id,name,slug}]` on each row in the response.
- Implementation: two extra round-trips (one for `song_genres`, one for `genres`) rather than a PostgREST embed — the fake-supabase test harness lowers select strings straight into raw SQL and would choke on embed syntax. For an admin-only page that serves at most 50 rows per request, the extra latency is in the noise.

Bonus, since the data is now available: the edit form preselects the song's current genres (a TODO comment in the file explicitly flagged this as a future enhancement contingent on the backend exposing them).

`select_next_song` and other in-game callers still return Song-shaped rows without genres; the `genres` field on the TS `Song` type is optional so those paths are unchanged.

## Test plan

- [x] `pytest tests/backend/test_admin_songs_crud.py` — 14 pass (3 new: list/get/create responses now include attached genres in the expected shape)
- [x] `pytest tests/backend/test_admin_songs_bulk_import.py` — all pass
- [x] `vitest run AdminSongsPage` — 17 pass (1 new asserting the two new columns + the soundtrack-prepend behaviour; existing edit test updated to expect the preselected-genres behaviour)
- [x] `ruff check`, `ruff format --check`, `mypy app`, `eslint`, `tsc --noEmit`, `prettier --check` all clean
- [ ] Manual: open https://soundclash.org/admin/songs after deploy, confirm Start and Genres columns render; edit a song and confirm its existing genres are pre-checked in the form