### PR TITLE
Split Soundtrack genre into Soundtracks + Israeli Soundtracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-05-24: New **Israeli Soundtracks** genre, separated from the existing soundtrack bucket so hosts can run a Hebrew-only (or English-only) soundtrack round. Six Israeli titles (גבעת חלפון אינה עונה, גברת פלפלת, נילס הולגרסון, הדרדסים, איזה עולם, הפיג'מות) moved into the new genre.
 - 2026-05-16: How-to-play page reworked into a numbered seven-step walkthrough (Host a game → genres → Display screen → teams join with QR → start → buzz/judge → optional Bonus) plus a short "Rules & FAQ" section covering the free-guess sweetener, two tokens per song, wrong-buzz-doesn't-lock-you-out, +4 Bonus anytime, and one-phone-per-team reconnect.
 - 2026-05-15: Display screen now keeps the join QR (and game code) visible at the bottom of the page for the whole game — late players can scan and join mid-round instead of being locked out the moment the first team appears.
 - 2026-05-10: Team's own phone now shows a "+10 / −3" pill the instant their score changes — same look as the projector toast — so a player gets immediate feedback on the device they're already looking at.
@@ -17,6 +18,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-24: Renamed the **Soundtrack** genre to **Soundtracks** (plural) to match the new Israeli Soundtracks sibling. The admin Songs page's auto-tag-on-save behaviour now routes Hebrew-language sources to Israeli Soundtracks and everything else to Soundtracks.
 - 2026-05-24: Soundtrack rounds now play differently. When the current song has a `source` set, the manager and display screens show a 🎬 **Soundtrack** badge, and the manager's two scoring buttons collapse to a single **Correct (+15)** button — the team only has to name the work (film / TV / game / musical), and a correct call awards 15 points instead of the usual 10/5 title-vs-artist split. Wrong (−3) still applies. Correct (+15) also releases the buzz lock and resumes playback immediately, so the host can press Next round in one tap (no separate Continue, since both tokens land together). The display screen reveals "Title" + "from <source>" once the manager confirms.
 - 2026-05-24: Admin Songs page no longer has a separate "Mark as soundtrack" checkbox. The **Source** field is now the single soundtrack marker — setting it auto-tags the song with the Soundtrack genre on save, and the gameplay 15-pt rule fires off the same field.
 - 2026-05-23: Admin Songs page now shows two extra columns at a glance — **Start time** (seconds, or `—` when 0) and **Genres** (chips, including "Soundtrack" when the song is flagged as one even if it's not tagged with the Soundtrack genre). The edit form also now preselects the song's current genres so the operator doesn't have to re-check them on every edit.

--- a/db/migrations/026_split_soundtracks_genre.sql
+++ b/db/migrations/026_split_soundtracks_genre.sql
@@ -1,0 +1,107 @@
+-- 026_split_soundtracks_genre.sql
+-- Split the single 'Soundtrack' (slug: soundtrack) genre into two buckets:
+--   1. Rename it to 'Soundtracks' (slug: soundtracks) for symmetry with the
+--      new sibling, and because the catalog now holds many titles per genre.
+--   2. Add 'Israeli Soundtracks' (slug: israeli-soundtracks) for Hebrew
+--      film / TV themes (גבעת חלפון, גברת פלפלת, …) so hosts can run a
+--      Hebrew-only soundtrack round without forcing English content in.
+--   3. Move the six Hebrew-source titles from the generic bucket into the
+--      new Israeli bucket. Identification is by youtube_id so the move
+--      survives subsequent title/artist edits.
+--   4. Clean up one mis-tagged row ('Everything I Wanted' by Billie Eilish
+--      had source='Billie Eilish' — the artist name, not a film/TV source).
+--      Clear its source and remove the Soundtracks tag; the row stays in
+--      the catalog under whatever other genres it has.
+--
+-- Idempotent against the chained-rerun scenario.
+--   - Step A:  on a re-run, mig 008 re-INSERTs the old 'soundtrack' slug
+--              (because its conflict clause is on slug, and we renamed
+--              that slug away), and mig 025 then back-fills song_genres
+--              for it. So before renaming, we re-home those song_genres
+--              onto the canonical 'soundtracks' row and delete the rogue
+--              'soundtrack' row if 'soundtracks' already exists. Then
+--              UPDATE handles the first-run rename. All three statements
+--              are no-ops in their non-applicable scenario.
+--   - Step B:  ON CONFLICT (slug) DO NOTHING.
+--   - Step C:  INSERT … ON CONFLICT (song_id, genre_id) DO NOTHING + the
+--              DELETE-by-youtube_id is naturally a no-op once the rows
+--              have already been moved.
+--   - Step D:  UPDATE WHERE source IS NOT NULL is a no-op once source has
+--              been cleared; the DELETE is a no-op once the link is gone.
+
+-- Step A: collapse 'soundtrack' (singular, possibly re-created by mig 008
+-- on rerun) into 'soundtracks' (plural, the canonical post-rename row).
+-- A.1 — re-home any song_genres still linked to the rogue singular row.
+INSERT INTO song_genres (song_id, genre_id)
+SELECT sg.song_id, g_new.id
+  FROM song_genres sg
+  JOIN genres g_old ON g_old.id  = sg.genre_id AND g_old.slug = 'soundtrack'
+  JOIN genres g_new ON g_new.slug = 'soundtracks'
+ON CONFLICT (song_id, genre_id) DO NOTHING;
+
+-- A.2 — drop the rogue singular row if the canonical plural row exists.
+DELETE FROM genres
+ WHERE slug = 'soundtrack'
+   AND EXISTS (SELECT 1 FROM genres WHERE slug = 'soundtracks');
+
+-- A.3 — first-run path: rename the original Soundtrack row. After A.2 the
+-- only surviving 'soundtrack' row is the one inserted by mig 008 on a fresh
+-- build (before mig 026 has ever run), so the UPDATE is collision-free.
+UPDATE genres
+   SET name = 'Soundtracks',
+       slug = 'soundtracks'
+ WHERE slug = 'soundtrack';
+
+-- Step B: add the new Israeli Soundtracks genre.
+INSERT INTO genres (name, slug) VALUES
+  ('Israeli Soundtracks', 'israeli-soundtracks')
+ON CONFLICT (slug) DO NOTHING;
+
+-- Step C: move the 6 Hebrew-source titles from soundtracks -> israeli-soundtracks.
+--   8H0cvMSAhLY  גבעת חלפון אינה עונה
+--   9SZZDDXyWVY  נילס הולגרסון
+--   g49huS-qQ1Y  גברת פלפלת
+--   WoKEdEy_g1A  הדרדסים
+--   qF0gBrO4gIY  איזה עולם (משמש)
+--   sHfwZFzMclk  הפיג'מות
+INSERT INTO song_genres (song_id, genre_id)
+SELECT s.id, g.id
+  FROM songs s
+  JOIN genres g ON g.slug = 'israeli-soundtracks'
+ WHERE s.youtube_id IN (
+   '8H0cvMSAhLY',
+   '9SZZDDXyWVY',
+   'g49huS-qQ1Y',
+   'WoKEdEy_g1A',
+   'qF0gBrO4gIY',
+   'sHfwZFzMclk'
+ )
+ON CONFLICT (song_id, genre_id) DO NOTHING;
+
+DELETE FROM song_genres sg
+ USING songs s, genres g
+ WHERE sg.song_id = s.id
+   AND sg.genre_id = g.id
+   AND g.slug = 'soundtracks'
+   AND s.youtube_id IN (
+     '8H0cvMSAhLY',
+     '9SZZDDXyWVY',
+     'g49huS-qQ1Y',
+     'WoKEdEy_g1A',
+     'qF0gBrO4gIY',
+     'sHfwZFzMclk'
+   );
+
+-- Step D: clean up 'Everything I Wanted' (Billie Eilish) — source was mis-set
+-- to the artist name rather than a film/TV source.
+UPDATE songs
+   SET source = NULL
+ WHERE youtube_id = 'e8psHWLGDN4'
+   AND source IS NOT NULL;
+
+DELETE FROM song_genres sg
+ USING songs s, genres g
+ WHERE sg.song_id = s.id
+   AND sg.genre_id = g.id
+   AND g.slug = 'soundtracks'
+   AND s.youtube_id = 'e8psHWLGDN4';

--- a/db/seed/songs.sql
+++ b/db/seed/songs.sql
@@ -1,6 +1,6 @@
 -- songs.sql
 -- Minimal song catalog for the e2e local Supabase stack. 12 songs across
--- rock / pop / electronic / soundtrack so the Playwright suite can run a
+-- rock / pop / electronic / soundtracks so the Playwright suite can run a
 -- 3-round game without exhausting pick_random_song.
 --
 -- Run once after migrations against the local stack:
@@ -50,8 +50,8 @@ JOIN (VALUES
   ('CevxZvSJLk8', 'electronic'),
   ('09R8_2nJtjg', 'electronic'),
   ('hT_nvWreIhg', 'electronic'),
-  ('nfWlot6h_JM', 'soundtrack'),
-  ('e-ORhEE9VVg', 'soundtrack')
+  ('nfWlot6h_JM', 'soundtracks'),
+  ('e-ORhEE9VVg', 'soundtracks')
 ) AS m(youtube_id, slug) ON songs.youtube_id = m.youtube_id
 JOIN genres ON genres.slug = m.slug
 ON CONFLICT (song_id, genre_id) DO NOTHING;

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -310,7 +310,7 @@ All under `/admin/songs/*`. **Admin-password auth required** on every endpoint (
 |---|---|---|
 | `GET`    | `/admin/songs` | List songs (paginated, `?page=1&per_page=50&search=&genre=`) |
 | `GET`    | `/admin/songs/{id}` | Get one song |
-| `POST`   | `/admin/songs` | Create a song (body: `title, artist, youtube_id, start_time, source, genre_ids[]`). When `source` is set, the admin UI auto-adds the Soundtrack genre id to `genre_ids` so soundtrack-only filtering works for game creation. |
+| `POST`   | `/admin/songs` | Create a song (body: `title, artist, youtube_id, start_time, source, genre_ids[]`). When `source` is set, the admin UI auto-adds the Soundtracks genre id to `genre_ids` (or Israeli Soundtracks when `source` contains Hebrew characters) so soundtrack-only filtering works for game creation. |
 | `PUT`    | `/admin/songs/{id}` | Update a song (full replacement; partial use PATCH if needed later) |
 | `DELETE` | `/admin/songs/{id}` | Delete a song (cascades to `song_genres`) |
 | `POST`   | `/admin/songs/bulk-import` | Multipart CSV upload; columns: `title, artist, youtube_id, start_time, source, genres` (semicolon-separated genre slugs) |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -41,7 +41,7 @@ CREATE TABLE songs (
   artist        text NOT NULL,
   youtube_id    char(11) NOT NULL,
   start_time    integer NOT NULL DEFAULT 0,    -- seconds
-  source        text,                           -- work the song is from (movie/TV/game/musical); nullable. NON-NULL = soundtrack round: manager + display show a 🎬 badge, scoring collapses to a single "Correct (+15)" button, and admin save auto-tags the Soundtrack genre.
+  source        text,                           -- work the song is from (movie/TV/game/musical); nullable. NON-NULL = soundtrack round: manager + display show a 🎬 badge, scoring collapses to a single "Correct (+15)" button, and admin save auto-tags the Soundtracks genre (Israeli Soundtracks when source contains Hebrew characters).
   created_at    timestamptz NOT NULL DEFAULT now(),
   updated_at    timestamptz NOT NULL DEFAULT now()
 );

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -108,7 +108,7 @@ When the current song has a `source` set (i.e. it's from a film / TV show / game
 - The single Correct button fires `award_attempt` with `p_title=10, p_artist=5` so the sum lands as +15 via the existing SQL function — no new RPC, no scoring branch in the DB.
 - On the display, the reveal panel shows "🎵 Title" and "🎬 from <source>" (instead of "🎤 Artist") once the manager confirms; both rows light up together.
 
-**Admin convention for soundtrack songs**: store the work name in the `artist` field (e.g. `artist = "Star Wars"` for the Imperial March, `artist = "Titanic"` for "My Heart Will Go On"). `source` typically matches. Setting `source` on save auto-tags the song with the Soundtrack genre so the host can filter to soundtrack-only games.
+**Admin convention for soundtrack songs**: store the work name in the `artist` field (e.g. `artist = "Star Wars"` for the Imperial March, `artist = "Titanic"` for "My Heart Will Go On"). `source` typically matches. Setting `source` on save auto-tags the song with the **Soundtracks** genre, or **Israeli Soundtracks** when `source` contains Hebrew characters, so the host can filter to a Hebrew-only or English-only soundtrack round.
 
 ### Free-guess rule
 

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -40,7 +40,8 @@ import { AdminSongsPage } from "./AdminSongsPage";
 const GENRES = [
   { id: "g1", name: "Rock", slug: "rock" },
   { id: "g2", name: "Pop", slug: "pop" },
-  { id: "g3", name: "Soundtrack", slug: "soundtrack" },
+  { id: "g3", name: "Soundtracks", slug: "soundtracks" },
+  { id: "g4", name: "Israeli Soundtracks", slug: "israeli-soundtracks" },
 ];
 
 const SONG_A: Song = {
@@ -62,7 +63,7 @@ const SONG_B: Song = {
   source: "Some film",
   genres: [
     { id: "g2", name: "Pop", slug: "pop" },
-    { id: "g3", name: "Soundtrack", slug: "soundtrack" },
+    { id: "g3", name: "Soundtracks", slug: "soundtracks" },
   ],
 };
 
@@ -158,13 +159,13 @@ describe("AdminSongsPage: list", () => {
     const alphaRow = screen.getByText("Alpha").closest("tr") as HTMLElement;
     expect(within(alphaRow).getByText("—")).toBeInTheDocument();
     expect(within(alphaRow).getByText("Rock")).toBeInTheDocument();
-    expect(within(alphaRow).queryByText("Soundtrack")).not.toBeInTheDocument();
+    expect(within(alphaRow).queryByText("Soundtracks")).not.toBeInTheDocument();
     // Bravo: start_time=12 renders as "12s"; the row reflects only the
-    // genre tags actually stored on the song (Pop + Soundtrack).
+    // genre tags actually stored on the song (Pop + Soundtracks).
     const bravoRow = screen.getByText("Bravo").closest("tr") as HTMLElement;
     expect(within(bravoRow).getByText("12s")).toBeInTheDocument();
     expect(within(bravoRow).getByText("Pop")).toBeInTheDocument();
-    expect(within(bravoRow).getByText("Soundtrack")).toBeInTheDocument();
+    expect(within(bravoRow).getByText("Soundtracks")).toBeInTheDocument();
   });
 
   it("shows the empty state when there are no songs", async () => {
@@ -266,7 +267,7 @@ describe("AdminSongsPage: create + edit + delete", () => {
     await waitFor(() => expect(screen.getByText(/song created/i)).toBeInTheDocument());
   });
 
-  it("auto-tags the Soundtrack genre when source is set on save", async () => {
+  it("auto-tags the Soundtracks genre when an English source is set on save", async () => {
     vi.mocked(createSong).mockResolvedValue(SONG_A);
     renderPage();
     await signIn();
@@ -286,6 +287,29 @@ describe("AdminSongsPage: create + edit + delete", () => {
     const [payload] = vi.mocked(createSong).mock.calls[0]!;
     expect(payload.source).toBe("Star Wars");
     expect([...payload.genre_ids].sort()).toEqual(["g1", "g3"]);
+  });
+
+  it("auto-tags Israeli Soundtracks (not generic) when source contains Hebrew", async () => {
+    vi.mocked(createSong).mockResolvedValue(SONG_A);
+    renderPage();
+    await signIn();
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ new song/i }));
+    fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: "גבעת חלפון" } });
+    fireEvent.change(screen.getByLabelText(/^artist$/i), { target: { value: "שיר" } });
+    fireEvent.change(screen.getByLabelText(/^youtube id$/i), {
+      target: { value: "abcdefghijk" },
+    });
+    fireEvent.change(screen.getByLabelText(/^source$/i), { target: { value: "גבעת חלפון" } });
+    fireEvent.click(screen.getByLabelText(/^rock$/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /create song/i }));
+
+    await waitFor(() => expect(createSong).toHaveBeenCalled());
+    const [payload] = vi.mocked(createSong).mock.calls[0]!;
+    expect(payload.source).toBe("גבעת חלפון");
+    // g4 = Israeli Soundtracks; g3 = generic Soundtracks should NOT be added.
+    expect([...payload.genre_ids].sort()).toEqual(["g1", "g4"]);
   });
 
   it("disables submit while the form is invalid", async () => {

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -26,7 +26,11 @@ import styles from "./AdminSongsPage.module.css";
 const PER_PAGE = 50;
 const YT_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 const SEARCH_DEBOUNCE_MS = 250;
-const SOUNDTRACK_GENRE_SLUG = "soundtrack";
+const SOUNDTRACKS_GENRE_SLUG = "soundtracks";
+const ISRAELI_SOUNDTRACKS_GENRE_SLUG = "israeli-soundtracks";
+// Hebrew unicode block; used to route an auto-tag to the Israeli bucket
+// when the admin enters a Hebrew source.
+const HEBREW_CHAR_RE = /[֐-׿]/;
 
 type Mode = { kind: "list" } | { kind: "create" } | { kind: "edit"; song: Song };
 
@@ -62,11 +66,15 @@ function songToForm(song: Song, genreIds: string[]): FormState {
 function formToPayload(form: FormState, genres: Genre[]): SongWritePayload {
   const source = form.source.trim() === "" ? null : form.source.trim();
   const genre_ids = new Set(form.genre_ids);
-  // Auto-tag: a song with a source is a soundtrack, so it should always
-  // carry the Soundtrack genre tag for game-creation filtering.
+  // Auto-tag: a song with a source is a soundtrack; route to the Israeli
+  // bucket when the source contains Hebrew chars, otherwise the generic
+  // Soundtracks bucket. Admin can still toggle chips to override.
   if (source) {
-    const soundtrack = genres.find((g) => g.slug === SOUNDTRACK_GENRE_SLUG);
-    if (soundtrack) genre_ids.add(soundtrack.id);
+    const targetSlug = HEBREW_CHAR_RE.test(source)
+      ? ISRAELI_SOUNDTRACKS_GENRE_SLUG
+      : SOUNDTRACKS_GENRE_SLUG;
+    const match = genres.find((g) => g.slug === targetSlug);
+    if (match) genre_ids.add(match.id);
   }
   return {
     title: form.title.trim(),
@@ -581,7 +589,8 @@ function SongForm({ genres, initial, submitLabel, busy, onCancel, onSubmit }: So
         </label>
         <label className={`${styles.field} ${styles.fieldFull}`}>
           <span>
-            Source — film / TV / game / musical (sets soundtrack round, auto-tags Soundtrack genre)
+            Source — film / TV / game / musical (sets soundtrack round; auto-tags Israeli
+            Soundtracks for Hebrew sources, Soundtracks otherwise)
           </span>
           <input
             type="text"


### PR DESCRIPTION
## Summary

- Split the single `Soundtrack` genre into two so hosts can run a Hebrew-only or English-only soundtrack round.
- Renamed the existing genre `Soundtrack` → `Soundtracks` (plural, matching the new sibling); added `Israeli Soundtracks`.
- Migration 026 also moves six Hebrew-source titles (גבעת חלפון, גברת פלפלת, נילס הולגרסון, הדרדסים, איזה עולם, הפיג'מות) into the Israeli bucket by `youtube_id`, and clears the mis-tagged `source` on Billie Eilish's "Everything I Wanted" (the source field was set to the artist name, not a film/TV source).
- Admin Songs page auto-tag-on-save now routes Hebrew-containing sources to Israeli Soundtracks, others to Soundtracks. Admin can still toggle chips to override.
- No backend/RPC/scoring changes. Soundtrack-round behaviour (badge, +15 single button) still keys off `songs.source IS NOT NULL`, not genre membership.

## Test plan

- [x] `db/migrate.sh` apply + re-apply against local Supabase → idempotent (mig 026 handles the chained-rerun case where mig 008 re-inserts the old `soundtrack` slug)
- [x] Backend `pytest -m "not stress" --cov=app` → 177 passed, 93.09% coverage (≥ 90% gate). 12 unrelated `test_rls_anon.py` failures pre-exist on `main`.
- [x] Frontend `npm run lint && npm run typecheck && npm run test:run && npm run build` → all green; 271/271 frontend tests pass, including a new test covering the Hebrew auto-tag route.
- [ ] `tests/e2e` Playwright (chromium) — running via the `run-e2e` label on CI; local Windows run was flaky (Playwright timeouts despite expected state visible on page snapshots).
- [ ] Apply migration to prod after merge: `supabase link --project-ref jvfddxuaqcsrguibkymp && supabase db query --linked -f db/migrations/026_split_soundtracks_genre.sql`.