### PR TITLE
Team buzzer full-bleed; drop team-screen timer; soundtrack Correct waits for Next round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project does not currently cut versioned releases; every change lands direc
 
 ## [Unreleased]
 
+### Changed
+
+- 2026-05-25: Team buzzer screen is now full-bleed — the BUZZ button reaches every edge of the phone, with the team name + current round shown as a small pill overlay in the top corner. Larger tap target, no chrome competing for the screen.
+
+### Removed
+
+- 2026-05-25: The 10-second post-buzz countdown bar is gone from the team screen. Players watch the display for time; the team's own phone is now just the BUZZ button.
+
+### Fixed
+
+- 2026-05-25: Soundtrack rounds no longer auto-resume the song or re-arm the buzzers after the host taps **Correct (+15)**. The round now waits for an explicit **Next round** press, matching how regular rounds behave once both title and artist have been scored.
+
 ### Added
 
 - 2026-05-24: How-to-play page now opens with a hero illustration showing the three-screen setup at a glance — host's phone with the manager console, TV/laptop running the display + scoreboard + join QR, and team phones with the BUZZ button — so first-time visitors can see how everything connects before reading the steps.

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -289,7 +289,7 @@ describe("ManagerConsolePage", () => {
     );
   });
 
-  it("Soundtrack rounds show a +15 button that fires both flags and auto-releases the lock", async () => {
+  it("Soundtrack rounds show a +15 button that fires both flags and leaves the lock/playback alone", async () => {
     setHydrate({
       game: makeActiveGame({
         status: "playing",
@@ -301,7 +301,7 @@ describe("ManagerConsolePage", () => {
       teams: [makeTeam({ id: "t1", name: "Alice" })],
       rounds: [makeRound({ id: "r1", round_number: 1, song_id: "song-S" })],
     });
-    // Source-non-null marks the song as a soundtrack round; the manager UI
+    // is_soundtrack=true marks the song as a soundtrack round; the manager UI
     // collapses to a single "Correct +15" button.
     setSongFetch({
       id: "song-S",
@@ -319,7 +319,6 @@ describe("ManagerConsolePage", () => {
       title_claimed_by: "t1",
       artist_claimed_by: "t1",
     });
-    vi.mocked(releaseBuzzLockDirect).mockResolvedValueOnce(undefined);
     renderConsole();
     await act(async () => {
       await fireSubscribed();
@@ -342,10 +341,11 @@ describe("ManagerConsolePage", () => {
         wrong_buzz: false,
       }),
     );
-    // Both tokens claim together; no extra Continue press needed -- the
-    // handler also fires releaseBuzzLockDirect so the lock is gone and the
-    // song resumes.
-    await waitFor(() => expect(releaseBuzzLockDirect).toHaveBeenCalledWith("ABCDEF", TOKEN));
+    // The round must stay in the fully-scored-but-locked state so the host
+    // explicitly advances with Next round — same as a non-soundtrack round
+    // where both title + artist were claimed. No auto-unlock, no auto-resume.
+    expect(releaseBuzzLockDirect).not.toHaveBeenCalled();
+    expect(lastHandle?.play).not.toHaveBeenCalled();
   });
 
   it("Continue button calls releaseBuzzLockDirect and resumes the player", async () => {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -258,10 +258,10 @@ export function ManagerConsolePage() {
   // "Correct +15" button instead of the title/artist split. The team's job is
   // to name the work (film / TV / game / musical), not the song title; awarding
   // both flags at once sums to 15 points via the existing award_attempt
-  // function -- no SQL change needed. Both tokens claim together, so unlike
-  // the regular Correct Song / Correct Artist buttons (which keep the buzz
-  // lock held so the team can also try the other token), we immediately
-  // release the lock and resume the song -- there is nothing more to score.
+  // function -- no SQL change needed. Both tokens claim together; nothing more
+  // can be scored on this round, so we let it sit in the fully-scored state
+  // (lock held, player paused) and wait for the manager's "Next round" click,
+  // mirroring how a regular round behaves once both title + artist are claimed.
   async function handleCorrectSoundtrack() {
     if (titleInFlightRef.current || artistInFlightRef.current) return;
     if (!state?.currentRound || busy || !managerToken) return;
@@ -280,8 +280,6 @@ export function ManagerConsolePage() {
         artist_correct: true,
         wrong_buzz: false,
       });
-      await releaseBuzzLockDirect(gameCode, managerToken);
-      playerRef.current?.play();
     } catch (err) {
       setPendingTitle(null);
       setPendingArtist(null);

--- a/frontend/src/pages/TeamGameplayPage.module.css
+++ b/frontend/src/pages/TeamGameplayPage.module.css
@@ -1,12 +1,23 @@
+/* Full-bleed team buzzer: the BUZZ button must reach every viewport edge on
+   phone AND desktop. Two things matter:
+     1. The shell has a *definite* height (100dvh, with 100vh fallback) so
+        flex children can resolve their `flex: 1` against a known size.
+        `min-height` alone leaves the flex axis ambiguous and the button
+        collapses to content size.
+     2. The `<main>` element is overridden away from any inherited block
+        defaults — no padding, no max-width, no margins — and stops the
+        body's page-gradient from leaking around the button. */
 .shell {
-  min-height: 100%;
-  padding: 0.75rem var(--space-md);
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
   max-width: none;
-  margin: 0 auto;
-  width: 100%;
+  overflow: hidden;
 }
 
 .pointStack {
@@ -23,42 +34,42 @@
   max-width: min(92vw, 360px);
 }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 0.5rem 0.9rem;
-  box-shadow: var(--shadow-sm);
-  flex: 0 0 auto;
-}
-
-.identity {
+.identityOverlay {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.6rem;
+  z-index: 40;
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.3rem 0.7rem;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(6px);
+  border-radius: var(--radius-pill);
+  pointer-events: none;
+  max-width: calc(100vw - 1.2rem);
+  overflow: hidden;
 }
 
 .teamName {
-  font-size: 1.05rem;
-  font-weight: 800;
-  color: #0f172a;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #f8fafc;
   letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60vw;
 }
 
 .roundPill {
   display: inline-flex;
   align-items: center;
-  padding: 2px 10px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
-  background: var(--color-primary-soft);
-  color: var(--color-primary-strong);
-  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.2);
+  color: #f8fafc;
+  font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.02em;
 }
@@ -73,109 +84,20 @@
   font-size: 1.05rem;
   color: var(--color-text-dim);
   box-shadow: var(--shadow-sm);
-}
-
-.timer {
-  --timer-pct: 100%;
-  display: flex;
-  align-items: center;
-  gap: 0.85rem;
-  padding: 0.75rem 1rem;
-  background: #ffffff;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-sm);
-  flex: 0 0 auto;
-}
-
-.timerBar {
-  flex: 1;
-  height: 8px;
-  background: rgba(245, 158, 11, 0.18);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.timerFill {
-  height: 100%;
-  width: var(--timer-pct);
-  background: var(--color-warning);
-  border-radius: 999px;
-  transition:
-    width 950ms linear,
-    background 200ms ease;
-}
-
-.timerValue {
-  font-variant-numeric: tabular-nums;
-  font-weight: 800;
-  font-size: 1rem;
-  color: var(--color-warning);
-  min-width: 2.5em;
-  text-align: right;
-}
-
-.timerLow .timerFill {
-  background: var(--color-danger);
-}
-
-.timerLow .timerValue {
-  color: var(--color-danger);
-  animation: timer-pulse-team 0.7s ease-in-out infinite;
-}
-
-@keyframes timer-pulse-team {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.12);
-  }
+  margin: 0.75rem;
 }
 
 .buzzZone {
-  display: flex;
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   min-height: 0;
-  padding: 0;
-  justify-content: stretch;
-  align-items: stretch;
+  min-width: 0;
+  display: flex;
 }
 
-.scoreCard {
-  background: #ffffff;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 1.5rem;
-  box-shadow: var(--shadow-md);
-}
-
-.scoreCardTitle {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--color-text-dim);
-  font-weight: 700;
-  margin-bottom: 1rem;
-}
-
-@media (min-width: 900px) {
-  .shell {
-    max-width: 900px;
-    padding: 1rem var(--space-lg);
-  }
-}
-
-@media (max-width: 480px) {
-  .shell {
-    padding: 0.5rem var(--space-sm);
-    gap: 0.5rem;
-  }
-  .teamName {
-    font-size: 1.05rem;
-  }
-  .gameCode {
-    font-size: 0.85rem;
-  }
+/* The BuzzButton's default 28px rounding would expose viewport corners when
+   it fills the screen, and its `height: 100%` needs a parent whose height
+   is fully resolved — the flex stretch from .buzzZone delivers that. */
+.buzzZone > button {
+  border-radius: 0;
+  flex: 1 1 auto;
 }

--- a/frontend/src/pages/TeamGameplayPage.test.tsx
+++ b/frontend/src/pages/TeamGameplayPage.test.tsx
@@ -187,78 +187,34 @@ describe("TeamGameplayPage", () => {
     expect(screen.queryByTestId("buzz")).not.toBeInTheDocument();
   });
 
-  it("does not render the post-buzz timer before any team has buzzed", async () => {
+  it("never renders the post-buzz countdown timer (the display screen is the source of truth)", async () => {
+    // The team screen used to mirror the 10s post-buzz countdown from the
+    // display, but it stole vertical real estate from the BUZZ button without
+    // adding new info (players are already looking at the display). We now
+    // assert there is never a timer here, even mid-buzz with another team
+    // holding the lock.
+    const FIXED_NOW = 1_780_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+    const lockedAt = new Date(FIXED_NOW - 2_000).toISOString();
     window.localStorage.setItem(
       "game:ABCDEF:team",
       JSON.stringify({ id: "team-1", name: "Alice" }),
     );
     setHydrate({
-      game: makeActiveGame({ status: "playing", buzzed_team_id: null, locked_at: null }),
-      teams: [makeTeam({ id: "team-1", name: "Alice" })],
-      rounds: [],
+      game: makeActiveGame({
+        status: "playing",
+        current_round_id: "round-1",
+        buzzed_team_id: "team-2",
+        locked_at: lockedAt,
+      }),
+      teams: [makeTeam({ id: "team-1" }), makeTeam({ id: "team-2", name: "Bob" })],
+      rounds: [makeRound({ id: "round-1" })],
     });
     renderAt("/team/ABCDEF");
     await act(async () => {
       await fireSubscribed();
     });
     expect(screen.queryByRole("timer")).not.toBeInTheDocument();
-  });
-
-  describe("timer accessibility", () => {
-    // The countdown only runs AFTER a team buzzes (post-buzz answer timer,
-    // 10 seconds total). We hydrate with another team holding the lock so
-    // the local team sees the timer without being the one that buzzed.
-    function setupBuzzedRound(secondsAgo: number): void {
-      const FIXED_NOW = 1_780_000_000_000;
-      vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
-      const lockedAt = new Date(FIXED_NOW - secondsAgo * 1000).toISOString();
-      window.localStorage.setItem(
-        "game:ABCDEF:team",
-        JSON.stringify({ id: "team-1", name: "Alice" }),
-      );
-      setHydrate({
-        game: makeActiveGame({
-          status: "playing",
-          current_round_id: "round-1",
-          buzzed_team_id: "team-2",
-          locked_at: lockedAt,
-        }),
-        teams: [makeTeam({ id: "team-1" }), makeTeam({ id: "team-2", name: "Bob" })],
-        rounds: [makeRound({ id: "round-1" })],
-      });
-    }
-
-    it("uses a static aria-label on the timer (no per-tick rewrite)", async () => {
-      setupBuzzedRound(2);
-      renderAt("/team/ABCDEF");
-      await act(async () => {
-        await fireSubscribed();
-      });
-      const timer = await screen.findByRole("timer");
-      expect(timer).toHaveAttribute("aria-label", "Time remaining");
-    });
-
-    it("renders an empty live region when there is plenty of time left", async () => {
-      setupBuzzedRound(2);
-      renderAt("/team/ABCDEF");
-      await act(async () => {
-        await fireSubscribed();
-      });
-      const timer = await screen.findByRole("timer");
-      const liveRegion = timer.querySelector('[aria-live="polite"]');
-      expect(liveRegion?.textContent).toBe("");
-    });
-
-    it("announces low time when remaining seconds drop to the 5→1 tail", async () => {
-      setupBuzzedRound(7);
-      renderAt("/team/ABCDEF");
-      await act(async () => {
-        await fireSubscribed();
-      });
-      const timer = await screen.findByRole("timer");
-      const liveRegion = timer.querySelector('[aria-live="polite"]');
-      expect(liveRegion?.textContent).toBe("3 seconds left");
-    });
   });
 
   it("pops a +N pill on this team's phone when our own score goes up", async () => {

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import { BuzzButton, type BuzzTone } from "../components/BuzzButton";
 import { EndScreen } from "../components/EndScreen";
 import { PointChange } from "../components/PointChange";
-import { RoundCountdown } from "../components/RoundCountdown";
 import { useBuzzer } from "../hooks/useBuzzer";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { clearStoredTeam, getStoredTeam } from "../lib/teamStorage";
@@ -13,8 +12,6 @@ interface PointEvent {
   id: string;
   delta: number;
 }
-
-const ANSWER_DURATION_SEC = 10;
 
 export function TeamGameplayPage() {
   const { gameCode = "" } = useParams<{ gameCode: string }>();
@@ -94,9 +91,6 @@ export function TeamGameplayPage() {
   const lockedTeam =
     game?.buzzed_team_id != null ? (state?.teams.get(game.buzzed_team_id) ?? null) : null;
 
-  const lockedAt = game?.locked_at ?? null;
-  const timerActive = game?.status === "playing" && lockedTeam != null && lockedAt != null;
-
   const buzzDisabled =
     !state || status !== "subscribed" || game?.status !== "playing" || buzzer.isLocked;
 
@@ -127,25 +121,15 @@ export function TeamGameplayPage() {
           />
         ))}
       </div>
-      <header className={styles.header}>
-        <div className={styles.identity}>
-          <span className={styles.teamName}>{stored.name}</span>
-          {game && game.status !== "waiting" ? (
-            <span className={styles.roundPill} data-testid="round-indicator">
-              Round {game.round_number}
-            </span>
-          ) : null}
-        </div>
-      </header>
 
-      {timerActive && lockedAt ? (
-        <RoundCountdown
-          lockedAt={lockedAt}
-          durationSec={ANSWER_DURATION_SEC}
-          styles={styles}
-          withSrAnnouncer
-        />
-      ) : null}
+      <div className={styles.identityOverlay} aria-label="Team identity">
+        <span className={styles.teamName}>{stored.name}</span>
+        {game && game.status !== "waiting" ? (
+          <span className={styles.roundPill} data-testid="round-indicator">
+            R{game.round_number}
+          </span>
+        ) : null}
+      </div>
 
       <div className={styles.buzzZone}>
         <BuzzButton

--- a/tests/e2e/manager_cleanup_yt_csp.spec.ts
+++ b/tests/e2e/manager_cleanup_yt_csp.spec.ts
@@ -2,7 +2,9 @@
 //   #1 Manager screen has no "Invite Players" section.
 //   #2 Manager screen has no per-team Kick button.
 //   #3 Post-buzz countdown bar replaces the old pre-buzz round timer.
-//   #4 Manager screen has no countdown bar (timer only on team + display).
+//   #4 Manager screen has no countdown bar (timer lives on the display only;
+//      the team screen used to mirror it but no longer does — players have
+//      the display in view and the team UI is now the full-bleed BUZZ).
 //   #5 YouTube player iframe loads with a real 11-char video ID after the
 //      first start_round (no more error 153 "blank embed URL").
 //   #6 Manager network traffic stays bounded after 20s of idle - the
@@ -48,7 +50,7 @@ test.describe("manager-cleanup-yt-csp branch", () => {
     await manager.page.close();
   });
 
-  test("manager screen never renders a countdown timer; team + display do, only after buzz", async ({
+  test("countdown timer lives on the display only; manager + team never render one", async ({
     browser,
   }) => {
     const manager = await openManagerAndCreateGame(browser, { genreName: "Rock" });
@@ -68,7 +70,6 @@ test.describe("manager-cleanup-yt-csp branch", () => {
     ).toBeVisible({ timeout: 10_000 });
 
     // PRE-buzz: no timer on any of the three roles.
-    // (Old behaviour: 20s pre-buzz countdown on team + manager.)
     await expect(manager.page.getByRole("timer")).toHaveCount(0);
     await expect(team.page.getByRole("timer")).toHaveCount(0);
     await expect(display.getByRole("timer")).toHaveCount(0);
@@ -79,26 +80,30 @@ test.describe("manager-cleanup-yt-csp branch", () => {
       timeout: 10_000,
     });
 
-    // POST-buzz: timer on team + display, NOT on manager.
+    // POST-buzz: timer ONLY on display. Manager and team never show it (the
+    // team screen is now full-bleed BUZZ; players watch the display for time).
     await expect(manager.page.getByRole("timer")).toHaveCount(0);
-    const teamTimer = team.page.getByRole("timer");
+    await expect(team.page.getByRole("timer")).toHaveCount(0);
     const displayTimer = display.getByRole("timer");
-    await expect(teamTimer).toBeVisible({ timeout: 5_000 });
     await expect(displayTimer).toBeVisible({ timeout: 5_000 });
 
-    // Both timers count down (initial value at most 10, drops within ~3s).
-    const startTeam = parseInt(((await teamTimer.textContent()) ?? "").replace(/\D/g, ""), 10);
-    expect(startTeam).toBeGreaterThan(0);
-    expect(startTeam).toBeLessThanOrEqual(10);
+    const startDisplay = parseInt(
+      ((await displayTimer.textContent()) ?? "").replace(/\D/g, ""),
+      10,
+    );
+    expect(startDisplay).toBeGreaterThan(0);
+    expect(startDisplay).toBeLessThanOrEqual(10);
 
-    await team.page.waitForTimeout(3_000);
-    const laterTeam = parseInt(((await teamTimer.textContent()) ?? "").replace(/\D/g, ""), 10);
-    expect(laterTeam).toBeLessThan(startTeam);
+    await display.waitForTimeout(3_000);
+    const laterDisplay = parseInt(
+      ((await displayTimer.textContent()) ?? "").replace(/\D/g, ""),
+      10,
+    );
+    expect(laterDisplay).toBeLessThan(startDisplay);
 
-    // Manager scores + advances; lock clears; timers disappear on team + display.
+    // Manager scores + advances; lock clears; the display timer disappears.
     await manager.page.getByTestId("score-title").click();
     await manager.page.getByTestId("start-round").click();
-    await expect(team.page.getByRole("timer")).toHaveCount(0, { timeout: 10_000 });
     await expect(display.getByRole("timer")).toHaveCount(0, { timeout: 10_000 });
 
     await display.close();


### PR DESCRIPTION
## Summary

- **Team buzzer is now full-bleed.** Removed the header chrome and timer from `TeamGameplayPage`; the `BuzzButton` now reaches every viewport edge on phone and desktop. Team name + round number layer on top as a small semi-transparent pill in the corner (matches the user-chosen mockup).
- **Dropped the 10s post-buzz countdown from the team screen.** The display already shows the same timer; the duplicate on the team device was stealing vertical real estate from the button. `RoundCountdown` stays in use by `DisplayPage`.
- **Soundtrack "Correct +15" no longer auto-resumes the song or re-arms the buzzers.** Removed the `releaseBuzzLockDirect` + `playerRef.current?.play()` calls from `handleCorrectSoundtrack`. The round now sits in the fully-scored-but-locked state, mirroring how a regular round behaves once both title + artist tokens have been claimed — manager presses **Next round** to advance.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 263 / 263 pass (TeamGameplayPage + ManagerConsolePage specs updated to match new behaviour)
- [x] `npm run build` — clean
- [x] Backend `pytest` — 188 pass; 12 `test_rls_anon` failures are pre-existing on `main` (Docker / testcontainers fixture cross-contamination — pass in isolation; see `.claude/rules/lessons-learned.md`)
- [x] Local 4-team smoke (Alpha / Bravo / Charlie / Delta) with the seed catalog; both soundtrack songs (Star Wars + Inception) exercised. Verified end-to-end via the running app:
  - Full-bleed BUZZ button on a 1280×800 viewport (desktop) and a 414×896 viewport (phone), in `waiting`, `idle`, and `winner` tones — no white space anywhere
  - No `role="timer"` on the team screen pre- or post-buzz; the display still renders the countdown
  - On a soundtrack round (Star Wars, Alpha buzzed): after **Correct +15**, `active_games.buzzed_team_id` stayed set, `locked_at` stayed populated, both `title_claimed_by` + `artist_claimed_by` were assigned, and the team's screen stayed on blue **YOU BUZZED** until the host advanced
  - Final podium rendered for all 4 teams on the display
- [x] E2E spec `tests/e2e/manager_cleanup_yt_csp.spec.ts` updated: the timer is now asserted on the **display only**; team + manager must never render one

Local seed has 13 songs total; the smoke played 12 rounds before `select_next_song` correctly raised `no_more_songs`. Both soundtracks were among the 12.