### PR TITLE
Re-tune start times for 588 catalog songs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-30: Re-tuned the playback start time for 588 songs in the catalog so each clip begins on a more recognizable part of the song.
 - 2026-05-25: Team buzzer screen is now full-bleed — the BUZZ button reaches every edge of the phone, with the team name + current round shown as a small pill overlay in the top corner. Larger tap target, no chrome competing for the screen.
 
 ### Removed


### PR DESCRIPTION
## Summary

Re-tuned the playback `start_time` for 588 songs in the catalog so each clip begins on a more recognizable part of the song (the hook/chorus rather than a quiet intro).

The data change was applied directly to the production `songs` table via 588 drift-protected `UPDATE` statements (each scoped by `youtube_id` AND the previously-exported `start_time`, run in a single transaction). This PR contains only the CHANGELOG entry documenting that change — `songs` is durable production data, not seeded from the repo.

## Test plan

- [x] Generated idempotent UPDATEs from the reviewed start-time list; applied in one transaction against prod (Frankfurt)
- [x] In-transaction verification returned 588 rows at their new values
- [x] Independent re-pull of all start_times cross-checked against the source list: 588/588 confirmed, 0 mismatches, 0 missing