### PR TITLE
Derive soundtrack rounds from genre membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-30: Songs in the **Soundtracks** / **Israeli Soundtracks** genres now always play as +15 soundtrack rounds. Soundtrack-ness is derived from genre membership instead of a separate per-song flag, fixing ~28 songs (e.g. Hungry Eyes, Shallow, the Star Wars and Disney themes) that were tagged as soundtracks but still scored as normal title/artist rounds. The admin Songs page drops the "Soundtrack round" checkbox — tagging a soundtrack genre is now the single marker.
 - 2026-05-25: Soundtrack rounds no longer auto-resume the song or re-arm the buzzers after the host taps **Correct (+15)**. The round now waits for an explicit **Next round** press, matching how regular rounds behave once both title and artist have been scored.
 
 ### Added

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,0 +1,15 @@
+"""Shared constants.
+
+Soundtrack rounds (single "Correct +15" scoring) are identified purely by genre
+membership — there is no per-song is_soundtrack column (dropped in migration
+028). The genres table is the source of truth; this set names the soundtrack
+genres by slug for the layers that can't perform the SQL join themselves: the
+admin list view (reads slugs from the PostgREST embed) and the CSV importer
+(slugs come straight from the upload's genres column). select_next_song hardcodes
+the same slugs in SQL.
+"""
+
+from __future__ import annotations
+
+# Slugs of the genres whose songs play as soundtrack rounds.
+SOUNDTRACK_GENRE_SLUGS = frozenset({"soundtracks", "israeli-soundtracks"})

--- a/backend/app/models/songs.py
+++ b/backend/app/models/songs.py
@@ -39,7 +39,6 @@ class SongCreate(BaseModel):
     artist: SongArtist
     youtube_id: YouTubeId
     start_time: int = Field(default=0, ge=0)
-    is_soundtrack: bool = False
     genre_ids: list[UUID] = Field(default_factory=list, min_length=1)
 
 
@@ -50,7 +49,6 @@ class SongUpdate(BaseModel):
     artist: SongArtist
     youtube_id: YouTubeId
     start_time: int = Field(default=0, ge=0)
-    is_soundtrack: bool = False
     genre_ids: list[UUID] = Field(default_factory=list, min_length=1)
 
 

--- a/backend/app/routers/admin_songs.py
+++ b/backend/app/routers/admin_songs.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import anyio
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile, status
 
+from app.constants import SOUNDTRACK_GENRE_SLUGS
 from app.db.errors import NotFoundError, mapped_postgrest_errors
 from app.db.supabase_client import SupabaseClientLike, get_supabase_client
 from app.middleware.admin_auth import require_admin
@@ -27,7 +28,7 @@ router = APIRouter(
     dependencies=[Depends(require_admin)],
 )
 
-SONG_COLUMNS = "id,title,artist,youtube_id,start_time,is_soundtrack"
+SONG_COLUMNS = "id,title,artist,youtube_id,start_time"
 
 
 def _attach_genres(client: SupabaseClientLike, songs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -56,7 +57,11 @@ def _attach_genres(client: SupabaseClientLike, songs: list[dict[str, Any]]) -> l
         if meta:
             by_song.setdefault(r["song_id"], []).append(meta)
     for s in songs:
-        s["genres"] = by_song.get(s["id"], [])
+        genres = by_song.get(s["id"], [])
+        s["genres"] = genres
+        # Soundtrack-ness is derived from genre membership (migration 028): a
+        # song is a soundtrack iff it belongs to a soundtrack genre.
+        s["is_soundtrack"] = any(g.get("slug") in SOUNDTRACK_GENRE_SLUGS for g in genres)
     return songs
 
 
@@ -116,7 +121,6 @@ def _create_song_blocking(client: SupabaseClientLike, body: SongCreate) -> dict[
         "artist": body.artist,
         "youtube_id": body.youtube_id,
         "start_time": body.start_time,
-        "is_soundtrack": body.is_soundtrack,
     }
     with mapped_postgrest_errors():
         resp = client.table("songs").insert(payload).execute()
@@ -142,7 +146,6 @@ def _update_song_blocking(
         "artist": body.artist,
         "youtube_id": body.youtube_id,
         "start_time": body.start_time,
-        "is_soundtrack": body.is_soundtrack,
     }
     with mapped_postgrest_errors():
         client.table("songs").update(payload).eq("id", song_id).execute()

--- a/backend/app/services/csv_import.py
+++ b/backend/app/services/csv_import.py
@@ -15,6 +15,7 @@ from typing import IO
 
 import anyio
 
+from app.constants import SOUNDTRACK_GENRE_SLUGS
 from app.db.errors import ValidationError
 from app.db.supabase_client import SupabaseClientLike
 
@@ -23,13 +24,10 @@ REQUIRED_COLUMNS = (
     "artist",
     "youtube_id",
     "start_time",
-    "is_soundtrack",
     "genres",
 )
 
 _YOUTUBE_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
-_TRUE_VALUES = frozenset({"true", "1", "yes", "y", "t"})
-_FALSE_VALUES = frozenset({"false", "0", "no", "n", "f", ""})
 
 
 @dataclass(frozen=True)
@@ -39,7 +37,6 @@ class SongImportRow:
     artist: str
     youtube_id: str
     start_time: int
-    is_soundtrack: bool
     genre_slugs: list[str]
 
 
@@ -61,18 +58,6 @@ def _parse_int(value: str, *, line: int, field: str) -> int:
             f"row {line}: {field} must be an integer",
             details={"line": line, "field": field, "issue": "not_an_integer"},
         ) from exc
-
-
-def _parse_bool(value: str, *, line: int, field: str) -> bool:
-    stripped = value.strip().lower()
-    if stripped in _TRUE_VALUES:
-        return True
-    if stripped in _FALSE_VALUES:
-        return False
-    raise ValidationError(
-        f"row {line}: {field} must be true/false",
-        details={"line": line, "field": field, "issue": "not_a_boolean"},
-    )
 
 
 def parse_csv(stream: IO[bytes] | bytes) -> list[SongImportRow]:
@@ -101,33 +86,10 @@ def parse_csv(stream: IO[bytes] | bytes) -> list[SongImportRow]:
         title = (raw_row.get("title") or "").strip()
         artist = (raw_row.get("artist") or "").strip()
         youtube_id = (raw_row.get("youtube_id") or "").strip()
-        is_soundtrack = _parse_bool(
-            raw_row.get("is_soundtrack") or "", line=index, field="is_soundtrack"
-        )
         if not title:
             raise ValidationError(
                 f"row {index}: title is required",
                 details={"line": index, "field": "title", "issue": "empty"},
-            )
-        if is_soundtrack:
-            # Soundtrack rule: title holds the show name; artist mirrors it.
-            # Blank artist is auto-filled; non-blank artist must match title
-            # so a typo doesn't slip in and split the soundtrack invariant.
-            if not artist:
-                artist = title
-            elif artist != title:
-                raise ValidationError(
-                    f"row {index}: for soundtracks, artist must be blank or equal to title",
-                    details={
-                        "line": index,
-                        "field": "artist",
-                        "issue": "soundtrack_artist_mismatch",
-                    },
-                )
-        elif not artist:
-            raise ValidationError(
-                f"row {index}: artist is required",
-                details={"line": index, "field": "artist", "issue": "empty"},
             )
         if not _YOUTUBE_ID.match(youtube_id):
             raise ValidationError(
@@ -154,6 +116,29 @@ def parse_csv(stream: IO[bytes] | bytes) -> list[SongImportRow]:
                 details={"line": index, "field": "genres", "issue": "empty"},
             )
 
+        # Soundtrack-ness is derived from genre membership (migration 028). For
+        # soundtracks the show name lives in title and artist mirrors it; a blank
+        # artist is auto-filled, a mismatching one is rejected so the invariant
+        # can't silently split.
+        is_soundtrack = any(slug in SOUNDTRACK_GENRE_SLUGS for slug in genre_slugs)
+        if is_soundtrack:
+            if not artist:
+                artist = title
+            elif artist != title:
+                raise ValidationError(
+                    f"row {index}: for soundtracks, artist must be blank or equal to title",
+                    details={
+                        "line": index,
+                        "field": "artist",
+                        "issue": "soundtrack_artist_mismatch",
+                    },
+                )
+        elif not artist:
+            raise ValidationError(
+                f"row {index}: artist is required",
+                details={"line": index, "field": "artist", "issue": "empty"},
+            )
+
         rows.append(
             SongImportRow(
                 line=index,
@@ -161,7 +146,6 @@ def parse_csv(stream: IO[bytes] | bytes) -> list[SongImportRow]:
                 artist=artist,
                 youtube_id=youtube_id,
                 start_time=start_time,
-                is_soundtrack=is_soundtrack,
                 genre_slugs=genre_slugs,
             )
         )
@@ -211,7 +195,6 @@ def _apply_blocking(client: SupabaseClientLike, rows: list[SongImportRow]) -> Im
             "artist": row.artist,
             "youtube_id": row.youtube_id,
             "start_time": row.start_time,
-            "is_soundtrack": row.is_soundtrack,
         }
         if row.youtube_id in existing:
             song_id = existing[row.youtube_id]

--- a/db/migrations/028_derive_is_soundtrack_from_genre.sql
+++ b/db/migrations/028_derive_is_soundtrack_from_genre.sql
@@ -1,0 +1,146 @@
+-- 028_derive_is_soundtrack_from_genre.sql
+-- Soundtrack-ness was stored twice: as the songs.is_soundtrack boolean AND as
+-- membership in the Soundtracks / Israeli Soundtracks genres. The two drifted
+-- (28 songs sat in a soundtrack genre with is_soundtrack=false, so they played
+-- as normal rounds). Genre membership is already a superset of the boolean, so
+-- we collapse to a single source of truth:
+--
+--   a song is a soundtrack  <=>  it belongs to a genre whose slug is in
+--                                ('soundtracks', 'israeli-soundtracks').
+--
+-- This migration:
+--   1. Drops songs.is_soundtrack.
+--   2. Re-issues select_next_song with the SAME signature and RETURNS shape as
+--      migration 027; the only change is that the is_soundtrack column is now
+--      COMPUTED via EXISTS over song_genres -> genres instead of read from the
+--      dropped column. Because the RETURNS TABLE shape is unchanged, no DROP
+--      FUNCTION is needed (CREATE OR REPLACE suffices) and PostgREST routing is
+--      untouched.
+--
+-- Idempotent: DROP COLUMN IF EXISTS + CREATE OR REPLACE are both re-runnable.
+-- The new function body no longer references songs.is_soundtrack, so dropping
+-- the column before replacing the function is safe.
+
+BEGIN;
+
+-- Step 1: drop the redundant per-song boolean.
+ALTER TABLE songs DROP COLUMN IF EXISTS is_soundtrack;
+
+-- Step 2: re-issue select_next_song. Body is identical to migration 027 except
+-- the final SELECT derives is_soundtrack from genre membership.
+CREATE OR REPLACE FUNCTION select_next_song(
+  p_game_code      text,
+  p_manager_token  uuid,
+  p_song_id        uuid DEFAULT NULL
+)
+RETURNS TABLE(
+  round_id      uuid,
+  round_number  integer,
+  song_id       uuid,
+  song_title    text,
+  song_artist   text,
+  youtube_id    text,
+  start_time    integer,
+  is_soundtrack boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_expected_token uuid;
+  v_game_ended_at  timestamptz;
+  v_genres         uuid[];
+  v_chosen_song    uuid;
+  v_round_id       uuid;
+  v_round_number   integer;
+BEGIN
+  SELECT ag.manager_token, ag.ended_at, ag.selected_genres
+    INTO v_expected_token, v_game_ended_at, v_genres
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_game_ended_at IS NOT NULL THEN
+    RAISE EXCEPTION 'game_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_expected_token IS NULL
+     OR p_manager_token IS NULL
+     OR v_expected_token <> p_manager_token THEN
+    RAISE EXCEPTION 'manager_token_required' USING ERRCODE = '28000';
+  END IF;
+
+  IF v_genres IS NULL OR cardinality(v_genres) = 0 THEN
+    RAISE EXCEPTION 'no_genres_selected' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_song_id IS NOT NULL THEN
+    PERFORM 1 FROM songs WHERE id = p_song_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'song_not_found' USING ERRCODE = 'P0002';
+    END IF;
+    v_chosen_song := p_song_id;
+  ELSE
+    WITH played AS (
+      SELECT gr.song_id AS sid
+        FROM game_rounds gr
+       WHERE gr.game_code = p_game_code
+         AND gr.song_id IS NOT NULL
+    ),
+    eligible AS (
+      SELECT sg.genre_id AS gid, sg.song_id AS sid
+        FROM song_genres sg
+       WHERE sg.genre_id = ANY (v_genres)
+         AND sg.song_id NOT IN (SELECT played.sid FROM played)
+    ),
+    chosen_genre AS (
+      SELECT eligible.gid
+        FROM eligible
+       GROUP BY eligible.gid
+       ORDER BY random()
+       LIMIT 1
+    )
+    SELECT e.sid INTO v_chosen_song
+      FROM eligible e
+      JOIN chosen_genre cg ON cg.gid = e.gid
+     ORDER BY random()
+     LIMIT 1;
+
+    IF v_chosen_song IS NULL THEN
+      RAISE EXCEPTION 'no_more_songs' USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  v_round_id := start_round(p_game_code::char(6), v_chosen_song);
+
+  SELECT ag.round_number INTO v_round_number
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  RETURN QUERY
+    SELECT v_round_id,
+           v_round_number,
+           s.id,
+           s.title,
+           s.artist,
+           s.youtube_id::text,
+           s.start_time,
+           EXISTS (
+             SELECT 1
+               FROM song_genres sg
+               JOIN genres g ON g.id = sg.genre_id
+              WHERE sg.song_id = s.id
+                AND g.slug IN ('soundtracks', 'israeli-soundtracks')
+           ) AS is_soundtrack
+      FROM songs s
+     WHERE s.id = v_chosen_song;
+END $$;
+
+GRANT EXECUTE ON FUNCTION select_next_song(text, uuid, uuid)
+  TO anon, authenticated, service_role;
+
+COMMIT;

--- a/db/seed/songs.sql
+++ b/db/seed/songs.sql
@@ -16,23 +16,27 @@
 -- loads a video (guard against the "error 153 / video unavailable" regression),
 -- so the seed needs at least the chosen genre to have a real, embeddable ID.
 
-INSERT INTO songs (title, artist, youtube_id, start_time, is_soundtrack)
-SELECT s.title, s.artist, s.youtube_id, s.start_time, s.is_soundtrack
+-- Soundtrack-ness is derived from genre membership (migration 028 dropped the
+-- songs.is_soundtrack column). The two soundtrack rows get their soundtrack
+-- behaviour from the song_genres mapping below (genre slug 'soundtracks').
+INSERT INTO songs (title, artist, youtube_id, start_time)
+SELECT s.title, s.artist, s.youtube_id, s.start_time
 FROM (VALUES
-  ('E2E Test Song 1',  'E2E Test Artist A', 'dQw4w9WgXcQ', 0, false),
-  ('E2E Test Song 2',  'E2E Test Artist B', 'jNQXAC9IVRw', 0, false),
-  ('E2E Test Song 3',  'E2E Test Artist C', '9bZkp7q19f0', 0, false),
-  ('E2E Test Song 4',  'E2E Test Artist D', 'fJ9rUzIMcZQ', 0, false),
-  ('E2E Test Song 5',  'E2E Test Artist E', 'kJQP7kiw5Fk', 0, false),
-  ('E2E Test Song 6',  'E2E Test Artist F', 'OPf0YbXqDm0', 0, false),
-  ('E2E Test Song 7',  'E2E Test Artist G', 'JGwWNGJdvx8', 0, false),
-  ('E2E Test Song 8',  'E2E Test Artist H', 'CevxZvSJLk8', 0, false),
-  ('E2E Test Song 9',  'E2E Test Artist I', '09R8_2nJtjg', 0, false),
-  ('E2E Test Song 10', 'E2E Test Artist J', 'hT_nvWreIhg', 0, false),
-  -- Soundtrack rows follow the title=artist=show-name invariant.
-  ('Star Wars',        'Star Wars',         'nfWlot6h_JM', 0, true),
-  ('Inception',        'Inception',         'e-ORhEE9VVg', 0, true)
-) AS s(title, artist, youtube_id, start_time, is_soundtrack)
+  ('E2E Test Song 1',  'E2E Test Artist A', 'dQw4w9WgXcQ', 0),
+  ('E2E Test Song 2',  'E2E Test Artist B', 'jNQXAC9IVRw', 0),
+  ('E2E Test Song 3',  'E2E Test Artist C', '9bZkp7q19f0', 0),
+  ('E2E Test Song 4',  'E2E Test Artist D', 'fJ9rUzIMcZQ', 0),
+  ('E2E Test Song 5',  'E2E Test Artist E', 'kJQP7kiw5Fk', 0),
+  ('E2E Test Song 6',  'E2E Test Artist F', 'OPf0YbXqDm0', 0),
+  ('E2E Test Song 7',  'E2E Test Artist G', 'JGwWNGJdvx8', 0),
+  ('E2E Test Song 8',  'E2E Test Artist H', 'CevxZvSJLk8', 0),
+  ('E2E Test Song 9',  'E2E Test Artist I', '09R8_2nJtjg', 0),
+  ('E2E Test Song 10', 'E2E Test Artist J', 'hT_nvWreIhg', 0),
+  -- Soundtrack rows: the work name lives in title/artist; the 'soundtracks'
+  -- genre tag below is what makes them play as +15 soundtrack rounds.
+  ('Star Wars',        'Star Wars',         'nfWlot6h_JM', 0),
+  ('Inception',        'Inception',         'e-ORhEE9VVg', 0)
+) AS s(title, artist, youtube_id, start_time)
 WHERE NOT EXISTS (
   SELECT 1 FROM songs WHERE songs.youtube_id = s.youtube_id
 );

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -134,7 +134,7 @@ Frontend wrapper: `frontend/src/hooks/useSelectNextSong.ts::selectNextSongDirect
   "song_artist": "Artist Name",
   "youtube_id": "dQw4w9WgXcQ",
   "start_time": 30,
-  "source": null
+  "is_soundtrack": false
 }]
 ```
 

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -310,10 +310,10 @@ All under `/admin/songs/*`. **Admin-password auth required** on every endpoint (
 |---|---|---|
 | `GET`    | `/admin/songs` | List songs (paginated, `?page=1&per_page=50&search=&genre=`) |
 | `GET`    | `/admin/songs/{id}` | Get one song |
-| `POST`   | `/admin/songs` | Create a song (body: `title, artist, youtube_id, start_time, source, genre_ids[]`). When `source` is set, the admin UI auto-adds the Soundtracks genre id to `genre_ids` (or Israeli Soundtracks when `source` contains Hebrew characters) so soundtrack-only filtering works for game creation. |
+| `POST`   | `/admin/songs` | Create a song (body: `title, artist, youtube_id, start_time, genre_ids[]`). Tagging the song with a soundtrack genre (Soundtracks / Israeli Soundtracks) is what makes it a +15 soundtrack round — there is no separate flag; convention is `title = artist = show name`. |
 | `PUT`    | `/admin/songs/{id}` | Update a song (full replacement; partial use PATCH if needed later) |
 | `DELETE` | `/admin/songs/{id}` | Delete a song (cascades to `song_genres`) |
-| `POST`   | `/admin/songs/bulk-import` | Multipart CSV upload; columns: `title, artist, youtube_id, start_time, source, genres` (semicolon-separated genre slugs) |
+| `POST`   | `/admin/songs/bulk-import` | Multipart CSV upload; columns: `title, artist, youtube_id, start_time, genres` (semicolon-separated genre slugs). A row plays as a soundtrack round when its `genres` include `soundtracks` or `israeli-soundtracks`. |
 
 Bulk import is idempotent on `youtube_id`: existing songs are updated, new ones are inserted.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -41,7 +41,6 @@ CREATE TABLE songs (
   artist        text NOT NULL,
   youtube_id    char(11) NOT NULL,
   start_time    integer NOT NULL DEFAULT 0,    -- seconds
-  is_soundtrack boolean NOT NULL DEFAULT false,  -- TRUE = soundtrack round: manager + display show a 🎬 badge, scoring collapses to a single "Correct (+15)" button, and admin save auto-tags the Soundtracks genre (Israeli Soundtracks when title contains Hebrew characters). Invariant for soundtracks: title = artist = show name (film / TV / game / musical); enforced by the admin form's auto-mirror and by the CSV importer.
   created_at    timestamptz NOT NULL DEFAULT now(),
   updated_at    timestamptz NOT NULL DEFAULT now()
 );
@@ -120,6 +119,20 @@ CREATE INDEX song_genres_genre_idx        ON song_genres (genre_id);
 The `active_games_expires_at_idx` is the most important: it backs the hourly pg_cron sweep, which scans for rows past their TTL.
 
 ## 4. Field Notes
+
+### Soundtrack rounds — no `is_soundtrack` column
+
+There is **no `is_soundtrack` column** on `songs` (it was dropped in migration 028).
+Soundtrack-ness — whether a round uses the single **Correct (+15)** button and the 🎬
+badge instead of the title/artist split — is derived from genre membership: a song is a
+soundtrack ⇔ it belongs to a genre whose slug is in `('soundtracks', 'israeli-soundtracks')`.
+The genres table is the single source of truth, so the per-song flag can no longer drift
+from the genre tag. The value is still surfaced everywhere as a field named
+`is_soundtrack`, just **computed** rather than stored: `select_next_song` computes it in
+SQL via `EXISTS` over `song_genres → genres` (see `rpc-functions.md §3c`), and the admin
+list / CSV importer compute it in Python from the genre slugs (`SOUNDTRACK_GENRE_SLUGS`
+in `backend/app/constants.py`). Convention for a soundtrack row: `title = artist = show
+name` (film / TV / game / musical).
 
 ### `active_games.game_code`
 

--- a/docs/game-rules.md
+++ b/docs/game-rules.md
@@ -101,14 +101,14 @@ Maximum per **buzz** from `award_attempt`: **+15** (title + artist together). Mi
 
 ### Soundtrack rounds
 
-When the current song has a `source` set (i.e. it's from a film / TV show / game / musical), the round plays differently:
+When the current song belongs to a **soundtrack genre** (`Soundtracks` or `Israeli Soundtracks`), the round plays differently:
 
 - A 🎬 **Soundtrack** badge appears on both the manager and display screens above the song area, so everyone knows the round is a soundtrack round.
-- The manager's two scoring buttons collapse into a single **Correct (+15)** button. The team's job is to name the **work** (the source), not the song title — soundtrack trivia in practice means players recognise the film/show, not the track. Wrong (−3) still applies.
+- The manager's two scoring buttons collapse into a single **Correct (+15)** button. The team's job is to name the **work** (the film / TV show / game / musical), not the song title — soundtrack trivia in practice means players recognise the show, not the track. Wrong (−3) still applies.
 - The single Correct button fires `award_attempt` with `p_title=10, p_artist=5` so the sum lands as +15 via the existing SQL function — no new RPC, no scoring branch in the DB.
-- On the display, the reveal panel shows "🎵 Title" and "🎬 from <source>" (instead of "🎤 Artist") once the manager confirms; both rows light up together.
+- On the display, the reveal panel shows a single **🎬 <work name>** row (instead of the separate "🎵 Title" / "🎤 Artist" rows) once the manager confirms.
 
-**Admin convention for soundtrack songs**: store the work name in the `artist` field (e.g. `artist = "Star Wars"` for the Imperial March, `artist = "Titanic"` for "My Heart Will Go On"). `source` typically matches. Setting `source` on save auto-tags the song with the **Soundtracks** genre, or **Israeli Soundtracks** when `source` contains Hebrew characters, so the host can filter to a Hebrew-only or English-only soundtrack round.
+**Admin convention for soundtrack songs**: store the work name in **both** the `title` and `artist` fields (e.g. `title = artist = "Star Wars"` for the Imperial March, `title = artist = "Titanic"` for "My Heart Will Go On"), and **tag the song with the Soundtracks genre** — or **Israeli Soundtracks** for Hebrew film / TV themes, so the host can filter to a Hebrew-only or English-only soundtrack round. That genre tag is the single soundtrack marker: there is no separate per-song flag, checkbox, or `source` column. A song is a soundtrack round purely because it belongs to a soundtrack genre.
 
 ### Free-guess rule
 

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -334,6 +334,7 @@ Behavior:
 - Manual path: caller supplies `p_song_id`; validates it exists in `songs`, raises `song_not_found` (`P0002`) otherwise. No "already played in this game" check (matches the legacy REST manual-pick semantics — Restart-song flow).
 - Delegates round creation to `start_round`, so the prior round is closed defensively, `round_number` advances, and `active_games.current_round_id` / `current_song_id` are wired up.
 - Returns one row with the new round + the picked song's metadata.
+- The returned `is_soundtrack` flag is **computed** (migration 028), not read from a column — `songs.is_soundtrack` was dropped. It is `EXISTS(SELECT 1 FROM song_genres sg JOIN genres g ON g.id = sg.genre_id WHERE sg.song_id = <picked> AND g.slug IN ('soundtracks', 'israeli-soundtracks'))`, i.e. true when the song belongs to a soundtrack genre. The `RETURNS TABLE` shape is unchanged, so PostgREST routing and the realtime/frontend contract are identical.
 
 ### Idempotency
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -193,13 +193,13 @@ describe("api - admin-songs routes", () => {
     youtube_id: "abcdefghijk",
     start_time: 0,
     is_soundtrack: false,
+    genres: [],
   };
   const PAYLOAD: SongWritePayload = {
     title: "Song",
     artist: "Artist",
     youtube_id: "abcdefghijk",
     start_time: 0,
-    is_soundtrack: false,
     genre_ids: ["g1"],
   };
 

--- a/frontend/src/lib/soundtrack.test.ts
+++ b/frontend/src/lib/soundtrack.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { deriveIsSoundtrack, SOUNDTRACK_GENRE_SLUGS } from "./soundtrack";
+
+describe("deriveIsSoundtrack", () => {
+  it("is true when a genre slug is a soundtrack slug", () => {
+    expect(deriveIsSoundtrack([{ genres: { slug: "soundtracks" } }])).toBe(true);
+    expect(deriveIsSoundtrack([{ genres: { slug: "israeli-soundtracks" } }])).toBe(true);
+  });
+
+  it("is true when any of several genres is a soundtrack slug", () => {
+    expect(
+      deriveIsSoundtrack([{ genres: { slug: "rock" } }, { genres: { slug: "soundtracks" } }]),
+    ).toBe(true);
+  });
+
+  it("is false for non-soundtrack genres", () => {
+    expect(deriveIsSoundtrack([{ genres: { slug: "rock" } }, { genres: { slug: "pop" } }])).toBe(
+      false,
+    );
+  });
+
+  it("is false for empty / null / missing genre data", () => {
+    expect(deriveIsSoundtrack([])).toBe(false);
+    expect(deriveIsSoundtrack(null)).toBe(false);
+    expect(deriveIsSoundtrack(undefined)).toBe(false);
+    expect(deriveIsSoundtrack([null])).toBe(false);
+    expect(deriveIsSoundtrack([{ genres: null }])).toBe(false);
+    expect(deriveIsSoundtrack([{ genres: { slug: null } }])).toBe(false);
+  });
+
+  it("exposes the two soundtrack slugs", () => {
+    expect(SOUNDTRACK_GENRE_SLUGS).toEqual(["soundtracks", "israeli-soundtracks"]);
+  });
+});

--- a/frontend/src/lib/soundtrack.ts
+++ b/frontend/src/lib/soundtrack.ts
@@ -1,0 +1,26 @@
+// Soundtrack rounds are derived from genre membership (migration 028 dropped
+// the songs.is_soundtrack column). A song plays as a +15 soundtrack round when
+// it belongs to a genre whose slug is in SOUNDTRACK_GENRE_SLUGS. This mirrors
+// the SQL in select_next_song and SOUNDTRACK_GENRE_SLUGS in
+// backend/app/constants.py -- keep the three in sync.
+//
+// In-game pages (Display, Manager) fetch the current song directly and can no
+// longer select the dropped column, so they embed the song's genre slugs
+// (`song_genres(genres(slug))`) and compute the flag client-side.
+
+export const SOUNDTRACK_GENRE_SLUGS = ["soundtracks", "israeli-soundtracks"] as const;
+
+// Shape of a `song_genres(genres(slug))` PostgREST embed row.
+export interface SongGenreSlugEmbed {
+  genres: { slug: string | null } | null;
+}
+
+export function deriveIsSoundtrack(
+  songGenres: ReadonlyArray<SongGenreSlugEmbed | null> | null | undefined,
+): boolean {
+  const soundtrackSlugs: ReadonlySet<string> = new Set(SOUNDTRACK_GENRE_SLUGS);
+  return (songGenres ?? []).some((sg) => {
+    const slug = sg?.genres?.slug;
+    return slug != null && soundtrackSlugs.has(slug);
+  });
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -149,7 +149,6 @@ export interface SongWritePayload {
   artist: string;
   youtube_id: string;
   start_time: number;
-  is_soundtrack: boolean;
   genre_ids: string[];
 }
 

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -259,7 +259,6 @@ describe("AdminSongsPage: create + edit + delete", () => {
         artist: "Some artist",
         youtube_id: "abcdefghijk",
         start_time: 0,
-        is_soundtrack: false,
         genre_ids: ["g1"],
       },
       "letmein",
@@ -267,51 +266,51 @@ describe("AdminSongsPage: create + edit + delete", () => {
     await waitFor(() => expect(screen.getByText(/song created/i)).toBeInTheDocument());
   });
 
-  it("auto-mirrors artist from title and tags Soundtracks when the soundtrack box is checked", async () => {
+  it("tags the Soundtracks genre and sends no separate soundtrack flag", async () => {
     vi.mocked(createSong).mockResolvedValue(SONG_A);
     renderPage();
     await signIn();
 
     fireEvent.click(screen.getByRole("button", { name: /\+ new song/i }));
     fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: "Star Wars" } });
+    fireEvent.change(screen.getByLabelText(/^artist$/i), { target: { value: "Star Wars" } });
     fireEvent.change(screen.getByLabelText(/^youtube id$/i), {
       target: { value: "abcdefghijk" },
     });
-    fireEvent.click(screen.getByLabelText(/^soundtrack round$/i));
-    fireEvent.click(screen.getByLabelText(/^rock$/i));
+    // Soundtrack-ness now comes from picking a soundtrack genre, not a checkbox.
+    fireEvent.click(screen.getByLabelText(/^soundtracks$/i));
 
     fireEvent.click(screen.getByRole("button", { name: /create song/i }));
 
     await waitFor(() => expect(createSong).toHaveBeenCalled());
     const [payload] = vi.mocked(createSong).mock.calls[0]!;
-    expect(payload.is_soundtrack).toBe(true);
     expect(payload.title).toBe("Star Wars");
     expect(payload.artist).toBe("Star Wars");
-    expect([...payload.genre_ids].sort()).toEqual(["g1", "g3"]);
+    expect([...payload.genre_ids].sort()).toEqual(["g3"]);
+    expect("is_soundtrack" in payload).toBe(false);
   });
 
-  it("auto-tags Israeli Soundtracks (not generic) when soundtrack title is Hebrew", async () => {
+  it("can tag the Israeli Soundtracks genre", async () => {
     vi.mocked(createSong).mockResolvedValue(SONG_A);
     renderPage();
     await signIn();
 
     fireEvent.click(screen.getByRole("button", { name: /\+ new song/i }));
     fireEvent.change(screen.getByLabelText(/^title$/i), { target: { value: "גבעת חלפון" } });
+    fireEvent.change(screen.getByLabelText(/^artist$/i), { target: { value: "גבעת חלפון" } });
     fireEvent.change(screen.getByLabelText(/^youtube id$/i), {
       target: { value: "abcdefghijk" },
     });
-    fireEvent.click(screen.getByLabelText(/^soundtrack round$/i));
-    fireEvent.click(screen.getByLabelText(/^rock$/i));
+    fireEvent.click(screen.getByLabelText(/^israeli soundtracks$/i));
 
     fireEvent.click(screen.getByRole("button", { name: /create song/i }));
 
     await waitFor(() => expect(createSong).toHaveBeenCalled());
     const [payload] = vi.mocked(createSong).mock.calls[0]!;
-    expect(payload.is_soundtrack).toBe(true);
     expect(payload.title).toBe("גבעת חלפון");
     expect(payload.artist).toBe("גבעת חלפון");
-    // g4 = Israeli Soundtracks; g3 = generic Soundtracks should NOT be added.
-    expect([...payload.genre_ids].sort()).toEqual(["g1", "g4"]);
+    expect([...payload.genre_ids].sort()).toEqual(["g4"]);
+    expect("is_soundtrack" in payload).toBe(false);
   });
 
   it("disables submit while the form is invalid", async () => {

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -26,11 +26,6 @@ import styles from "./AdminSongsPage.module.css";
 const PER_PAGE = 50;
 const YT_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 const SEARCH_DEBOUNCE_MS = 250;
-const SOUNDTRACKS_GENRE_SLUG = "soundtracks";
-const ISRAELI_SOUNDTRACKS_GENRE_SLUG = "israeli-soundtracks";
-// Hebrew unicode block; used to route a soundtrack auto-tag to the Israeli
-// bucket when the title (= show name) is in Hebrew.
-const HEBREW_CHAR_RE = /[֐-׿]/;
 
 type Mode = { kind: "list" } | { kind: "create" } | { kind: "edit"; song: Song };
 
@@ -39,7 +34,6 @@ interface FormState {
   artist: string;
   youtube_id: string;
   start_time: string;
-  is_soundtrack: boolean;
   genre_ids: Set<string>;
 }
 
@@ -48,7 +42,6 @@ const EMPTY_FORM: FormState = {
   artist: "",
   youtube_id: "",
   start_time: "0",
-  is_soundtrack: false,
   genre_ids: new Set(),
 };
 
@@ -58,43 +51,23 @@ function songToForm(song: Song, genreIds: string[]): FormState {
     artist: song.artist,
     youtube_id: song.youtube_id,
     start_time: String(song.start_time),
-    is_soundtrack: song.is_soundtrack,
     genre_ids: new Set(genreIds),
   };
 }
 
-function formToPayload(form: FormState, genres: Genre[]): SongWritePayload {
-  const title = form.title.trim();
-  // Soundtrack invariant: title = artist = show name. Mirror title into
-  // artist so non-soundtrack code paths can read both fields without
-  // a NULL check.
-  const artist = form.is_soundtrack ? title : form.artist.trim();
-  const genre_ids = new Set(form.genre_ids);
-  // Auto-tag: soundtrack rounds route to the Israeli bucket when the title
-  // (= show name) is Hebrew, otherwise the generic Soundtracks bucket.
-  // Admin can still toggle chips to override.
-  if (form.is_soundtrack) {
-    const targetSlug = HEBREW_CHAR_RE.test(title)
-      ? ISRAELI_SOUNDTRACKS_GENRE_SLUG
-      : SOUNDTRACKS_GENRE_SLUG;
-    const match = genres.find((g) => g.slug === targetSlug);
-    if (match) genre_ids.add(match.id);
-  }
+function formToPayload(form: FormState): SongWritePayload {
   return {
-    title,
-    artist,
+    title: form.title.trim(),
+    artist: form.artist.trim(),
     youtube_id: form.youtube_id.trim(),
     start_time: Number(form.start_time),
-    is_soundtrack: form.is_soundtrack,
-    genre_ids: Array.from(genre_ids),
+    genre_ids: Array.from(form.genre_ids),
   };
 }
 
 function formIsValid(form: FormState): boolean {
   if (form.title.trim().length === 0 || form.title.trim().length > 200) return false;
-  if (!form.is_soundtrack) {
-    if (form.artist.trim().length === 0 || form.artist.trim().length > 200) return false;
-  }
+  if (form.artist.trim().length === 0 || form.artist.trim().length > 200) return false;
   if (!YT_ID_PATTERN.test(form.youtube_id.trim())) return false;
   const start = Number(form.start_time);
   if (!Number.isInteger(start) || start < 0) return false;
@@ -544,7 +517,7 @@ function SongForm({ genres, initial, submitLabel, busy, onCancel, onSubmit }: So
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!valid || busy) return;
-    onSubmit(formToPayload(form, genres));
+    onSubmit(formToPayload(form));
   }
 
   return (
@@ -562,14 +535,13 @@ function SongForm({ genres, initial, submitLabel, busy, onCancel, onSubmit }: So
           />
         </label>
         <label className={styles.field}>
-          <span>{form.is_soundtrack ? "Artist (mirrors title for soundtracks)" : "Artist"}</span>
+          <span>Artist</span>
           <input
             type="text"
-            value={form.is_soundtrack ? form.title : form.artist}
+            value={form.artist}
             onChange={(e) => setForm({ ...form, artist: e.target.value })}
             maxLength={200}
             aria-label="Artist"
-            disabled={form.is_soundtrack}
           />
         </label>
         <label className={styles.field}>
@@ -592,18 +564,6 @@ function SongForm({ genres, initial, submitLabel, busy, onCancel, onSubmit }: So
             onChange={(e) => setForm({ ...form, start_time: e.target.value })}
             aria-label="Start time"
           />
-        </label>
-        <label className={`${styles.field} ${styles.fieldFull} ${styles.soundtrackToggle}`}>
-          <input
-            type="checkbox"
-            checked={form.is_soundtrack}
-            onChange={(e) => setForm({ ...form, is_soundtrack: e.target.checked })}
-            aria-label="Soundtrack round"
-          />
-          <span>
-            Soundtrack round — title holds the show name; artist auto-mirrors and the song auto-tags
-            Israeli Soundtracks (Hebrew title) or Soundtracks (otherwise).
-          </span>
         </label>
         <div className={`${styles.field} ${styles.fieldFull}`}>
           <span>Genres ({form.genre_ids.size} selected)</span>

--- a/frontend/src/pages/DisplayPage.tsx
+++ b/frontend/src/pages/DisplayPage.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "../components/Skeleton";
 import { SoundtrackBadge } from "../components/SoundtrackBadge";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { supabase } from "../lib/supabase";
+import { deriveIsSoundtrack, type SongGenreSlugEmbed } from "../lib/soundtrack";
 import type { Song } from "../lib/types";
 import styles from "./DisplayPage.module.css";
 
@@ -92,11 +93,16 @@ function DisplayBoard({ gameCode }: { gameCode: string }) {
     void (async () => {
       const { data, error } = await supabase
         .from("songs")
-        .select("id,title,artist,youtube_id,start_time,is_soundtrack")
+        .select("id,title,artist,youtube_id,start_time,song_genres(genres(slug))")
         .eq("id", currentRoundSongId)
         .maybeSingle();
       if (cancelled || error || !data) return;
-      setCurrentSong(data as Song);
+      // is_soundtrack is derived from genre membership (migration 028 dropped
+      // the column), so compute it from the embedded genre slugs.
+      const { song_genres, ...base } = data as unknown as Omit<Song, "is_soundtrack" | "genres"> & {
+        song_genres: SongGenreSlugEmbed[] | null;
+      };
+      setCurrentSong({ ...base, is_soundtrack: deriveIsSoundtrack(song_genres) });
     })();
     return () => {
       cancelled = true;

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -13,6 +13,7 @@ import { awardAttemptDirect, releaseBuzzLockDirect, RpcError } from "../hooks/us
 import { selectNextSongDirect } from "../hooks/useSelectNextSong";
 import { clearManagerToken, getManagerToken } from "../lib/managerToken";
 import { supabase } from "../lib/supabase";
+import { deriveIsSoundtrack, type SongGenreSlugEmbed } from "../lib/soundtrack";
 import type { Song } from "../lib/types";
 import styles from "./ManagerConsolePage.module.css";
 
@@ -105,11 +106,16 @@ export function ManagerConsolePage() {
     void (async () => {
       const { data, error } = await supabase
         .from("songs")
-        .select("id,title,artist,youtube_id,start_time,is_soundtrack")
+        .select("id,title,artist,youtube_id,start_time,song_genres(genres(slug))")
         .eq("id", currentRoundSongId)
         .maybeSingle();
       if (cancelled || error || !data) return;
-      const song = data as Song;
+      // is_soundtrack is derived from genre membership (migration 028 dropped
+      // the column), so compute it from the embedded genre slugs.
+      const { song_genres, ...base } = data as unknown as Omit<Song, "is_soundtrack" | "genres"> & {
+        song_genres: SongGenreSlugEmbed[] | null;
+      };
+      const song: Song = { ...base, is_soundtrack: deriveIsSoundtrack(song_genres) };
       setCurrentSong(song);
       if (playerReady) {
         playerRef.current?.loadVideoById(song.youtube_id, song.start_time);

--- a/frontend/src/test/supabaseMock.ts
+++ b/frontend/src/test/supabaseMock.ts
@@ -67,7 +67,16 @@ function buildSelect(table: TableName | "songs") {
         return { data: state.hydrate.game, error: null };
       }
       if (table === "songs" && pendingId !== null) {
-        return { data: state.songsById[pendingId] ?? null, error: null };
+        const row = state.songsById[pendingId];
+        if (!row) return { data: null, error: null };
+        // The in-game pages no longer select the dropped is_soundtrack column;
+        // they embed genre slugs (`song_genres(genres(slug))`) and derive it.
+        // Reproduce that shape from the stored flag so tests keep setting
+        // is_soundtrack directly.
+        const song_genres = row.is_soundtrack
+          ? [{ genres: { slug: "soundtracks" } }]
+          : [{ genres: { slug: "rock" } }];
+        return { data: { ...row, song_genres }, error: null };
       }
       return { data: null, error: null };
     }),

--- a/tests/backend/_helpers.py
+++ b/tests/backend/_helpers.py
@@ -21,15 +21,11 @@ def random_game_code() -> str:
 
 
 def random_youtube_id() -> str:
-    alphabet = (
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-    )
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
     return "".join(secrets.choice(alphabet) for _ in range(11))
 
 
-async def fetch_genre_ids(
-    db: asyncpg.Connection, slugs: list[str] | None = None
-) -> list[UUID]:
+async def fetch_genre_ids(db: asyncpg.Connection, slugs: list[str] | None = None) -> list[UUID]:
     if slugs:
         rows = await db.fetch(
             "SELECT id FROM genres WHERE slug = ANY($1::text[]) ORDER BY slug",
@@ -46,20 +42,20 @@ async def insert_song(
     title: str = "Test Title",
     artist: str = "Test Artist",
     youtube_id: str | None = None,
-    is_soundtrack: bool = False,
     genre_slugs: list[str] | None = None,
 ) -> UUID:
+    # Soundtrack-ness is derived from genre membership (migration 028); pass
+    # genre_slugs=["soundtracks"] to make a song a soundtrack round.
     yid = youtube_id or random_youtube_id()
     row = await db.fetchrow(
         """
-        INSERT INTO songs (title, artist, youtube_id, is_soundtrack)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO songs (title, artist, youtube_id)
+        VALUES ($1, $2, $3)
         RETURNING id
         """,
         title,
         artist,
         yid,
-        is_soundtrack,
     )
     assert row is not None
     song_id: UUID = row["id"]
@@ -105,9 +101,7 @@ def manager_headers(token: UUID | str) -> dict[str, str]:
     return {"X-Manager-Token": str(token)}
 
 
-async def insert_team(
-    db: asyncpg.Connection, game_code: str, *, name: str | None = None
-) -> UUID:
+async def insert_team(db: asyncpg.Connection, game_code: str, *, name: str | None = None) -> UUID:
     team_name = name or f"Team-{secrets.token_hex(3)}"
     row = await db.fetchrow(
         """

--- a/tests/backend/test_admin_songs_bulk_import.py
+++ b/tests/backend/test_admin_songs_bulk_import.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.needs_docker
 
 
 def _csv(rows: list[list[str]]) -> bytes:
-    header = "title,artist,youtube_id,start_time,is_soundtrack,genres\n"
+    header = "title,artist,youtube_id,start_time,genres\n"
     body = "\n".join(",".join(r) for r in rows)
     return (header + body + "\n").encode("utf-8")
 
@@ -20,8 +20,8 @@ def _csv(rows: list[list[str]]) -> bytes:
 async def test_inserts_new_rows(admin_client) -> None:
     csv = _csv(
         [
-            ["Hello", "Adele", "YQHsXMglC9A", "0", "false", "rock"],
-            ["Yesterday", "Beatles", "NrgmdOz227I", "10", "false", "rock"],
+            ["Hello", "Adele", "YQHsXMglC9A", "0", "rock"],
+            ["Yesterday", "Beatles", "NrgmdOz227I", "10", "rock"],
         ]
     )
     resp = await admin_client.post(
@@ -35,12 +35,8 @@ async def test_inserts_new_rows(admin_client) -> None:
 
 
 async def test_updates_existing_youtube_id(admin_client, db) -> None:
-    await insert_song(
-        db, title="Old", artist="Old", youtube_id="DUPKEY12345", genre_slugs=["rock"]
-    )
-    csv = _csv(
-        [["NewTitle", "NewArtist", "DUPKEY12345", "5", "false", "rock"]]
-    )
+    await insert_song(db, title="Old", artist="Old", youtube_id="DUPKEY12345", genre_slugs=["rock"])
+    csv = _csv([["NewTitle", "NewArtist", "DUPKEY12345", "5", "rock"]])
     resp = await admin_client.post(
         "/admin/songs/bulk-import",
         files={"file": ("songs.csv", io.BytesIO(csv), "text/csv")},
@@ -49,17 +45,15 @@ async def test_updates_existing_youtube_id(admin_client, db) -> None:
     body = resp.json()
     assert body["inserted"] == 0
     assert body["updated"] == 1
-    row = await db.fetchrow(
-        "SELECT title FROM songs WHERE youtube_id = $1", "DUPKEY12345"
-    )
+    row = await db.fetchrow("SELECT title FROM songs WHERE youtube_id = $1", "DUPKEY12345")
     assert row["title"] == "NewTitle"
 
 
 async def test_malformed_row_rejected_with_line_number(admin_client) -> None:
     csv = _csv(
         [
-            ["Hello", "Adele", "YQHsXMglC9A", "0", "false", "rock"],
-            ["Bad", "Bad", "tooshort", "0", "false", "rock"],
+            ["Hello", "Adele", "YQHsXMglC9A", "0", "rock"],
+            ["Bad", "Bad", "tooshort", "0", "rock"],
         ]
     )
     resp = await admin_client.post(
@@ -73,9 +67,7 @@ async def test_malformed_row_rejected_with_line_number(admin_client) -> None:
 
 
 async def test_unknown_genre_rejected(admin_client) -> None:
-    csv = _csv(
-        [["Song", "Artist", "abcDEF1234X", "0", "false", "non_existent_slug"]]
-    )
+    csv = _csv([["Song", "Artist", "abcDEF1234X", "0", "non_existent_slug"]])
     resp = await admin_client.post(
         "/admin/songs/bulk-import",
         files={"file": ("songs.csv", io.BytesIO(csv), "text/csv")},
@@ -85,7 +77,7 @@ async def test_unknown_genre_rejected(admin_client) -> None:
 
 
 async def test_admin_required(client) -> None:
-    csv = _csv([["X", "Y", "abcDEF1234X", "0", "false", "rock"]])
+    csv = _csv([["X", "Y", "abcDEF1234X", "0", "rock"]])
     resp = await client.post(
         "/admin/songs/bulk-import",
         files={"file": ("songs.csv", io.BytesIO(csv), "text/csv")},

--- a/tests/backend/test_admin_songs_crud.py
+++ b/tests/backend/test_admin_songs_crud.py
@@ -21,7 +21,6 @@ async def test_create_and_get(admin_client, db) -> None:
         "artist": "Tester",
         "youtube_id": "abcDEF12345",
         "start_time": 30,
-        "is_soundtrack": False,
         "genre_ids": [str(rock[0])],
     }
     create_resp = await admin_client.post("/admin/songs", json=payload)
@@ -44,7 +43,6 @@ async def test_invalid_youtube_id_400(admin_client, db) -> None:
             "artist": "Bad",
             "youtube_id": "tooshort",
             "start_time": 0,
-            "is_soundtrack": False,
             "genre_ids": [str(rock[0])],
         },
     )
@@ -61,7 +59,6 @@ async def test_update(admin_client, db) -> None:
             "artist": "Updated",
             "youtube_id": "ZZZZZZZZZZZ",
             "start_time": 5,
-            "is_soundtrack": False,
             "genre_ids": [str(rock[0])],
         },
     )
@@ -140,7 +137,6 @@ async def test_create_response_includes_attached_genres(admin_client, db) -> Non
             "artist": "X",
             "youtube_id": "qqqqqqqqqqq",
             "start_time": 0,
-            "is_soundtrack": False,
             "genre_ids": [str(rock), str(pop)],
         },
     )
@@ -150,16 +146,12 @@ async def test_create_response_includes_attached_genres(admin_client, db) -> Non
 
 
 async def test_get_unknown_id_404(admin_client) -> None:
-    resp = await admin_client.get(
-        "/admin/songs/00000000-0000-0000-0000-000000000000"
-    )
+    resp = await admin_client.get("/admin/songs/00000000-0000-0000-0000-000000000000")
     assert resp.status_code == 404
 
 
 async def test_delete_unknown_id_404(admin_client) -> None:
-    resp = await admin_client.delete(
-        "/admin/songs/00000000-0000-0000-0000-000000000000"
-    )
+    resp = await admin_client.delete("/admin/songs/00000000-0000-0000-0000-000000000000")
     assert resp.status_code == 404
 
 
@@ -172,7 +164,6 @@ async def test_update_unknown_id_404(admin_client, db) -> None:
             "artist": "Y",
             "youtube_id": "abcDEF12345",
             "start_time": 0,
-            "is_soundtrack": False,
             "genre_ids": [str(rock[0])],
         },
     )

--- a/tests/backend/test_services_unit.py
+++ b/tests/backend/test_services_unit.py
@@ -43,7 +43,7 @@ async def test_generate_unique_code_exhausts_after_retries() -> None:
 # ----- csv_import.parse_csv ---------------------------------------------
 
 
-HEADER = "title,artist,youtube_id,start_time,is_soundtrack,genres"
+HEADER = "title,artist,youtube_id,start_time,genres"
 
 
 def _bytes(rows: list[str]) -> bytes:
@@ -51,10 +51,9 @@ def _bytes(rows: list[str]) -> bytes:
 
 
 def test_parse_csv_happy_path() -> None:
-    rows = csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,false,rock"]))
+    rows = csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,rock"]))
     assert len(rows) == 1
     assert rows[0].title == "Hello"
-    assert rows[0].is_soundtrack is False
     assert rows[0].genre_slugs == ["rock"]
 
 
@@ -73,72 +72,63 @@ def test_parse_csv_empty_body_rejected() -> None:
 
 def test_parse_csv_invalid_youtube_id() -> None:
     with pytest.raises(ValidationError) as exc_info:
-        csv_import.parse_csv(_bytes(["Hi,There,short,0,false,rock"]))
+        csv_import.parse_csv(_bytes(["Hi,There,short,0,rock"]))
     assert exc_info.value.details["field"] == "youtube_id"
 
 
 def test_parse_csv_missing_title() -> None:
     with pytest.raises(ValidationError) as exc_info:
-        csv_import.parse_csv(_bytes([",Adele,YQHsXMglC9A,0,false,rock"]))
+        csv_import.parse_csv(_bytes([",Adele,YQHsXMglC9A,0,rock"]))
     assert exc_info.value.details["field"] == "title"
 
 
 def test_parse_csv_missing_artist_for_non_soundtrack() -> None:
     with pytest.raises(ValidationError) as exc_info:
-        csv_import.parse_csv(_bytes(["Hello,,YQHsXMglC9A,0,false,rock"]))
+        csv_import.parse_csv(_bytes(["Hello,,YQHsXMglC9A,0,rock"]))
     assert exc_info.value.details["field"] == "artist"
 
 
 def test_parse_csv_soundtrack_auto_mirrors_blank_artist() -> None:
-    rows = csv_import.parse_csv(
-        _bytes(["Pirates of the Caribbean,,YQHsXMglC9A,0,true,soundtracks"])
-    )
-    assert rows[0].is_soundtrack is True
+    # Soundtrack-ness comes from the genre slug now; blank artist auto-mirrors.
+    rows = csv_import.parse_csv(_bytes(["Pirates of the Caribbean,,YQHsXMglC9A,0,soundtracks"]))
     assert rows[0].title == "Pirates of the Caribbean"
     assert rows[0].artist == "Pirates of the Caribbean"
 
 
 def test_parse_csv_soundtrack_artist_must_match_title() -> None:
     with pytest.raises(ValidationError) as exc_info:
-        csv_import.parse_csv(
-            _bytes(["Pirates,Klaus Badelt,YQHsXMglC9A,0,true,soundtracks"])
-        )
+        csv_import.parse_csv(_bytes(["Pirates,Klaus Badelt,YQHsXMglC9A,0,soundtracks"]))
     assert exc_info.value.details["field"] == "artist"
     assert exc_info.value.details["issue"] == "soundtrack_artist_mismatch"
 
 
-def test_parse_csv_bad_boolean_is_soundtrack() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,maybe,rock"]))
-    assert exc_info.value.details["field"] == "is_soundtrack"
+def test_parse_csv_israeli_soundtrack_genre_is_soundtrack() -> None:
+    # The israeli-soundtracks slug also triggers the soundtrack mirror rule.
+    rows = csv_import.parse_csv(_bytes(["נילס,,YQHsXMglC9A,0,israeli-soundtracks"]))
+    assert rows[0].artist == "נילס"
 
 
 def test_parse_csv_negative_start_time() -> None:
     with pytest.raises(ValidationError):
-        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,-1,false,rock"]))
+        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,-1,rock"]))
 
 
 def test_parse_csv_bad_int_start_time() -> None:
     with pytest.raises(ValidationError):
-        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,abc,false,rock"]))
+        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,abc,rock"]))
 
 
 def test_parse_csv_no_genre_slugs() -> None:
     with pytest.raises(ValidationError):
-        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,false,"]))
+        csv_import.parse_csv(_bytes(["Hello,Adele,YQHsXMglC9A,0,"]))
 
 
 def test_parse_csv_accepts_stream() -> None:
-    rows = csv_import.parse_csv(
-        io.BytesIO(_bytes(["Hello,Adele,YQHsXMglC9A,0,false,rock;pop"]))
-    )
-    assert rows[0].is_soundtrack is False
+    rows = csv_import.parse_csv(io.BytesIO(_bytes(["Hello,Adele,YQHsXMglC9A,0,rock;pop"])))
     assert rows[0].genre_slugs == ["rock", "pop"]
 
 
 def test_parse_csv_strips_bom() -> None:
-    raw = b"\xef\xbb\xbf" + _bytes(["Hi,Adele,YQHsXMglC9A,0,false,rock"])
+    raw = b"\xef\xbb\xbf" + _bytes(["Hi,Adele,YQHsXMglC9A,0,rock"])
     rows = csv_import.parse_csv(raw)
     assert rows[0].title == "Hi"
-
-

--- a/tests/backend/test_validation.py
+++ b/tests/backend/test_validation.py
@@ -42,7 +42,6 @@ async def test_admin_song_invalid_youtube_id(admin_client, db) -> None:
             "artist": "Y",
             "youtube_id": "WAY_TOO_LONG_FOR_YT_ID_FORMAT_!!!",
             "start_time": 0,
-            "is_soundtrack": False,
             "genre_ids": [str(genres[0])],
         },
     )

--- a/tests/db/_helpers.py
+++ b/tests/db/_helpers.py
@@ -86,19 +86,22 @@ async def create_test_song(
     title: str = "Test Title",
     artist: str = "Test Artist",
     youtube_id: str = "abcdefghijk",
-    is_soundtrack: bool = False,
 ) -> uuid.UUID:
-    """Insert one row into songs and return its id."""
+    """Insert one row into songs and return its id.
+
+    Soundtrack-ness is derived from genre membership (migration 028), so there
+    is no is_soundtrack column to set here; attach the song to the 'soundtracks'
+    or 'israeli-soundtracks' genre via song_genres to make it a soundtrack.
+    """
     row = await conn.fetchrow(
         """
-        INSERT INTO songs (title, artist, youtube_id, is_soundtrack)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO songs (title, artist, youtube_id)
+        VALUES ($1, $2, $3)
         RETURNING id
         """,
         title,
         artist,
         youtube_id,
-        is_soundtrack,
     )
     assert row is not None
     return row["id"]

--- a/tests/e2e/admin_songs_crud.spec.ts
+++ b/tests/e2e/admin_songs_crud.spec.ts
@@ -51,7 +51,6 @@ test("admin songs: full CRUD round-trip + bulk-import idempotency", async () => 
       artist: "tmp",
       youtube_id: Y1,
       start_time: 0,
-      source: "manual",
       genre_ids: [first.id],
     });
     expect(made.id).toMatch(/^[0-9a-f-]{36}$/i);
@@ -74,11 +73,9 @@ test("admin songs: full CRUD round-trip + bulk-import idempotency", async () => 
       artist: "tmp2",
       youtube_id: Y1,
       start_time: 5,
-      source: "manual",
       genre_ids: [second.id],
     });
     expect(updated.title).toBe(`${TAG}-updated`);
-    expect(updated.source).toBe("manual");
     expect(updated.start_time).toBe(5);
 
     // -- LIST with search filter -----------------------------------------
@@ -88,10 +85,10 @@ test("admin songs: full CRUD round-trip + bulk-import idempotency", async () => 
 
     // -- BULK IMPORT (1 update of existing yt_id + 2 fresh inserts) ------
     const csv = [
-      "title,artist,youtube_id,start_time,source,genres",
-      `${TAG}-updated-via-bulk,tmp3,${Y1},0,manual,${first.slug}`,
-      `${TAG}-bulk-1,tmp,${Y2},0,manual,${first.slug}`,
-      `${TAG}-bulk-2,tmp,${Y3},0,manual,${first.slug}`,
+      "title,artist,youtube_id,start_time,genres",
+      `${TAG}-updated-via-bulk,tmp3,${Y1},0,${first.slug}`,
+      `${TAG}-bulk-1,tmp,${Y2},0,${first.slug}`,
+      `${TAG}-bulk-2,tmp,${Y3},0,${first.slug}`,
     ].join("\n");
     const summary = await bulkImportSongs(csv);
     expect(summary).toEqual({ inserted: 2, updated: 1, total: 3 });

--- a/tests/e2e/bonus_flow.spec.ts
+++ b/tests/e2e/bonus_flow.spec.ts
@@ -64,17 +64,18 @@ test("scenario 13: bonus picker only lists current teams", async ({ browser }) =
   await joinAsTeam(browser, manager.gameCode, "Alpha");
   await joinAsTeam(browser, manager.gameCode, "Bravo");
 
-  // Open the picker and confirm both teams listed.
+  // Open the picker and confirm both teams listed. The picker buttons'
+  // accessible name is their aria-label ("Award +4 bonus to <name>").
   await manager.page.getByTestId("score-bonus").click();
   await expect(
-    manager.page.getByRole("button", { name: "Alpha", exact: true }),
+    manager.page.getByRole("button", { name: "Award +4 bonus to Alpha", exact: true }),
   ).toBeVisible();
   await expect(
-    manager.page.getByRole("button", { name: "Bravo", exact: true }),
+    manager.page.getByRole("button", { name: "Award +4 bonus to Bravo", exact: true }),
   ).toBeVisible();
   // No third "Charlie" team listed.
   await expect(
-    manager.page.getByRole("button", { name: "Charlie", exact: true }),
+    manager.page.getByRole("button", { name: "Award +4 bonus to Charlie", exact: true }),
   ).toHaveCount(0);
 });
 

--- a/tests/e2e/fixtures/admin-api.ts
+++ b/tests/e2e/fixtures/admin-api.ts
@@ -30,7 +30,9 @@ export interface SongPayload {
   artist: string;
   youtube_id: string;
   start_time: number;
-  source: string | null;
+  // Derived from genre membership (migration 028 dropped the column); a song
+  // is a soundtrack when it belongs to a Soundtracks / Israeli Soundtracks genre.
+  is_soundtrack: boolean;
 }
 
 export interface SongCreate {
@@ -38,7 +40,6 @@ export interface SongCreate {
   artist: string;
   youtube_id: string;
   start_time?: number;
-  source?: string | null;
   genre_ids: string[];
 }
 

--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -20,9 +20,12 @@ export interface ManagerSession {
 }
 
 interface CreateOpts {
-  // Display name as it appears in the UI (e.g. "Rock", "Pop"), matched
-  // case-insensitively.
-  genreName: string;
+  // Display name(s) as they appear in the UI (e.g. "Rock", "Pop"), matched
+  // case-insensitively. Use `genreName` for a single genre or `genreNames`
+  // to tick several (e.g. mix Soundtracks + Rock so a game draws both
+  // soundtrack and normal rounds).
+  genreName?: string;
+  genreNames?: string[];
 }
 
 export async function openManagerAndCreateGame(
@@ -32,17 +35,23 @@ export async function openManagerAndCreateGame(
   const context = await browser.newContext();
   const page = await context.newPage();
 
+  const genres = opts.genreNames ?? (opts.genreName ? [opts.genreName] : []);
+  if (genres.length === 0) throw new Error("openManagerAndCreateGame: no genre(s) given");
+
   // 1. Land on home and click the "Host a game" CTA.
   await page.goto("/");
   await page.getByRole("link", { name: /host a game/i }).click();
   await expect(page).toHaveURL(/\/manager\/create$/);
 
-  // 2. Wait for genres to load (the form fetches them on mount).
-  const genreLabel = page.getByLabel(new RegExp(`^${opts.genreName}$`, "i"));
-  await expect(genreLabel).toBeVisible({ timeout: 10_000 });
+  // 2. Wait for genres to load (the form fetches them on mount), then tick
+  //    each requested genre.
+  for (const name of genres) {
+    const genreLabel = page.getByLabel(new RegExp(`^${name}$`, "i"));
+    await expect(genreLabel).toBeVisible({ timeout: 10_000 });
+    await genreLabel.check();
+  }
 
-  // 3. Pick a genre and submit.
-  await genreLabel.check();
+  // 3. Submit.
   await page.getByRole("button", { name: /create game/i }).click();
 
   // 4. App navigates to /manager/game/<code> client-side. Read the code

--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -146,5 +146,9 @@ export async function skipRound(page: Page): Promise<void> {
 
 export async function awardBonusToTeam(page: Page, teamName: string): Promise<void> {
   await page.getByTestId("score-bonus").click();
-  await page.getByRole("button", { name: teamName, exact: true }).click();
+  // The picker button's accessible name is its aria-label
+  // ("Award +4 bonus to <name>"), not the bare team name.
+  await page
+    .getByRole("button", { name: `Award +4 bonus to ${teamName}`, exact: true })
+    .click();
 }

--- a/tests/e2e/fixtures/supabase-admin.ts
+++ b/tests/e2e/fixtures/supabase-admin.ts
@@ -35,6 +35,62 @@ export async function setExpiresAtPast(gameCode: string): Promise<void> {
   }
 }
 
+// Ground-truth round type, read straight from the DB via service role so the
+// playthrough never has to infer it from transient UI state during a round
+// transition. Returns true when the game's current song belongs to a
+// soundtrack genre (mirrors select_next_song's derivation).
+const SOUNDTRACK_SLUGS = new Set(["soundtracks", "israeli-soundtracks"]);
+
+interface GenreSlugRow {
+  genres: { slug: string | null } | null;
+}
+
+export async function getCurrentSongId(gameCode: string): Promise<string | null> {
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/active_games?game_code=eq.${encodeURIComponent(
+      gameCode,
+    )}&select=current_song_id`,
+    { headers: serviceHeaders() },
+  );
+  if (!res.ok) throw new Error(`GET active_games failed: ${res.status} ${await res.text()}`);
+  const rows = (await res.json()) as Array<{ current_song_id: string | null }>;
+  return rows[0]?.current_song_id ?? null;
+}
+
+export async function songIsSoundtrack(songId: string): Promise<boolean> {
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/songs?id=eq.${encodeURIComponent(
+      songId,
+    )}&select=song_genres(genres(slug))`,
+    { headers: serviceHeaders() },
+  );
+  if (!res.ok) throw new Error(`GET songs failed: ${res.status} ${await res.text()}`);
+  const rows = (await res.json()) as Array<{ song_genres: GenreSlugRow[] | null }>;
+  const slugs = (rows[0]?.song_genres ?? []).map((r) => r.genres?.slug);
+  return slugs.some((s) => s != null && SOUNDTRACK_SLUGS.has(s));
+}
+
+// Count distinct songs that belong to any of the given genre slugs. Used to
+// size the playthrough so it never exhausts the pool: the local real catalog
+// has hundreds, the CI seed only a handful.
+export async function countSongsInGenreSlugs(slugs: string[]): Promise<number> {
+  const slugList = slugs.map((s) => encodeURIComponent(s)).join(",");
+  const gRes = await fetch(`${SUPABASE_URL}/rest/v1/genres?slug=in.(${slugList})&select=id`, {
+    headers: serviceHeaders(),
+  });
+  if (!gRes.ok) throw new Error(`GET genres failed: ${gRes.status} ${await gRes.text()}`);
+  const genreIds = ((await gRes.json()) as Array<{ id: string }>).map((g) => g.id);
+  if (genreIds.length === 0) return 0;
+  const idList = genreIds.map((id) => encodeURIComponent(id)).join(",");
+  const sgRes = await fetch(
+    `${SUPABASE_URL}/rest/v1/song_genres?genre_id=in.(${idList})&select=song_id&limit=10000`,
+    { headers: serviceHeaders() },
+  );
+  if (!sgRes.ok) throw new Error(`GET song_genres failed: ${sgRes.status} ${await sgRes.text()}`);
+  const rows = (await sgRes.json()) as Array<{ song_id: string }>;
+  return new Set(rows.map((r) => r.song_id)).size;
+}
+
 export async function cleanupExpiredGames(): Promise<number> {
   const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/cleanup_expired_games`, {
     method: "POST",

--- a/tests/e2e/soundtrack_playthrough.spec.ts
+++ b/tests/e2e/soundtrack_playthrough.spec.ts
@@ -1,0 +1,185 @@
+// Full 4-team / 15-round playthrough that validates the derive-soundtrack-
+// from-genre behaviour (migration 028) end to end against a real catalog.
+//
+// The game is created across Soundtracks + Rock + Pop so select_next_song
+// draws a mix of soundtrack and normal rounds. Each round we:
+//   - detect the round type from the manager UI (single "Correct +15"
+//     button => soundtrack; the title/artist split => normal),
+//   - assert the matching UI contract on BOTH manager and display
+//     (soundtrack: 🎬 badge + one reveal row; normal: no badge + two rows),
+//   - have a rotating team buzz and score it (single token per round to keep
+//     the click flow deterministic),
+//   - assert the running total lands precisely on the display scoreboard
+//     (which also proves the RPC committed before we advance the round).
+//
+// Finally we assert at least one of each round type was exercised and the
+// podium renders.
+//
+// Robustness notes: the manager scoring/next-round handlers early-return while
+// a prior RPC is in flight (`busy`). The buttons disable optimistically, so a
+// naive click-then-click-next can be silently dropped. We therefore (a) only
+// click a single scoring control per round, (b) gate on the score landing on
+// the display before advancing, and (c) retry the advance until the round
+// number actually increments.
+
+import { test, expect, type Page } from "@playwright/test";
+import { openManagerAndCreateGame } from "./fixtures/manager-context";
+import {
+  countSongsInGenreSlugs,
+  getCurrentSongId,
+  songIsSoundtrack,
+} from "./fixtures/supabase-admin";
+import { buzzAndExpectWinner, joinAsTeam, type JoinedTeam } from "./fixtures/team-context";
+
+// Target a full 15-round game. Against the real prod catalog (run locally) the
+// pool is in the hundreds so all 15 run; against the tiny CI seed we cap at the
+// available pool so the game never hits `no_more_songs`. Both still cover at
+// least one soundtrack and one normal round.
+const TARGET_ROUNDS = 15;
+const GENRE_NAMES = ["Soundtracks", "Rock", "Pop"];
+const GENRE_SLUGS = ["soundtracks", "rock", "pop"];
+const TEAM_NAMES = ["Alpha", "Bravo", "Charlie", "Delta"];
+
+// Click "Next round" (or "Start game" for round 1) and wait for the round
+// number to actually increment, retrying if the click was dropped because a
+// scoring RPC was still in flight.
+async function advanceTo(page: Page, nextRoundNum: number): Promise<void> {
+  const heading = page.getByText(new RegExp(`Round ${nextRoundNum}$`, "i"));
+  for (let attempt = 0; attempt < 4; attempt++) {
+    await expect(page.getByTestId("start-round")).toBeEnabled({ timeout: 15_000 });
+    await page.getByTestId("start-round").click();
+    try {
+      await expect(heading).toBeVisible({ timeout: 8_000 });
+      return;
+    } catch {
+      /* click likely dropped (busy); retry */
+    }
+  }
+  throw new Error(`failed to advance to Round ${nextRoundNum}`);
+}
+
+test("4-team 15-round playthrough: soundtrack + normal rounds score and reveal correctly", async ({
+  browser,
+}, testInfo) => {
+  test.setTimeout(360_000);
+
+  const pool = await countSongsInGenreSlugs(GENRE_SLUGS);
+  const totalRounds = Math.min(TARGET_ROUNDS, pool);
+  expect(totalRounds, "need at least 2 songs to cover both round types").toBeGreaterThanOrEqual(2);
+
+  const manager = await openManagerAndCreateGame(browser, { genreNames: GENRE_NAMES });
+  const code = manager.gameCode;
+
+  const teams: JoinedTeam[] = [];
+  for (const name of TEAM_NAMES) {
+    teams.push(await joinAsTeam(browser, code, name));
+  }
+
+  const displayCtx = await browser.newContext();
+  const display = await displayCtx.newPage();
+  await display.goto(`/display/${code}`);
+  for (const name of TEAM_NAMES) {
+    await expect(display.locator(`[data-team-id]:has-text("${name}")`).first()).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+
+  const totals: Record<string, number> = Object.fromEntries(TEAM_NAMES.map((n) => [n, 0]));
+  let soundtrackRounds = 0;
+  let normalRounds = 0;
+
+  await advanceTo(manager.page, 1);
+
+  for (let i = 0; i < totalRounds; i++) {
+    const roundNum = i + 1;
+    await expect(manager.page.getByText(new RegExp(`Round ${roundNum}$`, "i"))).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Ground-truth round type from the DB (set in the same transaction that
+    // advanced the round), so detection never races the UI transition.
+    const songId = await getCurrentSongId(code);
+    expect(songId, "game should have a current song").toBeTruthy();
+    const isSoundtrack = await songIsSoundtrack(songId!);
+
+    // Assert both manager and display CONVERGE to the correct UI for this
+    // round type. These are auto-retrying assertions, so they tolerate either
+    // screen lagging the round transition.
+    if (isSoundtrack) {
+      await expect(manager.page.getByTestId("soundtrack-badge")).toBeVisible();
+      await expect(manager.page.getByTestId("score-soundtrack")).toBeVisible();
+      await expect(manager.page.getByTestId("score-title")).toHaveCount(0);
+      await expect(manager.page.getByTestId("score-artist")).toHaveCount(0);
+      await expect(display.getByTestId("soundtrack-badge")).toBeVisible();
+      await expect(display.getByTestId("display-reveal-title")).toHaveCount(1);
+      await expect(display.getByTestId("display-reveal-artist")).toHaveCount(0);
+    } else {
+      await expect(manager.page.getByTestId("soundtrack-badge")).toHaveCount(0);
+      await expect(manager.page.getByTestId("score-soundtrack")).toHaveCount(0);
+      await expect(manager.page.getByTestId("score-title")).toBeVisible();
+      await expect(manager.page.getByTestId("score-artist")).toBeVisible();
+      await expect(display.getByTestId("soundtrack-badge")).toHaveCount(0);
+      await expect(display.getByTestId("display-reveal-title")).toHaveCount(1);
+      await expect(display.getByTestId("display-reveal-artist")).toHaveCount(1);
+    }
+
+    const team = teams[i % teams.length]!;
+    await buzzAndExpectWinner(team);
+
+    let expected: number;
+    if (isSoundtrack) {
+      if (soundtrackRounds === 0) {
+        await manager.page.screenshot({ path: testInfo.outputPath("soundtrack-manager.png") });
+        await display.screenshot({ path: testInfo.outputPath("soundtrack-display.png") });
+      }
+      await manager.page.getByTestId("score-soundtrack").click();
+      expected = 15;
+      soundtrackRounds++;
+    } else {
+      // Alternate single-token awards: even normal round = Correct Song (+10),
+      // odd = Correct Artist (+5). One click per round avoids the optimistic
+      // double-click race in the title+artist combo path.
+      if (normalRounds === 0) {
+        await manager.page.screenshot({ path: testInfo.outputPath("normal-manager.png") });
+        await display.screenshot({ path: testInfo.outputPath("normal-display.png") });
+      }
+      if (normalRounds % 2 === 0) {
+        await manager.page.getByTestId("score-title").click();
+        expected = 10;
+      } else {
+        await manager.page.getByTestId("score-artist").click();
+        expected = 5;
+      }
+      normalRounds++;
+    }
+    totals[team.name] += expected;
+
+    // Gate on the exact new total landing on the display scoreboard row (the
+    // score span renders the exact number) -- this proves the attempt
+    // committed, so the manager's `busy` flag has cleared before we advance.
+    const row = display.locator(`[data-team-id]:has-text("${team.name}")`).first();
+    await expect(row.getByText(String(totals[team.name]), { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    if (roundNum < totalRounds) {
+      await advanceTo(manager.page, roundNum + 1);
+    }
+  }
+
+  expect(soundtrackRounds, "expected at least one soundtrack round in the mix").toBeGreaterThan(0);
+  expect(normalRounds, "expected at least one normal round in the mix").toBeGreaterThan(0);
+
+  // Close the game out and confirm the podium renders.
+  const endGameBtn = manager.page.getByTestId("end-game");
+  await expect(endGameBtn).toBeEnabled();
+  await endGameBtn.click();
+  const dialog = manager.page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /^end game$/i }).click();
+
+  await expect(display.getByRole("heading", { name: /final results/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(display.getByText("WINNER")).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Soundtrack rounds (single **Correct (+15)** button instead of the Correct Song / Correct Artist split) were decided by a per-song `songs.is_soundtrack` boolean that duplicated the **Soundtracks** / **Israeli Soundtracks** genres. The two drifted: ~28 songs (Hungry Eyes, Shallow, the Star Wars and Disney themes, …) sat in a soundtrack genre but had `is_soundtrack = false`, so they played as normal rounds.

This collapses to a single source of truth: **a song is a soundtrack iff it belongs to a genre whose slug is in `('soundtracks','israeli-soundtracks')`.** The `is_soundtrack` value is now computed server-side and surfaced under the same field name everywhere it was read before, so the read path, RPC output shape, realtime payload, and manager/display UI are unchanged — only the *source* of the value changes.

### Changes
- **Migration 028**: drops `songs.is_soundtrack`; re-issues `select_next_song` (same signature/return shape) computing `is_soundtrack` via `EXISTS` over `song_genres → genres`.
- **Seed**: `db/seed/songs.sql` drops the column from its INSERT; soundtrack rows get their behaviour from the `soundtracks` genre tag.
- **Backend**: new `app/constants.py` (`SOUNDTRACK_GENRE_SLUGS`); admin list computes `is_soundtrack` from embedded genres; CSV importer derives it from the genres column (drops the `is_soundtrack` CSV column) and keeps the title=artist soundtrack invariant.
- **Frontend**: admin Songs page drops the "Soundtrack round" checkbox — tagging a soundtrack genre is the single marker; manager/display read the computed RPC value unchanged.
- **Docs**: data-model, game-rules, rpc-functions, api-contracts updated; CHANGELOG entry added.

### Production rollout note
This is a schema change. Apply the migration to prod **after** this PR's deploy lands (the new backend no longer selects the column; the old backend would break if the column were dropped first). I will apply `db/migrations/028` via `supabase db query --linked` once merged & deployed.

## Test plan
- [x] Frontend: `tsc`, `eslint`, `vitest run` — green (263 tests)
- [x] Backend: `ruff check .`, `ruff format --check .`, `mypy app` — green; `csv_import` unit tests green
- [x] Added a DB test asserting `select_next_song.is_soundtrack` reflects genre membership; updated CSV/CRUD fixtures to the genre-driven format
- [ ] DB-side `needs_docker` tests, e2e, and migration idempotency — run by CI (Docker unavailable locally)
- [ ] Post-merge: apply migration to prod, confirm Hungry Eyes derives as a soundtrack