### PR TITLE
Keep API warm during active games to avoid mid-game cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-05-31: The host console now keeps the API warm while a game is running, so **Bonus**, **End game**, **Kick team**, and late team joins stay fast even after long rounds. Previously the backend could idle-sleep mid-game (all gameplay goes straight to the database), making the host's next button press wait several seconds on a cold start.
 - 2026-05-30: Re-tuned the playback start time for 588 songs in the catalog so each clip begins on a more recognizable part of the song.
 - 2026-05-25: Team buzzer screen is now full-bleed — the BUZZ button reaches every edge of the phone, with the team name + current round shown as a small pill overlay in the top corner. Larger tap target, no chrome competing for the screen.
 

--- a/frontend/src/hooks/useKeepBackendWarm.test.ts
+++ b/frontend/src/hooks/useKeepBackendWarm.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/api", () => ({
+  getHealth: vi.fn(() => Promise.resolve({ status: "ok", version: "test", supabase: "ok" })),
+}));
+
+import { getHealth } from "../lib/api";
+import { KEEP_WARM_INTERVAL_MS, useKeepBackendWarm } from "./useKeepBackendWarm";
+
+const getHealthMock = vi.mocked(getHealth);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getHealthMock.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useKeepBackendWarm", () => {
+  it("pings /health once per interval while active (no immediate ping)", () => {
+    renderHook(() => useKeepBackendWarm(true));
+    expect(getHealthMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS);
+    expect(getHealthMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("never pings while inactive", () => {
+    renderHook(() => useKeepBackendWarm(false));
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 3);
+    expect(getHealthMock).not.toHaveBeenCalled();
+  });
+
+  it("stops pinging after unmount", () => {
+    const { unmount } = renderHook(() => useKeepBackendWarm(true));
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 2);
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops pinging once it flips from active to inactive", () => {
+    const { rerender } = renderHook(({ active }) => useKeepBackendWarm(active), {
+      initialProps: { active: true },
+    });
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+
+    rerender({ active: false });
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 2);
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a rejected health ping does not throw", () => {
+    getHealthMock.mockReturnValueOnce(Promise.reject(new Error("cold")));
+    renderHook(() => useKeepBackendWarm(true));
+    expect(() => vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100)).not.toThrow();
+    expect(getHealthMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useKeepBackendWarm.ts
+++ b/frontend/src/hooks/useKeepBackendWarm.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { getHealth } from "../lib/api";
+
+// Render's free-tier API container spins down after ~15 min idle. During an
+// active game every hot-path action (buzz, score, next round) goes straight to
+// Supabase, so the FastAPI backend sees no traffic and goes cold mid-game --
+// and then the host's next REST call (Bonus / End game / Kick) or a late team's
+// join stalls 2-30s on cold start. HomePage already pre-warms on entry, but
+// that wears off once a long game has been running on direct-RPC traffic alone.
+//
+// While the manager console is mounted and a game is in progress we ping
+// /health on an interval, keeping the container warm for exactly as long as a
+// game is being run (no 24/7 always-on cost — it conserves Render's free
+// monthly hours, which a cron pinger would burn). Errors are ignored: a failed
+// ping just means the next real call hits the same cold start it would have
+// hit anyway, so this is never worse than not pinging.
+export const KEEP_WARM_INTERVAL_MS = 10 * 60 * 1000; // 10 min, comfortably under Render's ~15 min idle
+
+export function useKeepBackendWarm(active: boolean): void {
+  useEffect(() => {
+    if (!active) return undefined;
+    const id = window.setInterval(() => {
+      void getHealth().catch(() => undefined);
+    }, KEEP_WARM_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [active]);
+}

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -7,6 +7,7 @@ import { SoundtrackBadge } from "../components/SoundtrackBadge";
 import { YouTubePlayer, type YouTubePlayerHandle } from "../components/YouTubePlayer";
 import { useToast } from "../context/useToast";
 import { useGameChannel } from "../hooks/useGameChannel";
+import { useKeepBackendWarm } from "../hooks/useKeepBackendWarm";
 import { usePlayerReady } from "../hooks/usePlayerReady";
 import { ApiError, awardBonus, endGame } from "../lib/api";
 import { awardAttemptDirect, releaseBuzzLockDirect, RpcError } from "../hooks/useManagerActions";
@@ -24,6 +25,11 @@ export function ManagerConsolePage() {
   const { state, status } = useGameChannel(gameCode);
   const player = usePlayerReady();
   const playerRef = useRef<YouTubePlayerHandle | null>(null);
+
+  // Keep the Render-hosted API warm while a game is running so the host's
+  // occasional REST calls (Bonus / End game / Kick) and late team joins don't
+  // hit a mid-game cold start. See useKeepBackendWarm for the why.
+  useKeepBackendWarm(state?.game?.status === "playing" || state?.game?.status === "waiting");
 
   const [currentSong, setCurrentSong] = useState<Song | null>(null);
   const [busy, setBusy] = useState(false);


### PR DESCRIPTION
## Summary

During an active game every hot-path action (buzz, score, next round) goes straight to Supabase, so the Render-hosted FastAPI backend sees **no traffic** and idle-sleeps after ~15 min. The host's next REST call — **Bonus**, **End game**, **Kick team** — and any **late team join** then stalls 2–30 s on a cold start. `HomePage` already pre-warms on entry, but that wears off once a long game has been running on direct-RPC traffic alone.

This adds a small `useKeepBackendWarm` hook that pings `/health` every 10 min while the manager console is mounted and a game is in progress (`waiting`/`playing`). That keeps the container warm for exactly as long as a game is being run — no 24/7 always-on cost, so it conserves Render's free monthly hours instead of burning them like a standalone cron pinger would. Ping errors are ignored: a failed ping is never worse than not pinging.

Scope is deliberately tight:
- Pre-game create/join cold start is already handled (`HomePage` pre-warm + memoized `listGenres` + the create form's `busy`/skeleton states) — unchanged.
- I did **not** touch the 20 s Realtime re-hydrate backstop (deliberate design with broad blast radius) or add any CI/cron infrastructure.

Found during the pre-launch production QA pass; this was the one operational gap worth fixing in code.

## Test plan

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:coverage` — 273/273 pass; thresholds clear (statements 90.76%, branches 83.24%, functions 89.9%, lines 95.24%)
- `npm run build` — succeeds
- New `useKeepBackendWarm.test.ts` (5 cases): pings once per interval while active, never while inactive, stops on unmount, stops when it flips to inactive, and a rejected ping doesn't throw.
- Frontend-only, additive; backend/db gates unaffected. The 10-min interval never fires during the short e2e runs, so existing Playwright specs are unaffected.