### PR TITLE
Separate each team into its own box in the bonus picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-05-31: The manager **Bonus** picker now shows each team in its own separated, bordered box (an equal-sized grid of cells) instead of a run of plain names, so the host no longer risks tapping the wrong team and awarding +4 to the wrong side.
 - 2026-05-30: Songs in the **Soundtracks** / **Israeli Soundtracks** genres now always play as +15 soundtrack rounds. Soundtrack-ness is derived from genre membership instead of a separate per-song flag, fixing ~28 songs (e.g. Hungry Eyes, Shallow, the Star Wars and Disney themes) that were tagged as soundtracks but still scored as normal title/artist rounds. The admin Songs page drops the "Soundtrack round" checkbox — tagging a soundtrack genre is now the single marker.
 - 2026-05-25: Soundtrack rounds no longer auto-resume the song or re-arm the buzzers after the host taps **Correct (+15)**. The round now waits for an explicit **Next round** press, matching how regular rounds behave once both title and artist have been scored.
 

--- a/frontend/src/pages/ManagerConsolePage.module.css
+++ b/frontend/src/pages/ManagerConsolePage.module.css
@@ -422,9 +422,20 @@
 }
 
 .bonusPickerList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+/* Each team sits in its own bordered box (from the global .btn base) so the
+   host can't blur two adjacent names together and award +4 to the wrong team.
+   Fill the grid cell and let long names wrap inside the box rather than
+   overflow it. */
+.bonusTeamBtn {
+  width: 100%;
+  min-height: 48px;
+  white-space: normal;
+  word-break: break-word;
 }
 
 /* Continue / Next-round sit below the four scoring buttons and now match

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -665,7 +665,7 @@ export function ManagerConsolePage() {
                     <button
                       key={t.id}
                       type="button"
-                      className="btn btn-ghost"
+                      className={`btn ${styles.bonusTeamBtn}`}
                       onClick={() => void handleBonus(t.id, t.name)}
                       disabled={busy}
                       aria-label={`Award +4 bonus to ${t.name}`}


### PR DESCRIPTION
## Summary

On the manager console, pressing **Bonus** opens a picker listing every team. The team buttons used `btn btn-ghost`, whose transparent border/background rendered each team as bare text in a tight `flex-wrap` row — adjacent names blended together with nothing delimiting one tap target from the next, so the host could easily award +4 to the wrong team.

Each team now sits in its own clearly-bordered box, laid out as an equal-sized responsive grid (wraps to a second row for 4+ teams). The change reuses the existing global `.btn` base (2px border, elevated background, hover highlight); we just stop the `btn-ghost` override and switch the list to a grid. The picker stays roughly its current height, so the Continue / Next-round row below barely shifts.

- `ManagerConsolePage.tsx`: team button class `btn btn-ghost` -> `btn ${styles.bonusTeamBtn}`. `onClick`, `aria-label`, and `data-testid` are unchanged, so no test selectors break.
- `ManagerConsolePage.module.css`: `.bonusPickerList` becomes a `repeat(auto-fit, minmax(120px, 1fr))` grid; new `.bonusTeamBtn` fills the cell and wraps long names.
- `CHANGELOG.md`: one line under `[Unreleased]` -> `### Fixed`.

No change to award logic, the `handleBonus` handler, the `awardBonus` API, the other `.bonusPicker*` styles, or the global `.btn-ghost` (other pages still use it).

## Test plan

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:run` (ManagerConsolePage) — 39/39 pass, including the bonus-picker click tests that rely on the preserved `bonus-team-*` testids
- `npm run build` — succeeds
- Visual: rendered the picker with 2 / 3 / 4 teams using the real CSS — each team is a separated bordered box; 4 teams wrap to a 2x2 grid; long names wrap inside their box