### PR TITLE
Add Grafana Cloud + OpenTelemetry latency telemetry

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,10 @@ PORT=8000
 CORS_ORIGINS=http://localhost:5173
 LOG_LEVEL=DEBUG
 SENTRY_DSN_BACKEND=
+
+# OpenTelemetry → Grafana Cloud (Tempo). Tracing is OFF unless the endpoint is
+# set. On Render, set these from Grafana Cloud -> OTLP. Leave blank locally.
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-<zone>.grafana.net/otlp
+# OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(instanceID:token)>
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# OTEL_SERVICE_NAME=sound-clash-backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 
 from app import __version__
 from app.middleware import cors as cors_module
-from app.middleware import error_handler, sentry
+from app.middleware import error_handler, otel, sentry
 from app.middleware import rate_limit as rate_limit_module
 from app.routers import admin_songs, games, genres, health
 
@@ -26,6 +26,10 @@ def create_app() -> FastAPI:
     app.include_router(genres.router)
     app.include_router(games.router)
     app.include_router(admin_songs.router)
+
+    # Opt-in OpenTelemetry tracing; no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is
+    # set. Instrument after routers so all routes are wrapped.
+    otel.install(app)
     return app
 
 

--- a/backend/app/middleware/otel.py
+++ b/backend/app/middleware/otel.py
@@ -1,0 +1,54 @@
+"""Conditional OpenTelemetry tracing → Grafana Cloud (Tempo).
+
+Mirrors :mod:`app.middleware.sentry`: skips initialization in tests
+(``PYTEST_CURRENT_TEST`` is set by pytest) and when no OTLP endpoint is
+configured.
+
+When ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set (a Grafana Cloud OTLP gateway), this
+wires a batched OTLP/HTTP span exporter and auto-instruments FastAPI request
+handling plus outbound httpx calls (which is how supabase-py reaches Postgres).
+The exporter reads its endpoint + auth from the standard ``OTEL_EXPORTER_OTLP_*``
+environment variables; we only check the endpoint to decide whether to enable.
+
+Batching keeps span export off the request path. The hot-path RPCs
+(buzz / score / next-round) go browser→Supabase directly and never reach
+FastAPI, so backend traces only cover create / join / bonus / end.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from app import __version__
+
+
+def install(app: FastAPI) -> None:
+    """Enable OTLP tracing when configured; otherwise a no-op."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+    if not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        return
+    _configure(app)
+
+
+def _configure(app: FastAPI) -> None:
+    resource = Resource.create(
+        {
+            "service.name": os.environ.get("OTEL_SERVICE_NAME", "sound-clash-backend"),
+            "service.version": __version__,
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    HTTPXClientInstrumentor().instrument(tracer_provider=provider)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
     "slowapi>=0.1.9",
     "sentry-sdk[fastapi]>=2.18",
     "python-dotenv>=1.0",
+    # OpenTelemetry → Grafana Cloud (Tempo/Loki). Tracing is opt-in at runtime
+    # via OTEL_EXPORTER_OTLP_ENDPOINT; see app/middleware/otel.py.
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
 ]
 
 [project.optional-dependencies]

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -126,6 +126,23 @@ The anon key is shipped to the browser; it's not really a secret, but rotating i
 1. Cloudflare dashboard → "My Profile" → API Tokens → revoke + create new.
 2. Update GitHub repo secret `CF_API_TOKEN`.
 
+### 3.6 Grafana Cloud (latency observability)
+
+Three distinct credentials, all from one free Grafana Cloud stack. See
+`tech-stack.md` §7.5 for the architecture.
+
+| Credential | Where it lives | Public? | Rotate |
+|---|---|---|---|
+| Faro collector URL (`VITE_FARO_URL`) | Cloudflare Pages env + `frontend/.env.production` | Yes — app-key in the URL, ships in the browser bundle | Grafana → Frontend Observability → app → regenerate; redeploy frontend |
+| OTLP write token (`OTEL_EXPORTER_OTLP_HEADERS`) | Render env vars only | No — server-side write credential | Grafana → Access Policies → rotate token; update Render `OTEL_EXPORTER_OTLP_*`; redeploy backend |
+| Service-account token (Grafana MCP / queries) | Local only (Claude Code MCP config, `claude mcp add-json`) | No — read-only | Grafana → Administration → Service accounts → rotate |
+
+The Faro URL is browser-safe **by design** (like the Supabase anon key); the
+OTLP write token must **never** appear in the frontend bundle. Render OTel env
+vars: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, `OTEL_SERVICE_NAME=sound-clash-backend`.
+Tracing is OFF until `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
 ## 4. Common Issues
 
 ### 4.1 "Buzzer is slow"

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -13,7 +13,8 @@ For quota analysis (capacity in games/month), see `free-tier-budget.md`. For why
 | Frontend hosting | Cloudflare Pages | Unlimited bandwidth, 500 builds/mo |
 | DNS | Cloudflare | Free; existing |
 | CI/CD | GitHub Actions | Unlimited for public repos |
-| Error tracking | Sentry | 5,000 errors/mo, 10k performance events |
+| Error tracking | Sentry | 5,000 errors/mo (errors only; tracing off) |
+| Latency observability | Grafana Cloud (Faro + OTel) | ~50 GB traces + 50 GB logs/mo, 14-day retention |
 | Render keepalive | cron-job.org | 50 cron jobs |
 | Domain | Namecheap (existing) | $12/yr (only paid item) |
 
@@ -174,8 +175,11 @@ GitHub Actions is **unlimited minutes for public repos**, 2,000/mo for private. 
 
 | Layer | What's tracked |
 |---|---|
-| Frontend (browser) | Unhandled errors, React error boundaries, `buzz_in` RPC duration as a custom transaction |
-| Backend (FastAPI) | Unhandled exceptions, slow RPC calls (>1s), 5xx responses |
+| Frontend (browser) | Unhandled errors, React error boundaries |
+| Backend (FastAPI) | Unhandled exceptions, 5xx responses |
+
+Sentry is **errors only** (`tracesSampleRate: 0` / `traces_sample_rate=0.0`).
+Latency tracing lives in Grafana Cloud — see §7.5.
 
 ### What we DON'T send
 
@@ -183,6 +187,41 @@ GitHub Actions is **unlimited minutes for public repos**, 2,000/mo for private. 
 - Team names (user-supplied; could be inappropriate; sanitized via `beforeSend` hook)
 - Admin passwords (scrubbed by header filters)
 - PII (none collected anyway)
+
+## 7.5 Latency Observability: Grafana Cloud + OpenTelemetry
+
+**Logs + distributed traces for "how long did X take?" — separate from Sentry
+(errors).** Chosen for a much larger free tier (~50 GB traces/logs vs Sentry's
+10k spans) and because it's OpenTelemetry-native (no vendor lock-in). Queryable
+by the maintainer in Grafana Explore and by Claude via the Grafana MCP.
+
+### Data flow
+
+- **Frontend → Grafana Faro Web SDK → Faro collector → Tempo (traces) + Loki (logs).**
+  Faro is Grafana's OTel-based RUM SDK; its collector endpoint is browser-safe
+  (app-key in the URL), so no write credential ships in the bundle. Auto fetch/XHR
+  instrumentation is **disabled** — we trace manually (`frontend/src/lib/telemetry.ts`)
+  so nothing ever injects a `traceparent` header into a cross-origin Supabase RPC
+  (which would CORS-break the <200 ms buzzer path).
+- **Backend → OpenTelemetry Python → Grafana Cloud OTLP gateway (server-side
+  token) → Tempo/Loki** (`backend/app/middleware/otel.py`; FastAPI + httpx
+  auto-instrumentation). Off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+### What we measure (custom spans)
+
+| Span (`op`) | Window |
+|---|---|
+| `game.song_start` (+ children) | "Next round" click → audio actually PLAYING |
+| `game.buzz.e2e` | pointerdown → buzz lock observed in Realtime (won/lost_race) |
+| `game.score.e2e` | scoring click → `game_rounds` UPDATE observed in Realtime |
+| `db.rpc` | each Supabase PostgREST RPC round-trip (`rpc.name` attribute) |
+| `http.client` | each REST call to FastAPI (id-normalized route) |
+| `game.player_init` | YouTube IFrame API load → player ready |
+| `realtime_fanout` (event) | Postgres commit → client receipt, per table |
+
+The hot path is browser→Supabase direct, so the signal is almost entirely
+client-side. Sampling is per-game (`SAMPLE_RATE` in `telemetry.ts`); Grafana's
+free tier has ample headroom. Credentials + rotation: `runbook.md` §3.6.
 
 ## 8. Render Keepalive: cron-job.org
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,8 @@ VITE_SUPABASE_URL=http://localhost:54321
 VITE_SUPABASE_ANON_KEY=
 VITE_API_URL=http://localhost:8000
 VITE_SENTRY_DSN=
+# Grafana Faro collector URL (browser-safe, public app-key in the URL). Leave
+# blank to disable latency telemetry. Get it from Grafana Cloud -> Frontend
+# Observability -> your app, e.g.
+# https://faro-collector-prod-eu-west-2.grafana.net/collect/<app-key>
+VITE_FARO_URL=

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -12,6 +12,6 @@ VITE_SUPABASE_URL=https://jvfddxuaqcsrguibkymp.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp2ZmRkeHVhcWNzcmd1aWJreW1wIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzgwODc1MDYsImV4cCI6MjA5MzY2MzUwNn0.dhQWQnHDwuZc2DolW98PQmCPdACi1O-4DFPuhKGUSpk
 VITE_API_URL=https://api.soundclash.org
 VITE_SENTRY_DSN=https://a6fdb6eb2af882876781c74169de0f07@o4511344399941632.ingest.de.sentry.io/4511344493199440
-# Grafana Faro collector URL — fill in once the Grafana Cloud Frontend
-# Observability app is created (browser-safe, designed to ship in the bundle).
-VITE_FARO_URL=
+# Grafana Faro collector URL (browser-safe, app-key in the URL — ships in the
+# bundle by design, like the Sentry DSN above).
+VITE_FARO_URL=https://faro-collector-prod-eu-central-0.grafana.net/collect/6500f878d865833e0d8c884ef1a2b0f3

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -12,3 +12,6 @@ VITE_SUPABASE_URL=https://jvfddxuaqcsrguibkymp.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imp2ZmRkeHVhcWNzcmd1aWJreW1wIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzgwODc1MDYsImV4cCI6MjA5MzY2MzUwNn0.dhQWQnHDwuZc2DolW98PQmCPdACi1O-4DFPuhKGUSpk
 VITE_API_URL=https://api.soundclash.org
 VITE_SENTRY_DSN=https://a6fdb6eb2af882876781c74169de0f07@o4511344399941632.ingest.de.sentry.io/4511344493199440
+# Grafana Faro collector URL — fill in once the Grafana Cloud Frontend
+# Observability app is created (browser-safe, designed to ship in the bundle).
+VITE_FARO_URL=

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "test:e2e": "cd ../tests/e2e && npx playwright test"
   },
   "dependencies": {
+    "@grafana/faro-web-sdk": "^2.7.1",
+    "@grafana/faro-web-tracing": "^2.7.1",
     "@sentry/react": "^8.40.0",
     "@supabase/supabase-js": "^2.46.0",
     "@types/qrcode": "^1.5.6",

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.grafana.net

--- a/frontend/src/components/YouTubePlayer.tsx
+++ b/frontend/src/components/YouTubePlayer.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { startPlayerInit } from "../lib/telemetry";
 import styles from "./YouTubePlayer.module.css";
 
 export interface YouTubePlayerHandle {
@@ -23,6 +24,12 @@ interface Props {
   coverWhilePaused?: boolean;
   onReady?: () => void;
   onError?: (code: number) => void;
+  // Fired the first time the player reaches PLAYING after a loadVideoById. The
+  // YouTube IFrame API has no native "audio started" event, so we derive it
+  // from onStateChange (PLAYING) with a bounded getPlayerState poll as a
+  // fallback. Used to measure song-start latency; `detection` records which
+  // mechanism fired. Fires at most once per load.
+  onPlaying?: (detection: "statechange" | "poll") => void;
 }
 
 interface YTPlayer {
@@ -30,6 +37,7 @@ interface YTPlayer {
   pauseVideo: () => void;
   playVideo: () => void;
   stopVideo: () => void;
+  getPlayerState: () => number;
   destroy: () => void;
 }
 
@@ -41,10 +49,14 @@ interface YTStateChangeEvent {
   data: number;
 }
 
-// YT.PlayerState.ENDED. We don't import the namespace at runtime because the
-// IFrame API loads asynchronously; hard-coding the constant keeps the import
-// surface flat.
+// YT.PlayerState.ENDED / PLAYING. We don't import the namespace at runtime
+// because the IFrame API loads asynchronously; hard-coding the constants keeps
+// the import surface flat.
 const YT_STATE_ENDED = 0;
+const YT_STATE_PLAYING = 1;
+// getPlayerState poll cadence + cap for the PLAYING fallback (~6s).
+const PLAY_POLL_MS = 250;
+const PLAY_POLL_MAX_TICKS = 24;
 
 interface YTNamespace {
   Player: new (
@@ -106,7 +118,7 @@ const EMBED_SRC =
   }).toString();
 
 export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function YouTubePlayer(
-  { noCover, hideOverlay, coverWhilePaused, onReady, onError },
+  { noCover, hideOverlay, coverWhilePaused, onReady, onError, onPlaying },
   ref,
 ) {
   const containerRef = useRef<HTMLIFrameElement | null>(null);
@@ -125,10 +137,20 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
   // hammered (~10 req/s, hundreds of MB/min).
   const onReadyRef = useRef(onReady);
   const onErrorRef = useRef(onError);
+  const onPlayingRef = useRef(onPlaying);
   useEffect(() => {
     onReadyRef.current = onReady;
     onErrorRef.current = onError;
+    onPlayingRef.current = onPlaying;
   });
+
+  // PLAYING-detection state for the song-start measurement. `playingFiredRef`
+  // dedupes the two sources (onStateChange + poll) so onPlaying fires once per
+  // load; `playWatchRef` holds the bounded fallback poll's interval id. Cleared
+  // inline (only refs are touched) so the run-once mount effect and the
+  // imperative handle stay free of extra deps.
+  const playingFiredRef = useRef(false);
+  const playWatchRef = useRef<number | null>(null);
 
   // We render the iframe ourselves (rather than letting YT.Player replace a
   // div) and wait for its `load` event before attaching the API. Otherwise
@@ -140,9 +162,12 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
   // host emits once a video plays.
   useEffect(() => {
     let cancelled = false;
+    const playerInit = startPlayerInit();
     void (async () => {
+      const apiCached = !!window.YT?.Player;
       const YT = await loadApi();
       if (cancelled || !containerRef.current) return;
+      playerInit.apiLoaded(apiCached);
       const iframe = containerRef.current;
       await new Promise<void>((resolve) => {
         if (iframe.dataset.ytLoaded === "1") {
@@ -162,6 +187,7 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
           onReady: () => {
             setErrorCode(null);
             setLoaded(true);
+            playerInit.ready();
             onReadyRef.current?.();
           },
           onError: (event) => {
@@ -169,6 +195,14 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
             onErrorRef.current?.(event.data);
           },
           onStateChange: (event) => {
+            if (event.data === YT_STATE_PLAYING && !playingFiredRef.current) {
+              playingFiredRef.current = true;
+              if (playWatchRef.current !== null) {
+                window.clearInterval(playWatchRef.current);
+                playWatchRef.current = null;
+              }
+              onPlayingRef.current?.("statechange");
+            }
             if (event.data === YT_STATE_ENDED) {
               setEnded(true);
               playerRef.current?.stopVideo();
@@ -179,6 +213,10 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
     })();
     return () => {
       cancelled = true;
+      if (playWatchRef.current !== null) {
+        window.clearInterval(playWatchRef.current);
+        playWatchRef.current = null;
+      }
       playerRef.current?.destroy();
       playerRef.current = null;
     };
@@ -193,6 +231,29 @@ export const YouTubePlayer = forwardRef<YouTubePlayerHandle, Props>(function You
         // covered mode) doesn't keep showing "Video unavailable" for what
         // is now a different, valid video.
         setErrorCode(null);
+        // Arm PLAYING detection for this load: reset the dedupe flag and start
+        // a bounded fallback poll in case onStateChange(PLAYING) is coalesced
+        // or missed. The poll self-clears once PLAYING is seen or the cap hits.
+        playingFiredRef.current = false;
+        if (playWatchRef.current !== null) window.clearInterval(playWatchRef.current);
+        let ticks = 0;
+        playWatchRef.current = window.setInterval(() => {
+          ticks += 1;
+          if (
+            !playingFiredRef.current &&
+            playerRef.current?.getPlayerState() === YT_STATE_PLAYING
+          ) {
+            playingFiredRef.current = true;
+            onPlayingRef.current?.("poll");
+          }
+          if (
+            (playingFiredRef.current || ticks >= PLAY_POLL_MAX_TICKS) &&
+            playWatchRef.current !== null
+          ) {
+            window.clearInterval(playWatchRef.current);
+            playWatchRef.current = null;
+          }
+        }, PLAY_POLL_MS);
         playerRef.current?.loadVideoById({
           videoId,
           startSeconds: startSeconds ?? 0,

--- a/frontend/src/hooks/directRpc.telemetry.test.ts
+++ b/frontend/src/hooks/directRpc.telemetry.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/supabase", async () => {
+  const mod = await import("../test/supabaseMock");
+  return { supabase: mod.supabaseMock };
+});
+
+// tracedRpc passes through to run() so the supabase mock drives the result; we
+// only assert each direct RPC is wrapped with the right span name.
+const telemetry = vi.hoisted(() => ({
+  tracedRpc: vi.fn((_name: string, _attrs: unknown, run: () => unknown) => run()),
+}));
+vi.mock("../lib/telemetry", () => telemetry);
+
+import { awardAttemptDirect, releaseBuzzLockDirect } from "./useManagerActions";
+import { selectNextSongDirect } from "./useSelectNextSong";
+import { resetSupabaseMock, setRpcResponse } from "../test/supabaseMock";
+
+const TOKEN = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  resetSupabaseMock();
+  telemetry.tracedRpc.mockClear();
+  telemetry.tracedRpc.mockImplementation((_n: string, _a: unknown, run: () => unknown) => run());
+});
+
+describe("direct-RPC telemetry wiring", () => {
+  it("wraps select_next_song", async () => {
+    setRpcResponse({
+      data: [
+        {
+          round_id: "r-1",
+          round_number: 1,
+          song_id: "s-1",
+          song_title: "T",
+          song_artist: "A",
+          youtube_id: "yt",
+          start_time: 0,
+          is_soundtrack: false,
+        },
+      ],
+      error: null,
+    });
+    await selectNextSongDirect("ABCDEF", TOKEN);
+    expect(telemetry.tracedRpc).toHaveBeenCalledWith(
+      "select_next_song",
+      { game_code: "ABCDEF" },
+      expect.any(Function),
+    );
+  });
+
+  it("wraps award_attempt", async () => {
+    setRpcResponse({
+      data: [
+        {
+          team_id: "team-1",
+          points_delta: 10,
+          team_total_score: 10,
+          title_claimed_by: null,
+          artist_claimed_by: null,
+        },
+      ],
+      error: null,
+    });
+    await awardAttemptDirect("ABCDEF", TOKEN, "r-1", {
+      title_correct: true,
+      artist_correct: false,
+      wrong_buzz: false,
+    });
+    expect(telemetry.tracedRpc).toHaveBeenCalledWith(
+      "award_attempt",
+      { game_code: "ABCDEF" },
+      expect.any(Function),
+    );
+  });
+
+  it("wraps release_buzz_lock", async () => {
+    setRpcResponse({ data: null, error: null });
+    await releaseBuzzLockDirect("ABCDEF", TOKEN);
+    expect(telemetry.tracedRpc).toHaveBeenCalledWith(
+      "release_buzz_lock",
+      { game_code: "ABCDEF" },
+      expect.any(Function),
+    );
+  });
+});

--- a/frontend/src/hooks/useBuzzer.telemetry.test.ts
+++ b/frontend/src/hooks/useBuzzer.telemetry.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/supabase", async () => {
+  const mod = await import("../test/supabaseMock");
+  return { supabase: mod.supabaseMock };
+});
+
+// Mock the telemetry wrapper so we can assert the buzz hot path is instrumented.
+// tracedRpc must pass through to its `run()` so the supabase mock still drives
+// the result.
+const telemetry = vi.hoisted(() => ({
+  markBuzzStart: vi.fn(),
+  failBuzz: vi.fn(),
+  tracedRpc: vi.fn((_name: string, _attrs: unknown, run: () => unknown) => run()),
+}));
+vi.mock("../lib/telemetry", () => telemetry);
+
+import { useBuzzer } from "./useBuzzer";
+import { makeActiveGame, makeTeam, resetSupabaseMock, setRpcResponse } from "../test/supabaseMock";
+import type { GameState } from "../lib/types";
+
+function buildState(): GameState {
+  const game = makeActiveGame({ status: "playing", buzzed_team_id: null, round_number: 3 });
+  const team = makeTeam();
+  return { game, teams: new Map([[team.id, team]]), rounds: [], currentRound: null };
+}
+
+beforeEach(() => {
+  resetSupabaseMock();
+  telemetry.markBuzzStart.mockClear();
+  telemetry.failBuzz.mockClear();
+  telemetry.tracedRpc.mockClear();
+  telemetry.tracedRpc.mockImplementation((_n: string, _a: unknown, run: () => unknown) => run());
+});
+
+describe("useBuzzer telemetry wiring", () => {
+  it("opens a buzz e2e span and wraps buzz_in in a traced RPC", async () => {
+    const { result } = renderHook(() => useBuzzer("ABCDEF", "team-1", buildState()));
+    await act(async () => {
+      await result.current.buzz();
+    });
+    expect(telemetry.markBuzzStart).toHaveBeenCalledWith("ABCDEF", "team-1", 3);
+    expect(telemetry.tracedRpc).toHaveBeenCalledWith(
+      "buzz_in",
+      { game_code: "ABCDEF" },
+      expect.any(Function),
+    );
+  });
+
+  it("closes the buzz span via failBuzz when the RPC errors", async () => {
+    setRpcResponse({ data: null, error: { message: "boom" } });
+    const { result } = renderHook(() => useBuzzer("ABCDEF", "team-1", buildState()));
+    await act(async () => {
+      await result.current.buzz();
+    });
+    expect(telemetry.failBuzz).toHaveBeenCalledWith("team-1");
+  });
+
+  it("does not open a span when the buzz is blocked (not playing)", async () => {
+    const game = makeActiveGame({ status: "waiting" });
+    const state: GameState = {
+      game,
+      teams: new Map(),
+      rounds: [],
+      currentRound: null,
+    };
+    const { result } = renderHook(() => useBuzzer("ABCDEF", "team-1", state));
+    await act(async () => {
+      await result.current.buzz();
+    });
+    expect(telemetry.markBuzzStart).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useBuzzer.ts
+++ b/frontend/src/hooks/useBuzzer.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { supabase } from "../lib/supabase";
+import { failBuzz, markBuzzStart, tracedRpc } from "../lib/telemetry";
 import type { BuzzResult, GameState } from "../lib/types";
 
 export function useBuzzer(
@@ -23,27 +24,35 @@ export function useBuzzer(
   const lockedByMe = gameState?.game.buzzed_team_id === teamId;
   const isPlaying = gameState?.game.status === "playing";
 
+  const roundNumber = gameState?.game.round_number;
   const buzz = useCallback(async () => {
     if (inFlightRef.current || isLocked || !isPlaying) return;
     inFlightRef.current = true;
     setIsBuzzing(true);
     setError(null);
+    // Open the end-to-end buzz span here (closest we get to the pointerdown —
+    // the handler runs synchronously off it). It is resolved in useGameChannel
+    // when this client observes the buzz lock in Realtime (won / lost_race).
+    markBuzzStart(gameCode, teamId, roundNumber);
     try {
-      const { error: rpcError } = await supabase.rpc("buzz_in", {
-        p_game_code: gameCode,
-        p_team_id: teamId,
-      });
+      const { error: rpcError } = await tracedRpc("buzz_in", { game_code: gameCode }, () =>
+        supabase.rpc("buzz_in", {
+          p_game_code: gameCode,
+          p_team_id: teamId,
+        }),
+      );
       if (rpcError) throw rpcError;
       // We deliberately do not act on the BuzzResult here; the source of
       // truth is the Realtime UPDATE on active_games, which useGameChannel
       // applies to gameState. This keeps the UI consistent across all tabs.
     } catch (e) {
+      failBuzz(teamId);
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
       inFlightRef.current = false;
       setIsBuzzing(false);
     }
-  }, [gameCode, teamId, isLocked, isPlaying]);
+  }, [gameCode, teamId, roundNumber, isLocked, isPlaying]);
 
   return { buzz, isBuzzing, isLocked, lockedByMe, error };
 }

--- a/frontend/src/hooks/useGameChannel.telemetry.test.ts
+++ b/frontend/src/hooks/useGameChannel.telemetry.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/supabase", async () => {
+  const mod = await import("../test/supabaseMock");
+  return { supabase: mod.supabaseMock };
+});
+
+const telemetry = vi.hoisted(() => ({
+  log: vi.fn(),
+  recordFanout: vi.fn(),
+  resolveBuzzE2E: vi.fn(),
+  resolveScoreE2E: vi.fn(),
+}));
+vi.mock("../lib/telemetry", () => telemetry);
+
+import { useGameChannel } from "./useGameChannel";
+import {
+  fireGame,
+  fireRound,
+  fireStatus,
+  fireTeam,
+  makeActiveGame,
+  makePayload,
+  makeRound,
+  makeTeam,
+  resetSupabaseMock,
+  setHydrate,
+} from "../test/supabaseMock";
+
+const TS = "2026-05-05T12:00:05.000Z";
+
+beforeEach(() => {
+  resetSupabaseMock();
+  telemetry.recordFanout.mockClear();
+  telemetry.resolveBuzzE2E.mockClear();
+  telemetry.resolveScoreE2E.mockClear();
+  telemetry.log.mockClear();
+});
+
+describe("useGameChannel telemetry wiring", () => {
+  it("records fan-out per table and resolves buzz/score e2e from Realtime", () => {
+    const game = makeActiveGame({ status: "playing" });
+    setHydrate({ game, teams: [], rounds: [] });
+    renderHook(() => useGameChannel("ABCDEF"));
+
+    act(() => {
+      fireGame(
+        makePayload("active_games", "UPDATE", { new: { ...game, buzzed_team_id: "team-9" } }, TS),
+      );
+    });
+    expect(telemetry.recordFanout).toHaveBeenCalledWith("game", TS);
+    expect(telemetry.resolveBuzzE2E).toHaveBeenCalledWith("team-9", TS);
+
+    act(() => {
+      fireRound(makePayload("game_rounds", "UPDATE", { new: makeRound({ id: "round-1" }) }, TS));
+    });
+    expect(telemetry.recordFanout).toHaveBeenCalledWith("round", TS);
+    expect(telemetry.resolveScoreE2E).toHaveBeenCalledWith("round-1", TS);
+
+    act(() => {
+      fireTeam(makePayload("game_teams", "UPDATE", { new: makeTeam({ id: "team-9" }) }, TS));
+    });
+    expect(telemetry.recordFanout).toHaveBeenCalledWith("team", TS);
+  });
+
+  it("does not resolve a buzz span when no lock is set", () => {
+    const game = makeActiveGame({ status: "playing" });
+    setHydrate({ game, teams: [], rounds: [] });
+    renderHook(() => useGameChannel("ABCDEF"));
+    act(() => {
+      fireGame(
+        makePayload("active_games", "UPDATE", { new: { ...game, buzzed_team_id: null } }, TS),
+      );
+    });
+    expect(telemetry.resolveBuzzE2E).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning on a Realtime disconnect", async () => {
+    setHydrate({ game: makeActiveGame({ status: "playing" }), teams: [], rounds: [] });
+    renderHook(() => useGameChannel("ABCDEF"));
+    await act(async () => {
+      await fireStatus("CHANNEL_ERROR");
+    });
+    expect(telemetry.log).toHaveBeenCalledWith(
+      "warn",
+      "realtime_disconnect",
+      expect.objectContaining({ game_code: "ABCDEF", sub_status: "CHANNEL_ERROR" }),
+    );
+  });
+});

--- a/frontend/src/hooks/useGameChannel.ts
+++ b/frontend/src/hooks/useGameChannel.ts
@@ -9,6 +9,7 @@ import type {
   Team,
 } from "../lib/types";
 import { observeServerTime } from "./useServerTime";
+import { log, recordFanout, resolveBuzzE2E, resolveScoreE2E } from "../lib/telemetry";
 
 export type ChannelStatus = "idle" | "connecting" | "subscribed" | "reconnecting" | "gone";
 
@@ -204,6 +205,15 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<ActiveGame>;
           observeServerTime(typed.commit_timestamp);
+          recordFanout("game", typed.commit_timestamp);
+          // Resolve the local player's open buzz span the moment we see the
+          // lock land (won if it's our team, lost_race otherwise).
+          if (typed.eventType !== "DELETE") {
+            const row = typed.new as ActiveGame;
+            if (row.buzzed_team_id) {
+              resolveBuzzE2E(row.buzzed_team_id, typed.commit_timestamp);
+            }
+          }
           dispatchOrQueue({ type: "GAME_CHANGE", payload: typed });
           if (typed.eventType === "DELETE") setStatus("gone");
         },
@@ -214,6 +224,7 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<Team>;
           observeServerTime(typed.commit_timestamp);
+          recordFanout("team", typed.commit_timestamp);
           dispatchOrQueue({ type: "TEAM_CHANGE", payload: typed });
         },
       )
@@ -223,6 +234,12 @@ export function useGameChannel(gameCode: string): {
         (payload) => {
           const typed = payload as PostgresChangePayload<GameRound>;
           observeServerTime(typed.commit_timestamp);
+          recordFanout("round", typed.commit_timestamp);
+          // Resolve any open score span for this round (click → ROUND_CHANGE).
+          if (typed.eventType !== "DELETE") {
+            const row = typed.new as GameRound;
+            if (row.id) resolveScoreE2E(row.id, typed.commit_timestamp);
+          }
           dispatchOrQueue({ type: "ROUND_CHANGE", payload: typed });
         },
       )
@@ -232,6 +249,7 @@ export function useGameChannel(gameCode: string): {
           setStatus("subscribed");
           void hydrate();
         } else if (subStatus === "CHANNEL_ERROR" || subStatus === "TIMED_OUT") {
+          log("warn", "realtime_disconnect", { game_code: gameCode, sub_status: subStatus });
           setStatus("reconnecting");
         } else if (subStatus === "CLOSED") {
           setStatus("idle");

--- a/frontend/src/hooks/useManagerActions.ts
+++ b/frontend/src/hooks/useManagerActions.ts
@@ -6,6 +6,7 @@
 // Frankfurt -> back) to ~150ms (browser -> Supabase direct).
 
 import { supabase } from "../lib/supabase";
+import { tracedRpc } from "../lib/telemetry";
 import type { AttemptResponse } from "../lib/types";
 
 const TITLE_POINTS = 10;
@@ -45,14 +46,16 @@ export async function awardAttemptDirect(
   roundId: string,
   flags: AttemptFlags,
 ): Promise<AttemptResponse> {
-  const { data, error } = await supabase.rpc("award_attempt", {
-    p_game_code: gameCode,
-    p_round_id: roundId,
-    p_title: flags.title_correct ? TITLE_POINTS : 0,
-    p_artist: flags.artist_correct ? ARTIST_POINTS : 0,
-    p_wrong_buzz: flags.wrong_buzz ? WRONG_BUZZ_PENALTY : 0,
-    p_manager_token: managerToken,
-  });
+  const { data, error } = await tracedRpc("award_attempt", { game_code: gameCode }, () =>
+    supabase.rpc("award_attempt", {
+      p_game_code: gameCode,
+      p_round_id: roundId,
+      p_title: flags.title_correct ? TITLE_POINTS : 0,
+      p_artist: flags.artist_correct ? ARTIST_POINTS : 0,
+      p_wrong_buzz: flags.wrong_buzz ? WRONG_BUZZ_PENALTY : 0,
+      p_manager_token: managerToken,
+    }),
+  );
   if (error) {
     throw new RpcError(error.message, error.code);
   }
@@ -72,10 +75,12 @@ export async function awardAttemptDirect(
 }
 
 export async function releaseBuzzLockDirect(gameCode: string, managerToken: string): Promise<void> {
-  const { error } = await supabase.rpc("release_buzz_lock", {
-    p_game_code: gameCode,
-    p_manager_token: managerToken,
-  });
+  const { error } = await tracedRpc("release_buzz_lock", { game_code: gameCode }, () =>
+    supabase.rpc("release_buzz_lock", {
+      p_game_code: gameCode,
+      p_manager_token: managerToken,
+    }),
+  );
   if (error) {
     throw new RpcError(error.message, error.code);
   }

--- a/frontend/src/hooks/useSelectNextSong.ts
+++ b/frontend/src/hooks/useSelectNextSong.ts
@@ -11,6 +11,7 @@
 // click-to-feedback gap is ~10ms.
 
 import { supabase } from "../lib/supabase";
+import { tracedRpc } from "../lib/telemetry";
 import { RpcError } from "./useManagerActions";
 import type { SelectSongResponse } from "../lib/types";
 
@@ -30,14 +31,16 @@ export async function selectNextSongDirect(
   managerToken: string,
   songId?: string,
 ): Promise<SelectSongResponse> {
-  const { data, error } = await supabase.rpc("select_next_song", {
-    p_game_code: gameCode,
-    p_manager_token: managerToken,
-    // null vs undefined matters: PostgREST drops undefined-valued keys, which
-    // would route the call to a 2-arg overload that doesn't exist. Always
-    // send p_song_id explicitly so we hit the 3-arg signature.
-    p_song_id: songId ?? null,
-  });
+  const { data, error } = await tracedRpc("select_next_song", { game_code: gameCode }, () =>
+    supabase.rpc("select_next_song", {
+      p_game_code: gameCode,
+      p_manager_token: managerToken,
+      // null vs undefined matters: PostgREST drops undefined-valued keys, which
+      // would route the call to a 2-arg overload that doesn't exist. Always
+      // send p_song_id explicitly so we hit the 3-arg signature.
+      p_song_id: songId ?? null,
+    }),
+  );
   if (error) {
     throw new RpcError(error.message, error.code);
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { env } from "./env";
+import { tracedFetch } from "./telemetry";
 import type {
   ApiErrorBody,
   AwardBonusRequest,
@@ -33,6 +34,18 @@ interface RequestOptions {
   body?: unknown;
 }
 
+// Collapse per-request identifiers (game codes, team/song ids, query strings)
+// to placeholders so the telemetry span's `http.route` groups by endpoint
+// rather than fragmenting into one series per game.
+function normalizeRoute(method: string, path: string): string {
+  const route = path
+    .replace(/\?.*$/, "")
+    .replace(/\/games\/[^/]+/, "/games/:code")
+    .replace(/\/teams\/[^/]+/, "/teams/:id")
+    .replace(/\/admin\/songs\/[^/]+/, "/admin/songs/:id");
+  return `${method} ${route}`;
+}
+
 async function request<T>(method: string, path: string, opts: RequestOptions = {}): Promise<T> {
   const headers: Record<string, string> = {};
   const isFormData = typeof FormData !== "undefined" && opts.body instanceof FormData;
@@ -55,11 +68,19 @@ async function request<T>(method: string, path: string, opts: RequestOptions = {
     body = JSON.stringify(opts.body);
   }
 
-  const response = await fetch(`${env.VITE_API_URL}${path}`, {
-    method,
-    headers,
-    body,
-  });
+  const doFetch = (): Promise<Response> =>
+    fetch(`${env.VITE_API_URL}${path}`, {
+      method,
+      headers,
+      body,
+    });
+  // Trace every REST call except the frequent /health warm-up pings (they'd
+  // drown out the meaningful create/join/bonus/end latencies). The route is
+  // id-normalized so per-game codes don't explode span cardinality.
+  const response =
+    path === "/health"
+      ? await doFetch()
+      : await tracedFetch(method, normalizeRoute(method, path), doFetch);
 
   if (response.status === 204) {
     return undefined as T;

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -6,6 +6,9 @@ interface Env {
   VITE_SUPABASE_ANON_KEY: string;
   VITE_API_URL: string;
   VITE_SENTRY_DSN: string | undefined;
+  // Grafana Faro collector URL. When unset, all latency telemetry is a no-op
+  // (local dev, tests, and any prod build before the collector is provisioned).
+  VITE_FARO_URL: string | undefined;
 }
 
 function read(name: keyof Env, required: boolean): string | undefined {
@@ -21,4 +24,5 @@ export const env: Env = {
   VITE_SUPABASE_ANON_KEY: read("VITE_SUPABASE_ANON_KEY", true) as string,
   VITE_API_URL: read("VITE_API_URL", true) as string,
   VITE_SENTRY_DSN: read("VITE_SENTRY_DSN", false),
+  VITE_FARO_URL: read("VITE_FARO_URL", false),
 };

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mutable fake env + fake Faro/OTel, created at hoist time so the vi.mock
+// factories (hoisted) and the test bodies share the same objects. We toggle
+// envMock.VITE_FARO_URL + call _resetTelemetry()/initTelemetry() to flip the
+// module between enabled and disabled — no module resets or env stubs needed.
+// (The Faro SDK is dynamically imported by initTelemetry; vi.mock intercepts
+// dynamic imports too, so the fakes still apply.)
+const h = vi.hoisted(() => {
+  const makeSpan = () => ({ setAttribute: vi.fn(), setStatus: vi.fn(), end: vi.fn() });
+  const startSpan = vi.fn(() => makeSpan());
+  const tracer = { startSpan };
+  const otel = {
+    trace: { getTracer: vi.fn(() => tracer), setSpan: vi.fn((ctx: unknown) => ctx) },
+    context: { active: vi.fn(() => ({})) },
+  };
+  const pushEvent = vi.fn();
+  const pushLog = vi.fn();
+  const faro = { api: { getOTEL: vi.fn(() => otel), pushEvent, pushLog } };
+  const initializeFaro = vi.fn(() => faro);
+  const envMock: {
+    VITE_SUPABASE_URL: string;
+    VITE_SUPABASE_ANON_KEY: string;
+    VITE_API_URL: string;
+    VITE_SENTRY_DSN: string | undefined;
+    VITE_FARO_URL: string | undefined;
+  } = {
+    VITE_SUPABASE_URL: "http://localhost:54321",
+    VITE_SUPABASE_ANON_KEY: "anon-test",
+    VITE_API_URL: "http://localhost:8000",
+    VITE_SENTRY_DSN: undefined,
+    VITE_FARO_URL: undefined,
+  };
+  return { makeSpan, startSpan, otel, pushEvent, pushLog, faro, initializeFaro, envMock };
+});
+
+vi.mock("./env", () => ({ env: h.envMock }));
+vi.mock("@grafana/faro-web-sdk", () => ({
+  initializeFaro: h.initializeFaro,
+  getWebInstrumentations: () => [],
+  LogLevel: { INFO: "info", WARN: "warn", ERROR: "error" },
+}));
+vi.mock("@grafana/faro-web-tracing", () => ({
+  TracingInstrumentation: class {},
+}));
+
+import * as tele from "./telemetry";
+
+const FARO_URL = "https://faro-collector-test.grafana.net/collect/abc";
+
+async function enable() {
+  h.envMock.VITE_FARO_URL = FARO_URL;
+  tele._resetTelemetry();
+  await tele.initTelemetry();
+}
+
+async function disable() {
+  h.envMock.VITE_FARO_URL = undefined;
+  tele._resetTelemetry();
+  await tele.initTelemetry();
+}
+
+// New spans created since index `i` (mock call history is never cleared, so we
+// slice rather than reset — keeps the fake implementations intact).
+function spansFrom(i: number) {
+  return h.startSpan.mock.results.slice(i).map((r) => r.value);
+}
+function spanCount() {
+  return h.startSpan.mock.results.length;
+}
+
+describe("telemetry (disabled — VITE_FARO_URL unset)", () => {
+  it("never initializes Faro and reports disabled", async () => {
+    h.initializeFaro.mockClear();
+    await disable();
+    expect(tele.isEnabled()).toBe(false);
+    expect(h.initializeFaro).not.toHaveBeenCalled();
+  });
+
+  it("tracedRpc passes the resolved value through unchanged", async () => {
+    await disable();
+    const value = { data: [1], error: null };
+    await expect(
+      tele.tracedRpc("buzz_in", { game_code: "ABC" }, () => Promise.resolve(value)),
+    ).resolves.toBe(value);
+  });
+
+  it("tracedRpc rejects with the same error (non-blocking contract)", async () => {
+    await disable();
+    const err = new Error("boom");
+    await expect(tele.tracedRpc("buzz_in", {}, () => Promise.reject(err))).rejects.toBe(err);
+  });
+
+  it("tracedFetch passes the response through unchanged", async () => {
+    await disable();
+    const res = new Response("ok", { status: 200 });
+    await expect(tele.tracedFetch("POST", "POST /games", () => Promise.resolve(res))).resolves.toBe(
+      res,
+    );
+  });
+
+  it("all span/log helpers are no-throw no-ops", async () => {
+    await disable();
+    const before = spanCount();
+    expect(() => {
+      const song = tele.startSongStart({ game_code: "ABC" });
+      song.rpcDone({ roundNumber: 1, songId: "s1", youtubeId: "yt" });
+      song.loadIssued();
+      song.playing("statechange");
+      song.fail("x");
+      tele.markBuzzStart("ABC", "team1", 2);
+      tele.resolveBuzzE2E("team1", new Date().toISOString());
+      tele.failBuzz("team1");
+      tele.markScoreStart("ABC", "r1", "title");
+      tele.resolveScoreE2E("r1", new Date().toISOString());
+      tele.failScore("r1", "title");
+      tele.recordFanout("game", new Date().toISOString());
+      const pi = tele.startPlayerInit();
+      pi.apiLoaded(true);
+      pi.ready();
+      tele.log("error", "msg", { k: "v" });
+    }).not.toThrow();
+    expect(spanCount()).toBe(before);
+  });
+});
+
+describe("telemetry (enabled)", () => {
+  it("initializes Faro once and reports enabled (idempotent)", async () => {
+    h.envMock.VITE_FARO_URL = FARO_URL;
+    tele._resetTelemetry();
+    const before = h.initializeFaro.mock.calls.length;
+    await tele.initTelemetry();
+    await tele.initTelemetry();
+    expect(h.initializeFaro.mock.calls.length - before).toBe(1);
+    expect(tele.isEnabled()).toBe(true);
+  });
+
+  it("tracedRpc starts a span, returns the value, and ends the span", async () => {
+    await enable();
+    const i = spanCount();
+    const value = { data: 1, error: null };
+    const out = await tele.tracedRpc("award_attempt", { game_code: "ABC" }, () =>
+      Promise.resolve(value),
+    );
+    expect(out).toBe(value);
+    const span = spansFrom(i)[0];
+    expect(span.setAttribute).toHaveBeenCalledWith("rpc.name", "award_attempt");
+    expect(span.setStatus).not.toHaveBeenCalled();
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracedRpc marks the span errored when the result carries an error", async () => {
+    await enable();
+    const i = spanCount();
+    await tele.tracedRpc("buzz_in", {}, () => Promise.resolve({ error: { message: "nope" } }));
+    const span = spansFrom(i)[0];
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("tracedRpc ends the span and rethrows on rejection", async () => {
+    await enable();
+    const i = spanCount();
+    const err = new Error("io");
+    await expect(tele.tracedRpc("buzz_in", {}, () => Promise.reject(err))).rejects.toBe(err);
+    const span = spansFrom(i)[0];
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("tracedFetch records status and flags non-2xx", async () => {
+    await enable();
+    const i = spanCount();
+    await tele.tracedFetch("POST", "POST /games/:code/bonus", () =>
+      Promise.resolve(new Response("err", { status: 500 })),
+    );
+    const span = spansFrom(i)[0];
+    expect(span.setAttribute).toHaveBeenCalledWith("http.status_code", 500);
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+  });
+
+  it("startSongStart runs the parent+children lifecycle and ends every span", async () => {
+    await enable();
+    const i = spanCount();
+    const song = tele.startSongStart({ game_code: "ABC" });
+    song.rpcDone({ roundNumber: 3, songId: "s1", youtubeId: "yt" });
+    song.loadIssued();
+    song.playing("statechange");
+    // parent + click_to_rpc + rpc_to_load + load_to_playing = 4 spans, all ended.
+    const spans = spansFrom(i);
+    expect(spans.length).toBe(4);
+    for (const s of spans) expect(s.end).toHaveBeenCalled();
+    expect(() => song.playing("poll")).not.toThrow();
+  });
+
+  it("startSongStart.fail errors the span", async () => {
+    await enable();
+    const i = spanCount();
+    const song = tele.startSongStart({ game_code: "ABC" });
+    song.fail("rpc_failed");
+    const span = spansFrom(i)[0];
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("buzz e2e: mark then resolve ends the span with an outcome", async () => {
+    await enable();
+    const i = spanCount();
+    tele.markBuzzStart("ABC", "team1", 1);
+    const span = spansFrom(i)[0];
+    tele.resolveBuzzE2E("team1", new Date().toISOString());
+    expect(span.setAttribute).toHaveBeenCalledWith("outcome", "won");
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("buzz e2e: a losing team is marked lost_race", async () => {
+    await enable();
+    const i = spanCount();
+    tele.markBuzzStart("ABC", "team1", 1);
+    const span = spansFrom(i)[0];
+    tele.resolveBuzzE2E("team2", new Date().toISOString());
+    expect(span.setAttribute).toHaveBeenCalledWith("outcome", "lost_race");
+  });
+
+  it("buzz e2e: failBuzz closes an open span as errored", async () => {
+    await enable();
+    const i = spanCount();
+    tele.markBuzzStart("ABC", "team1");
+    const span = spansFrom(i)[0];
+    tele.failBuzz("team1");
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("score e2e: mark then resolve ends the matching span only", async () => {
+    await enable();
+    const i = spanCount();
+    tele.markScoreStart("ABC", "r1", "title");
+    const span = spansFrom(i)[0];
+    tele.resolveScoreE2E("r1", new Date().toISOString());
+    expect(span.end).toHaveBeenCalled();
+    expect(() => tele.resolveScoreE2E("other", new Date().toISOString())).not.toThrow();
+  });
+
+  it("score e2e: failScore closes an open span as errored", async () => {
+    await enable();
+    const i = spanCount();
+    tele.markScoreStart("ABC", "r1", "artist");
+    const span = spansFrom(i)[0];
+    tele.failScore("r1", "artist");
+    expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(span.end).toHaveBeenCalled();
+  });
+
+  it("recordFanout pushes an event; log pushes a log", async () => {
+    await enable();
+    tele.recordFanout("round", new Date().toISOString());
+    expect(h.pushEvent).toHaveBeenLastCalledWith(
+      "realtime_fanout",
+      expect.objectContaining({ event_type: "round" }),
+    );
+    tele.log("warn", "hello", { a: "b" });
+    expect(h.pushLog).toHaveBeenLastCalledWith(["hello"], { level: "warn", context: { a: "b" } });
+  });
+
+  it("startPlayerInit runs api_load → player_ready and ends the spans", async () => {
+    await enable();
+    const i = spanCount();
+    const pi = tele.startPlayerInit();
+    pi.apiLoaded(false);
+    pi.ready();
+    const spans = spansFrom(i);
+    expect(spans.length).toBeGreaterThan(0);
+    for (const s of spans) expect(s.end).toHaveBeenCalled();
+  });
+
+  it("recovers (stays disabled) when initializeFaro throws", async () => {
+    h.initializeFaro.mockImplementationOnce(() => {
+      throw new Error("init failed");
+    });
+    h.envMock.VITE_FARO_URL = FARO_URL;
+    tele._resetTelemetry();
+    await tele.initTelemetry();
+    expect(tele.isEnabled()).toBe(false);
+  });
+});

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,0 +1,414 @@
+// Latency telemetry — the single place the observability vendor (Grafana Faro
+// → Grafana Cloud Tempo/Loki) is wired in. Every other module imports the
+// small wrapper API below and never touches Faro directly, so:
+//   - call sites stay clean (no span bookkeeping leaking into game logic), and
+//   - swapping the vendor later is a one-file change.
+//
+// Hard contracts every export must honour (the buzzer hot path depends on them):
+//   1. No-op when telemetry is disabled (VITE_FARO_URL unset — dev, tests, or a
+//      prod build before the collector URL is provisioned).
+//   2. Never throw. A telemetry bug must not break a buzz or a score.
+//   3. Never block. Callers must not `await` anything here; spans end fire-and-
+//      forget on a later tick. Faro batches/exports off the critical path.
+//
+// Why Faro and not raw OpenTelemetry-web: a Grafana Cloud OTLP *write* token is
+// a real credential and cannot ship in the browser bundle. Faro posts to a
+// public collector endpoint (app-key in the URL, designed for browser
+// exposure) and lands the same data in Tempo (traces) + Loki (logs).
+
+import type { Faro, LogLevel } from "@grafana/faro-web-sdk";
+import { env } from "./env";
+
+// Derive the OTel trace/span types straight from Faro's return type so we don't
+// take a direct dependency on @opentelemetry/api (it is only a transitive dep).
+type FaroOtel = NonNullable<ReturnType<Faro["api"]["getOTEL"]>>;
+type Tracer = ReturnType<FaroOtel["trace"]["getTracer"]>;
+type Span = ReturnType<Tracer["startSpan"]>;
+
+type AttrValue = string | number | boolean | undefined | null;
+type Attributes = Record<string, AttrValue>;
+
+// OTel SpanStatusCode.ERROR === 2. Inlined to avoid importing the enum from the
+// transitive @opentelemetry/api package.
+const STATUS_ERROR = 2 as const;
+
+// Stable span "op" names. Tempo groups by span name, so keeping these constant
+// (never inline a literal at a call site) is what makes p50/p95/p99 queries
+// durable. Attributes carry the specifics (game_code, song_id, rpc.name, …).
+export const SPAN_OPS = {
+  songStart: "game.song_start",
+  songClickToRpc: "game.song_start.click_to_rpc",
+  songRpcToLoad: "game.song_start.rpc_to_load",
+  songLoadToPlaying: "game.song_start.load_to_playing",
+  buzzE2e: "game.buzz.e2e",
+  scoreE2e: "game.score.e2e",
+  rpc: "db.rpc",
+  rest: "http.client",
+  playerInit: "game.player_init",
+} as const;
+
+let faro: Faro | undefined;
+let otel: FaroOtel | undefined;
+let tracer: Tracer | undefined;
+let initStarted = false;
+// LogLevel values, captured at init so `log()` doesn't need a static import of
+// the (otherwise lazily-loaded) Faro module.
+let levels: Record<"info" | "warn" | "error", LogLevel> | undefined;
+
+/** True once Faro has initialized and a tracer is available. */
+export function isEnabled(): boolean {
+  return tracer !== undefined;
+}
+
+/**
+ * Initialize Faro once. Safe to call unconditionally on app start: it resolves
+ * immediately (no-op) when VITE_FARO_URL is unset or when already initialized.
+ * Must never throw — a telemetry init failure cannot take down the app.
+ *
+ * The Faro SDK is **dynamically imported** so it (~tens of KB) is a lazy chunk
+ * fetched off the critical render path, and is never downloaded at all in a
+ * build whose collector URL is unset. Returns a promise so tests can await it;
+ * production calls it fire-and-forget (`void initTelemetry()`).
+ */
+export async function initTelemetry(): Promise<void> {
+  const url = env.VITE_FARO_URL;
+  if (faro || initStarted || !url) return;
+  initStarted = true;
+  try {
+    const sdk = await import("@grafana/faro-web-sdk");
+    const { TracingInstrumentation } = await import("@grafana/faro-web-tracing");
+    const instance = sdk.initializeFaro({
+      url,
+      app: {
+        name: "sound-clash-web",
+        environment: import.meta.env.MODE,
+      },
+      instrumentations: [
+        ...sdk.getWebInstrumentations(),
+        // `instrumentations: []` turns OFF auto fetch/XHR patching while keeping
+        // the OTel tracer provider + OTLP-over-Faro exporter wired up. We trace
+        // the network manually (tracedRpc / tracedFetch) instead. Why fully
+        // manual: auto fetch instrumentation injects a W3C `traceparent` header
+        // into outgoing requests, which would turn every cross-origin Supabase
+        // RPC into a CORS-preflighted call Supabase may reject — unacceptable on
+        // the <200ms buzzer path. Manual-only means nothing ever touches the
+        // Supabase request, and we still get clean named spans for querying.
+        new TracingInstrumentation({ instrumentations: [] }),
+      ],
+    });
+    levels = { info: sdk.LogLevel.INFO, warn: sdk.LogLevel.WARN, error: sdk.LogLevel.ERROR };
+    otel = instance.api.getOTEL();
+    tracer = otel?.trace.getTracer("sound-clash-web");
+    faro = instance;
+  } catch {
+    // Swallow: telemetry is best-effort and must not affect gameplay.
+    faro = undefined;
+    otel = undefined;
+    tracer = undefined;
+    initStarted = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function setAttrs(span: Span, attrs: Attributes): void {
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined && v !== null) span.setAttribute(k, v);
+  }
+}
+
+/** Start a span parented to `parent` (for cross-file, non-callback nesting). */
+function startChild(name: string, parent: Span, attrs: Attributes = {}): Span | undefined {
+  if (!tracer || !otel) return undefined;
+  const ctx = otel.trace.setSpan(otel.context.active(), parent);
+  const span = tracer.startSpan(name, undefined, ctx);
+  setAttrs(span, attrs);
+  return span;
+}
+
+/** Milliseconds between a Realtime row's commit and our receipt of the event. */
+function fanoutMs(commitTimestamp: string): number | undefined {
+  const parsed = Date.parse(commitTimestamp);
+  if (Number.isNaN(parsed)) return undefined;
+  const delta = Date.now() - parsed;
+  // Negative => client clock ahead of server; clamp rather than store garbage.
+  return delta < 0 ? 0 : delta;
+}
+
+// ---------------------------------------------------------------------------
+// Generic wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a Supabase PostgREST RPC call. Captures one `db.rpc` span (attribute
+ * `rpc.name`) covering the network round-trip. PostgREST reports failures in
+ * the resolved `{ error }` field rather than throwing, so we mark the span
+ * errored when `error` is set. Returns the run() result untouched.
+ */
+export async function tracedRpc<T extends { error?: unknown }>(
+  rpcName: string,
+  attrs: Attributes,
+  run: () => PromiseLike<T>,
+): Promise<T> {
+  if (!tracer) return run();
+  const span = tracer.startSpan(SPAN_OPS.rpc);
+  setAttrs(span, { "rpc.name": rpcName, ...attrs });
+  try {
+    const result = await run();
+    if (result && result.error) span.setStatus({ code: STATUS_ERROR });
+    return result;
+  } catch (e) {
+    span.setStatus({ code: STATUS_ERROR });
+    throw e;
+  } finally {
+    span.end();
+  }
+}
+
+/** Wrap a REST fetch to our FastAPI backend. One `http.client` span. */
+export async function tracedFetch<T extends Response>(
+  method: string,
+  route: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!tracer) return run();
+  const span = tracer.startSpan(SPAN_OPS.rest);
+  setAttrs(span, { "http.method": method, "http.route": route });
+  try {
+    const res = await run();
+    setAttrs(span, { "http.status_code": res.status });
+    if (!res.ok) span.setStatus({ code: STATUS_ERROR });
+    return res;
+  } catch (e) {
+    span.setStatus({ code: STATUS_ERROR });
+    throw e;
+  } finally {
+    span.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Song-start: click → audio actually playing (the headline "how long did the
+// song take to start?"). Parent span with three children. The end-point
+// (PLAYING) is detected by YouTubePlayer; see resolveSongStart via the handle.
+// ---------------------------------------------------------------------------
+
+export interface SongStartHandle {
+  /** Call when select_next_song resolves; supplies the round/song identity. */
+  rpcDone(info: { roundNumber?: number; songId?: string; youtubeId?: string }): void;
+  /** Call right after loadVideoById is issued to the player. */
+  loadIssued(): void;
+  /** Call when the player reaches PLAYING (or the load times out). Ends all. */
+  playing(detection: "statechange" | "poll" | "timeout"): void;
+  /** Call on any error (RPC failure, player error). Ends all, errored. */
+  fail(reason: string): void;
+}
+
+const INERT_SONG_START: SongStartHandle = {
+  rpcDone: () => {},
+  loadIssued: () => {},
+  playing: () => {},
+  fail: () => {},
+};
+
+export function startSongStart(attrs: { game_code: string }): SongStartHandle {
+  if (!tracer) return INERT_SONG_START;
+  const parent = tracer.startSpan(SPAN_OPS.songStart);
+  setAttrs(parent, attrs);
+  let child = startChild(SPAN_OPS.songClickToRpc, parent);
+  let done = false;
+
+  const closeChild = (): void => {
+    child?.end();
+    child = undefined;
+  };
+
+  return {
+    rpcDone(info) {
+      if (done) return;
+      setAttrs(parent, {
+        round_number: info.roundNumber,
+        song_id: info.songId,
+        youtube_id: info.youtubeId,
+      });
+      closeChild();
+      child = startChild(SPAN_OPS.songRpcToLoad, parent);
+    },
+    loadIssued() {
+      if (done) return;
+      closeChild();
+      child = startChild(SPAN_OPS.songLoadToPlaying, parent);
+    },
+    playing(detection) {
+      if (done) return;
+      done = true;
+      closeChild();
+      setAttrs(parent, { playing_detection: detection });
+      if (detection === "timeout") parent.setStatus({ code: STATUS_ERROR });
+      parent.end();
+    },
+    fail(reason) {
+      if (done) return;
+      done = true;
+      closeChild();
+      setAttrs(parent, { error_reason: reason });
+      parent.setStatus({ code: STATUS_ERROR });
+      parent.end();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Buzz e2e: pointerdown → this client observes the buzz lock in Realtime. The
+// start is marked in useBuzzer (it has the game context); the end is resolved
+// in useGameChannel when active_games.buzzed_team_id transitions to set. Keyed
+// by the local team's id — at most one open span per client.
+// ---------------------------------------------------------------------------
+
+const buzzSpans = new Map<string, Span>();
+
+export function markBuzzStart(gameCode: string, teamId: string, roundNumber?: number): void {
+  if (!tracer) return;
+  buzzSpans.get(teamId)?.end(); // defensive: close a prior unresolved span
+  const span = tracer.startSpan(SPAN_OPS.buzzE2e);
+  setAttrs(span, { game_code: gameCode, team_id: teamId, round_number: roundNumber });
+  buzzSpans.set(teamId, span);
+}
+
+export function resolveBuzzE2E(buzzedTeamId: string, commitTimestamp: string): void {
+  if (buzzSpans.size === 0) return;
+  const lag = fanoutMs(commitTimestamp);
+  for (const [teamId, span] of buzzSpans) {
+    setAttrs(span, {
+      outcome: teamId === buzzedTeamId ? "won" : "lost_race",
+      "realtime.fanout_ms": lag,
+    });
+    span.end();
+  }
+  buzzSpans.clear();
+}
+
+/** Close an open buzz span when the RPC itself failed (no lock will arrive). */
+export function failBuzz(teamId: string): void {
+  const span = buzzSpans.get(teamId);
+  if (!span) return;
+  setAttrs(span, { outcome: "error" });
+  span.setStatus({ code: STATUS_ERROR });
+  span.end();
+  buzzSpans.delete(teamId);
+}
+
+// ---------------------------------------------------------------------------
+// Score e2e: scoring click → ROUND_CHANGE for that round arrives in Realtime.
+// Keyed by `${roundId}:${verdict}` so concurrent verdicts don't collide.
+// ---------------------------------------------------------------------------
+
+const scoreSpans = new Map<string, Span>();
+
+export function markScoreStart(gameCode: string, roundId: string, verdict: string): void {
+  if (!tracer) return;
+  const key = `${roundId}:${verdict}`;
+  scoreSpans.get(key)?.end();
+  const span = tracer.startSpan(SPAN_OPS.scoreE2e);
+  setAttrs(span, { game_code: gameCode, round_id: roundId, verdict });
+  scoreSpans.set(key, span);
+}
+
+export function resolveScoreE2E(roundId: string, commitTimestamp: string): void {
+  if (scoreSpans.size === 0) return;
+  const lag = fanoutMs(commitTimestamp);
+  for (const [key, span] of scoreSpans) {
+    if (!key.startsWith(`${roundId}:`)) continue;
+    setAttrs(span, { "realtime.fanout_ms": lag });
+    span.end();
+    scoreSpans.delete(key);
+  }
+}
+
+/** Close an open score span when the RPC failed (no ROUND_CHANGE will arrive). */
+export function failScore(roundId: string, verdict: string): void {
+  const key = `${roundId}:${verdict}`;
+  const span = scoreSpans.get(key);
+  if (!span) return;
+  span.setStatus({ code: STATUS_ERROR });
+  span.end();
+  scoreSpans.delete(key);
+}
+
+// ---------------------------------------------------------------------------
+// Realtime fan-out lag, per event type — the cheapest, backend-free signal of
+// Supabase Realtime health. Pushed as a Faro event (queryable in Loki).
+// ---------------------------------------------------------------------------
+
+export function recordFanout(eventType: "game" | "team" | "round", commitTimestamp: string): void {
+  if (!faro) return;
+  const lag = fanoutMs(commitTimestamp);
+  if (lag === undefined) return;
+  try {
+    faro.api.pushEvent("realtime_fanout", { event_type: eventType, fanout_ms: String(lag) });
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// YouTube player init: mount → first onReady. One span per page load.
+// ---------------------------------------------------------------------------
+
+export interface PlayerInitHandle {
+  apiLoaded(apiCached: boolean): void;
+  ready(): void;
+}
+
+const INERT_PLAYER_INIT: PlayerInitHandle = { apiLoaded: () => {}, ready: () => {} };
+
+export function startPlayerInit(): PlayerInitHandle {
+  if (!tracer) return INERT_PLAYER_INIT;
+  const parent = tracer.startSpan(SPAN_OPS.playerInit);
+  let child = startChild("game.player_init.api_load", parent);
+  let done = false;
+  return {
+    apiLoaded(apiCached) {
+      if (done) return;
+      setAttrs(parent, { api_cached: apiCached });
+      child?.end();
+      child = startChild("game.player_init.player_ready", parent);
+    },
+    ready() {
+      if (done) return;
+      done = true;
+      child?.end();
+      parent.end();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structured logs → Loki. Use sparingly, never on the buzzer path.
+// ---------------------------------------------------------------------------
+
+export function log(
+  level: "info" | "warn" | "error",
+  message: string,
+  context?: Record<string, string>,
+): void {
+  if (!faro || !levels) return;
+  try {
+    faro.api.pushLog([message], { level: levels[level], context });
+  } catch {
+    // best-effort
+  }
+}
+
+// Test-only: reset module state between tests.
+export function _resetTelemetry(): void {
+  faro = undefined;
+  otel = undefined;
+  tracer = undefined;
+  levels = undefined;
+  initStarted = false;
+  buzzSpans.clear();
+  scoreSpans.clear();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,17 @@ import { createRoot } from "react-dom/client";
 import * as Sentry from "@sentry/react";
 import { App } from "./App";
 import { env } from "./lib/env";
+import { initTelemetry } from "./lib/telemetry";
 import "./styles.css";
 
 if (env.VITE_SENTRY_DSN) {
   Sentry.init({ dsn: env.VITE_SENTRY_DSN, tracesSampleRate: 0 });
 }
+
+// Latency telemetry → Grafana Cloud (Tempo/Loki) via Grafana Faro. No-op when
+// VITE_FARO_URL is unset (dev/tests). The Faro SDK is a lazy chunk and init is
+// fire-and-forget, so it never blocks rendering or the buzzer.
+void initTelemetry();
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("#root element not found");

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -40,6 +40,35 @@ vi.mock("../hooks/useSelectNextSong", () => ({
   selectNextSongDirect: vi.fn(),
 }));
 
+// Telemetry wrapper: assert the headline metrics (song-start, score-start) are
+// wired without touching real Faro. startSongStart returns a spy handle so the
+// page's songStart.rpcDone(...) calls don't crash.
+const telemetry = vi.hoisted(() => {
+  const handle = {
+    rpcDone: vi.fn(),
+    loadIssued: vi.fn(),
+    playing: vi.fn(),
+    fail: vi.fn(),
+  };
+  return {
+    handle,
+    startSongStart: vi.fn(() => handle),
+    markScoreStart: vi.fn(),
+    failScore: vi.fn(),
+    log: vi.fn(),
+  };
+});
+vi.mock("../lib/telemetry", () => ({
+  startSongStart: telemetry.startSongStart,
+  markScoreStart: telemetry.markScoreStart,
+  failScore: telemetry.failScore,
+  log: telemetry.log,
+  // Also consumed by useGameChannel, which the page renders.
+  recordFanout: vi.fn(),
+  resolveBuzzE2E: vi.fn(),
+  resolveScoreE2E: vi.fn(),
+}));
+
 interface MockHandle {
   loadVideoById: ReturnType<typeof vi.fn>;
   pause: ReturnType<typeof vi.fn>;
@@ -101,6 +130,15 @@ beforeEach(() => {
   vi.mocked(releaseBuzzLockDirect).mockReset();
   vi.mocked(awardBonus).mockReset();
   vi.mocked(endGame).mockReset();
+  // Re-establish the telemetry handle impl (afterEach's clearAllMocks drops it).
+  telemetry.startSongStart.mockReset();
+  telemetry.startSongStart.mockImplementation(() => telemetry.handle);
+  telemetry.handle.rpcDone.mockClear();
+  telemetry.handle.loadIssued.mockClear();
+  telemetry.handle.playing.mockClear();
+  telemetry.handle.fail.mockClear();
+  telemetry.markScoreStart.mockClear();
+  telemetry.failScore.mockClear();
 });
 
 afterEach(() => {
@@ -199,6 +237,67 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(screen.getByText("Wayne's World")).toBeInTheDocument());
     // Soundtrack rounds: show name is the only label; no "from X" subline.
     expect(screen.getByTestId("soundtrack-badge")).toBeInTheDocument();
+  });
+
+  it("opens a song-start span and reports rpcDone when Start is pressed", async () => {
+    setHydrate({
+      game: makeActiveGame({ status: "waiting" }),
+      teams: [],
+      rounds: [],
+    });
+    vi.mocked(selectNextSongDirect).mockResolvedValueOnce({
+      round_id: "r1",
+      round_number: 1,
+      song: {
+        id: "s1",
+        title: "T",
+        artist: "A",
+        youtube_id: "abcdefghijk",
+        start_time: 0,
+        is_soundtrack: false,
+      },
+    });
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    act(() => {
+      onReadyHandler?.();
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: /start game/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+    expect(telemetry.startSongStart).toHaveBeenCalledWith({ game_code: "ABCDEF" });
+    await waitFor(() =>
+      expect(telemetry.handle.rpcDone).toHaveBeenCalledWith(
+        expect.objectContaining({ roundNumber: 1, songId: "s1", youtubeId: "abcdefghijk" }),
+      ),
+    );
+  });
+
+  it("marks a score-start span when a correct answer is scored", async () => {
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1", name: "Alice" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    vi.mocked(awardAttemptDirect).mockResolvedValueOnce({
+      round_id: "r1",
+      team_id: "t1",
+      points_awarded: 10,
+      team_total_score: 10,
+      title_claimed_by: "t1",
+      artist_claimed_by: null,
+    });
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    fireEvent.click(screen.getByTestId("score-title"));
+    expect(telemetry.markScoreStart).toHaveBeenCalledWith("ABCDEF", "r1", "title");
   });
 
   it("score buttons enable only when a team is buzzed", async () => {

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -13,6 +13,13 @@ import { ApiError, awardBonus, endGame } from "../lib/api";
 import { awardAttemptDirect, releaseBuzzLockDirect, RpcError } from "../hooks/useManagerActions";
 import { selectNextSongDirect } from "../hooks/useSelectNextSong";
 import { clearManagerToken, getManagerToken } from "../lib/managerToken";
+import {
+  failScore,
+  log,
+  markScoreStart,
+  startSongStart,
+  type SongStartHandle,
+} from "../lib/telemetry";
 import { supabase } from "../lib/supabase";
 import { deriveIsSoundtrack, type SongGenreSlugEmbed } from "../lib/soundtrack";
 import type { Song } from "../lib/types";
@@ -25,6 +32,12 @@ export function ManagerConsolePage() {
   const { state, status } = useGameChannel(gameCode);
   const player = usePlayerReady();
   const playerRef = useRef<YouTubePlayerHandle | null>(null);
+  // Song-start measurement: the handle is opened on a "Next round" click and
+  // resolved when the player reaches PLAYING (or the timeout fires). It crosses
+  // the click handler → loadVideoById → YouTubePlayer.onPlaying boundary, so it
+  // lives in a ref rather than state.
+  const songStartRef = useRef<SongStartHandle | null>(null);
+  const songStartTimeoutRef = useRef<number | null>(null);
 
   // Keep the Render-hosted API warm while a game is running so the host's
   // occasional REST calls (Bonus / End game / Kick) and late team joins don't
@@ -174,18 +187,47 @@ export function ManagerConsolePage() {
         );
         return;
       }
+      log("error", "manager_rpc_failed", { message: err.message });
       toast(err.message, { variant: "error" });
       return;
     }
+    log("error", "manager_action_failed", {
+      message: err instanceof Error ? err.message : String(err),
+    });
     toast(err instanceof Error ? err.message : "Request failed", { variant: "error" });
   }
 
   async function loadSongIntoPlayer(song: Song) {
     if (player.ready) {
+      songStartRef.current?.loadIssued();
+      armSongStartTimeout();
       playerRef.current?.loadVideoById(song.youtube_id, song.start_time);
     } else {
+      // Player not ready yet (first song): the load is deferred to
+      // onPlayerReady, which issues loadVideoById and marks loadIssued there.
       player.enqueueSong({ youtube_id: song.youtube_id, start_time: song.start_time });
     }
+  }
+
+  // Bound the song-start span so a video that never reaches PLAYING (autoplay
+  // blocked, dead embed) is recorded as a timeout outlier rather than left open.
+  function armSongStartTimeout() {
+    if (songStartTimeoutRef.current !== null) window.clearTimeout(songStartTimeoutRef.current);
+    songStartTimeoutRef.current = window.setTimeout(() => {
+      songStartRef.current?.playing("timeout");
+      songStartRef.current = null;
+      songStartTimeoutRef.current = null;
+    }, 8000);
+  }
+
+  // Resolve the open song-start span when the player actually starts playing.
+  function handlePlayerPlaying(detection: "statechange" | "poll") {
+    if (songStartTimeoutRef.current !== null) {
+      window.clearTimeout(songStartTimeoutRef.current);
+      songStartTimeoutRef.current = null;
+    }
+    songStartRef.current?.playing(detection);
+    songStartRef.current = null;
   }
 
   // Apply an attempt via the direct browser -> Supabase RPC. Migration 021
@@ -226,6 +268,7 @@ export function ManagerConsolePage() {
     // flicker in the gap.
     setPendingTitle(roundId);
     setBusy(true);
+    markScoreStart(gameCode, roundId, "title");
     try {
       await applyAttempt(roundId, {
         title_correct: true,
@@ -233,6 +276,7 @@ export function ManagerConsolePage() {
         wrong_buzz: false,
       });
     } catch (err) {
+      failScore(roundId, "title");
       setPendingTitle(null);
       reportError(err);
     } finally {
@@ -251,6 +295,7 @@ export function ManagerConsolePage() {
     if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
     setPendingArtist(roundId);
     setBusy(true);
+    markScoreStart(gameCode, roundId, "artist");
     try {
       await applyAttempt(roundId, {
         title_correct: false,
@@ -258,6 +303,7 @@ export function ManagerConsolePage() {
         wrong_buzz: false,
       });
     } catch (err) {
+      failScore(roundId, "artist");
       setPendingArtist(null);
       reportError(err);
     } finally {
@@ -286,6 +332,7 @@ export function ManagerConsolePage() {
     setPendingTitle(roundId);
     setPendingArtist(roundId);
     setBusy(true);
+    markScoreStart(gameCode, roundId, "soundtrack");
     try {
       await applyAttempt(roundId, {
         title_correct: true,
@@ -293,6 +340,7 @@ export function ManagerConsolePage() {
         wrong_buzz: false,
       });
     } catch (err) {
+      failScore(roundId, "soundtrack");
       setPendingTitle(null);
       setPendingArtist(null);
       reportError(err);
@@ -362,6 +410,10 @@ export function ManagerConsolePage() {
     if (nextRoundInFlightRef.current) return;
     if (busy || !managerToken) return;
     nextRoundInFlightRef.current = true;
+    // Open the song-start span at the click instant (before the toast) so it
+    // captures click → RPC → load → audio actually playing.
+    const songStart = startSongStart({ game_code: gameCode });
+    songStartRef.current = songStart;
     // Optimistic toast confirms the click immediately. The single direct RPC
     // (migration 022 -> select_next_song) replaces what used to be two
     // chained Render hops (POST /end-round + POST /select-song), so the
@@ -372,9 +424,16 @@ export function ManagerConsolePage() {
     setBusy(true);
     try {
       const result = await selectNextSongDirect(gameCode, managerToken);
+      songStart.rpcDone({
+        roundNumber: result.round_number,
+        songId: result.song.id,
+        youtubeId: result.song.youtube_id,
+      });
       setCurrentSong(result.song);
       await loadSongIntoPlayer(result.song);
     } catch (err) {
+      songStart.fail("select_next_song_failed");
+      songStartRef.current = null;
       reportError(err);
     } finally {
       setBusy(false);
@@ -419,6 +478,10 @@ export function ManagerConsolePage() {
     player.setReady();
     const queued = player.flushPendingSong();
     if (queued) {
+      // This is the deferred first-song load; mark loadIssued here so the
+      // song-start span's load_to_playing child measures from the real load.
+      songStartRef.current?.loadIssued();
+      armSongStartTimeout();
       playerRef.current?.loadVideoById(queued.youtube_id, queued.start_time);
     }
   }
@@ -547,11 +610,13 @@ export function ManagerConsolePage() {
           ref={playerRef}
           noCover
           onReady={onPlayerReady}
-          onError={() =>
+          onPlaying={handlePlayerPlaying}
+          onError={(code) => {
+            log("warn", "yt_player_error", { code: String(code) });
             toast("Video unavailable — click Next round to pick a different song.", {
               variant: "error",
-            })
-          }
+            });
+          }}
         />
 
         <section className={styles.card}>

--- a/tests/backend/test_otel.py
+++ b/tests/backend/test_otel.py
@@ -1,0 +1,143 @@
+"""Conditional OpenTelemetry init (app.middleware.otel).
+
+Mirrors the Sentry install tests: the default test run must NOT configure OTel,
+and the production path (endpoint set, PYTEST guard removed) must wire the
+provider + instrumentors. We monkeypatch the OTel symbols so no real tracer
+provider is set globally and httpx is not patched.
+"""
+
+from __future__ import annotations
+
+from app.middleware import otel as otel_module
+
+
+def test_otel_skipped_in_tests(monkeypatch) -> None:
+    """PYTEST_CURRENT_TEST is set, so install() must not configure anything."""
+    called: dict[str, object] = {}
+    monkeypatch.setattr(otel_module, "_configure", lambda app: called.setdefault("app", app))
+    otel_module.install(object())  # sentinel app
+    assert called == {}
+
+
+def test_otel_skipped_without_endpoint(monkeypatch) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    called: dict[str, object] = {}
+    monkeypatch.setattr(otel_module, "_configure", lambda app: called.setdefault("app", app))
+    otel_module.install(object())
+    assert called == {}
+
+
+def test_otel_configures_when_endpoint_set(monkeypatch) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otlp.example/otlp")
+    sentinel = object()
+    called: dict[str, object] = {}
+    monkeypatch.setattr(otel_module, "_configure", lambda app: called.setdefault("app", app))
+    otel_module.install(sentinel)
+    assert called["app"] is sentinel
+
+
+def test_configure_wires_provider_and_instrumentors(monkeypatch) -> None:
+    """_configure builds a provider + exporter and instruments FastAPI + httpx,
+    all against fakes so nothing touches global state or the network."""
+    calls: dict[str, object] = {}
+
+    class FakeResource:
+        @staticmethod
+        def create(attrs: dict[str, object]) -> dict[str, object]:
+            calls["resource"] = attrs
+            return attrs
+
+    class FakeProvider:
+        def __init__(self, resource: object = None) -> None:
+            calls["provider_resource"] = resource
+
+        def add_span_processor(self, processor: object) -> None:
+            calls["processor"] = processor
+
+    class FakeBatch:
+        def __init__(self, exporter: object) -> None:
+            calls["exporter"] = exporter
+
+    class FakeExporter:
+        def __init__(self) -> None:
+            calls["exporter_created"] = True
+
+    class FakeTrace:
+        @staticmethod
+        def set_tracer_provider(provider: object) -> None:
+            calls["set_provider"] = provider
+
+    class FakeFastAPIInstrumentor:
+        @staticmethod
+        def instrument_app(app: object, tracer_provider: object = None) -> None:
+            calls["fastapi_app"] = app
+            calls["fastapi_provider"] = tracer_provider
+
+    class FakeHTTPX:
+        def instrument(self, tracer_provider: object = None) -> None:
+            calls["httpx_provider"] = tracer_provider
+
+    monkeypatch.setattr(otel_module, "Resource", FakeResource)
+    monkeypatch.setattr(otel_module, "TracerProvider", FakeProvider)
+    monkeypatch.setattr(otel_module, "BatchSpanProcessor", FakeBatch)
+    monkeypatch.setattr(otel_module, "OTLPSpanExporter", FakeExporter)
+    monkeypatch.setattr(otel_module, "trace", FakeTrace)
+    monkeypatch.setattr(otel_module, "FastAPIInstrumentor", FakeFastAPIInstrumentor)
+    monkeypatch.setattr(otel_module, "HTTPXClientInstrumentor", FakeHTTPX)
+
+    app = object()
+    otel_module._configure(app)
+
+    assert calls["fastapi_app"] is app
+    assert calls["set_provider"] is not None
+    assert calls["fastapi_provider"] is calls["set_provider"]
+    assert calls["httpx_provider"] is calls["set_provider"]
+    assert calls["exporter_created"] is True
+    # service.name + service.version present on the resource.
+    resource = calls["resource"]
+    assert isinstance(resource, dict)
+    assert resource["service.name"] == "sound-clash-backend"
+
+
+def test_configure_honours_custom_service_name(monkeypatch) -> None:
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "custom-svc")
+    captured: dict[str, object] = {}
+
+    class FakeResource:
+        @staticmethod
+        def create(attrs: dict[str, object]) -> dict[str, object]:
+            captured.update(attrs)
+            return attrs
+
+    monkeypatch.setattr(otel_module, "Resource", FakeResource)
+    monkeypatch.setattr(otel_module, "TracerProvider", lambda resource=None: _Noop())
+    monkeypatch.setattr(otel_module, "BatchSpanProcessor", lambda exporter: None)
+    monkeypatch.setattr(otel_module, "OTLPSpanExporter", lambda: None)
+    monkeypatch.setattr(otel_module, "trace", _NoopTrace())
+    monkeypatch.setattr(otel_module, "FastAPIInstrumentor", _NoopInstrumentor())
+    monkeypatch.setattr(otel_module, "HTTPXClientInstrumentor", lambda: _NoopHTTPX())
+
+    otel_module._configure(object())
+    assert captured["service.name"] == "custom-svc"
+
+
+class _Noop:
+    def add_span_processor(self, processor: object) -> None:
+        return None
+
+
+class _NoopTrace:
+    def set_tracer_provider(self, provider: object) -> None:
+        return None
+
+
+class _NoopInstrumentor:
+    def instrument_app(self, app: object, tracer_provider: object = None) -> None:
+        return None
+
+
+class _NoopHTTPX:
+    def instrument(self, tracer_provider: object = None) -> None:
+        return None


### PR DESCRIPTION
## Summary

Adds logs + distributed traces for latency analysis, sent to **Grafana Cloud** (Tempo + Loki) — separate from Sentry, which stays errors-only. Everything is gated on env vars, so this is a **no-op until the collector URL / OTLP token are configured**.

- **Frontend (the bulk of the signal — the hot path is browser→Supabase direct):** Grafana Faro Web SDK behind a single wrapper (`frontend/src/lib/telemetry.ts`). Faro is **dynamically imported** (lazy chunk; the main bundle drops ~58 KB gzip and Faro isn't downloaded at all when the collector URL is unset). Auto fetch/XHR instrumentation is **off** so nothing ever injects a `traceparent` header into a cross-origin Supabase RPC (which would CORS-break the <200 ms buzzer). Custom spans:
  - `game.song_start` (+ children): "Next round" click → audio actually PLAYING. PLAYING is derived from the YouTube IFrame `onStateChange(PLAYING)` with a bounded `getPlayerState` poll + timeout fallback (no native event).
  - `game.buzz.e2e`: pointerdown → buzz lock observed in Realtime (won / lost_race), with a `realtime.fanout_ms` estimate.
  - `game.score.e2e`, `db.rpc` (per RPC), `http.client` (per REST call), `game.player_init`, and a `realtime_fanout` event per table.
- **Backend:** opt-in OpenTelemetry (`backend/app/middleware/otel.py`) — FastAPI + httpx auto-instrumentation → Grafana OTLP gateway. Off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Only covers create/join/bonus/end (hot-path RPCs bypass FastAPI).
- Telemetry is no-throw, non-blocking, and a no-op when disabled — it cannot affect gameplay.
- Docs: `tech-stack.md` §7.5 (architecture) + §1 table; `runbook.md` §3.6 (the three Grafana credentials + rotation). No CHANGELOG entry (not user-visible).

## Test plan

- Frontend: `npm run lint`, `npm run typecheck`, `npm run test:run` (295 pass), `npm run test:coverage` (gate holds: stmts 90.1 / branches 83.3 / funcs 90.2 / lines 94.5), `npm run build` (Faro confirmed as a lazy chunk). New `telemetry.test.ts` covers enabled + disabled paths (no-op + pass-through contracts).
- Backend: `ruff check`, `ruff format --check`, `mypy app` clean; new `tests/backend/test_otel.py` (5 tests, `otel.py` at 100% coverage).
- Post-merge (needs Grafana credentials): set `VITE_FARO_URL` (Cloudflare Pages) + `OTEL_EXPORTER_OTLP_*` (Render), play a full game, confirm traces in Tempo / logs in Loki, and **confirm Supabase RPCs still 200** (the CORS check).