### PR TITLE
Grant service_role base-table privileges so e2e can read genres

### DIFF
--- a/db/migrations/030_grant_service_role_tables.sql
+++ b/db/migrations/030_grant_service_role_tables.sql
@@ -1,0 +1,41 @@
+-- 030_grant_service_role_tables.sql
+-- Grant the backend's service_role the base-table privileges it needs.
+--
+-- Background: the FastAPI backend connects to PostgREST as `service_role`
+-- (the Supabase service-role key) and is the trusted server-side principal. It
+-- is created BYPASSRLS in migration 006 and does all server-side reads/writes:
+-- GET /genres, POST /games (active_games + game_teams), the admin song catalog
+-- (songs + song_genres), kick (game_teams DELETE), etc.
+--
+-- The bug this fixes: bypassing RLS is NOT the same as holding a base-table
+-- privilege -- PostgreSQL checks table GRANTs *before* RLS. Migration 006
+-- granted SELECT on the six public tables to `anon` only, never to
+-- `service_role`. In hosted Supabase that gap is invisible because the project
+-- bootstrap auto-grants privileges on every `public` table to
+-- anon/authenticated/service_role. But a stack that only applies
+-- db/migrations/ -- the CI e2e `supabase start` stack -- gets no such
+-- auto-grant, so every service_role table access fails with
+-- `42501 permission denied for table ...`, starting with `GET /genres`, which
+-- 500s and leaves the manager create-game page with no genres to pick (every
+-- game-creating e2e spec then fails at setup).
+--
+-- Fix: grant service_role the privileges explicitly, mirroring the hosted
+-- bootstrap. This is the same "don't rely on hosted-Supabase's auto-grant"
+-- philosophy as migration 020 (which re-asserts function EXECUTE grants). It is
+-- a no-op in production, where service_role already holds these grants.
+--
+-- Spec: docs/security-rls.md §2.
+--
+-- Idempotent: GRANT is naturally idempotent; the defensive role create mirrors
+-- migration 006 and is a no-op on Supabase where the role exists natively.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN BYPASSRLS;
+  END IF;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON songs, genres, song_genres, active_games, game_teams, game_rounds
+  TO service_role;

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -82,6 +82,24 @@ CREATE POLICY "anon_read_game_rounds"  ON game_rounds  FOR SELECT TO anon USING 
 
 No `INSERT`, `UPDATE`, or `DELETE` policies are created for `anon` → all writes are denied by default.
 
+### Table grants
+
+```sql
+-- anon needs the base-table privilege before RLS even gates anything (it only
+-- ever SELECTs; the read policies above scope it). Migration 006.
+GRANT SELECT ON songs, genres, song_genres, active_games, game_teams, game_rounds TO anon;
+
+-- service_role bypasses RLS but STILL needs base-table privileges (Postgres
+-- checks GRANTs before RLS). Hosted Supabase auto-grants these on bootstrap, so
+-- prod has always worked; a migrations-only stack (the CI e2e `supabase start`)
+-- does not, so service_role table access 500s with `42501 permission denied`.
+-- Migration 030 grants them explicitly -- same "don't trust the auto-grant"
+-- stance as the function grants below. No-op in production.
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON songs, genres, song_genres, active_games, game_teams, game_rounds
+  TO service_role;
+```
+
 ### Function grants
 
 ```sql


### PR DESCRIPTION
## Summary

The Playwright e2e suite has been failing on `main` (all 27 specs) — unrelated to any recent feature work. Root cause: the FastAPI backend connects to PostgREST as `service_role`, but **no migration ever granted `service_role` base-table privileges**. The only table grant in the whole migration set is `006_rls_policies.sql:43` → `GRANT SELECT ... TO anon`.

`service_role` is created `BYPASSRLS` (migration 006), but bypassing RLS is not the same as holding a base-table privilege — Postgres checks table `GRANT`s *before* RLS. In hosted Supabase the project bootstrap auto-grants every `public` table to anon/authenticated/service_role, so **prod has always worked**. The CI e2e stack only applies `db/migrations/` (via `supabase start`), gets no auto-grant, so every `service_role` table access fails with `42501 permission denied for table ...` — starting with `GET /genres`, which 500s and leaves the create-game page with no genres, so every game-creating spec dies at setup (`getByLabel(/^Rock$/i)` not found).

Migration `030_grant_service_role_tables.sql` grants `service_role` `SELECT, INSERT, UPDATE, DELETE` on the six public tables explicitly — the same "don't rely on hosted-Supabase's auto-grant" stance migration 020 already takes for function `EXECUTE`. **No-op in production** (those grants already exist there); it only repairs migrations-only stacks like CI e2e.

## Test plan

- Migration is idempotent (`GRANT` is naturally idempotent; the role create is guarded) and a no-op in prod, so no prod apply is required.
- `docs/security-rls.md` §2 updated with a "Table grants" subsection documenting the explicit `service_role` grant and why it's needed.
- Labeling this PR `run-e2e` to confirm the suite goes green (the e2e workflow only runs on PRs when labeled).