### PR TITLE
Song-curation: metadata-sources reference + catalog changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-06-18: Added **195 new songs** to the catalog (804 → 999), curated and human-reviewed across every genre — heaviest on Israeli music: israeli-rock-pop (+47), mizrahit (+35), israeli-pop (+21), israeli-rap-hip-hop (+7), plus current 2024–2026 Hebrew hits, and refreshes to pop (+27), electronic (+22), rock (+15), hip-hop (+15), soundtracks (+5), israeli-cover (+2).
 - 2026-05-24: How-to-play page now opens with a hero illustration showing the three-screen setup at a glance — host's phone with the manager console, TV/laptop running the display + scoreboard + join QR, and team phones with the BUZZ button — so first-time visitors can see how everything connects before reading the steps.
 - 2026-05-24: New **Israeli Soundtracks** genre, separated from the existing soundtrack bucket so hosts can run a Hebrew-only (or English-only) soundtrack round. Six Israeli titles (גבעת חלפון אינה עונה, גברת פלפלת, נילס הולגרסון, הדרדסים, איזה עולם, הפיג'מות) moved into the new genre.
 - 2026-05-16: How-to-play page reworked into a numbered seven-step walkthrough (Host a game → genres → Display screen → teams join with QR → start → buzz/judge → optional Bonus) plus a short "Rules & FAQ" section covering the free-guess sweetener, two tokens per song, wrong-buzz-doesn't-lock-you-out, +4 Bonus anytime, and one-phone-per-team reconnect.

--- a/tools/song-curation/data-sources.md
+++ b/tools/song-curation/data-sources.md
@@ -1,0 +1,66 @@
+# Song metadata sources
+
+Reference list of external databases/APIs for song metadata (title, artist,
+genre, **year → decade**, popularity). Use these to **discover** what songs to
+add and, later, to **enrich/cross-check** year+decade — **not** as data to bulk
+import.
+
+> **Why not just import one of these?** They give you metadata (the easy half).
+> They do **not** give a reliable, embeddable `youtube_id` (the hard half — the
+> whole reason `verify.py` + `review.html` exist). They're also huge (MusicBrainz
+> ~40M recordings) and mostly ToS-restricted for storage. Our catalog is ~800
+> hand-picked, verified, *playable* songs and stays the single source of truth.
+> See `README.md` for the curation pipeline these feed into.
+
+## Metadata authorities — canonical title / artist / **year** / genre
+
+| Source | Access | Includes | Notes |
+| --- | --- | --- | --- |
+| **MusicBrainz** | Free REST API (1 req/s) + full bulk DB dumps. **CC0** | Canonical artist/recording/release, **first-release date → year/decade**, ISRC, community genre tags | Best for year + canonical names. Tags are noisy. No YouTube id. |
+| **Wikidata** | Free SPARQL endpoint. **CC0** | Song entities: publication date (P577 → year), genre (P136), performer (P175), external IDs (MusicBrainz, Spotify, sometimes YouTube video id P1651). **Has Hebrew labels.** | Structured + cross-links. Coverage thin for niche/Mizrahi. |
+| **Discogs** | Free API (rate-limited; OAuth for more) + monthly XML dumps | Year, two-level **genre + style** taxonomy, artist/title | Release-centric. No YouTube id. |
+
+These three are CC0/facts → safe to store and redistribute. Backbone for
+year/decade and correct names.
+
+## Popularity & discovery — *which* songs to add, by genre/decade
+
+| Source | Access | Includes | Notes |
+| --- | --- | --- | --- |
+| **Spotify Web API** | Free (client-credentials) | Album **release_date → year/decade**, **popularity 0–100**, ISRC, editorial playlists ("Top 50 by decade/genre/country") | Genre is **per-artist, not per-track**. ToS limits storing/displaying → use for ranking/discovery only. |
+| **Last.fm API** | Free key | **Folksonomy genre tags**, listener/play counts (popularity), top-tracks-by-tag/country | Tags messy; year unreliable. No YouTube id. |
+| **Deezer API** | Free, no-auth for many endpoints | Album release_date, genre list, chart/editorial endpoints | Coarse genre. No YouTube id. |
+| **Billboard / chart datasets** (Hot 100 year-end; public Kaggle dumps) | Free datasets | **Decade-by-decade popularity** ground truth | Dataset/scrape, not a live API. |
+
+## The linchpin — name → *playable* id
+
+| Source | Access | Includes |
+| --- | --- | --- |
+| **YouTube Data API v3** | Free, 10k quota units/day (search = 100 units) | `search` → candidate videos; `videos` → `status.embeddable`, title, channel, `publishedAt`. Automates "name → verified embeddable id". |
+
+⚠️ `publishedAt` is the **upload date, not the release year** — never use it for year.
+
+## Hebrew / Mizrahi gap-fillers (our weak spot)
+
+English sources under-cover Israeli music. For these genres, use:
+
+| Source | Includes |
+| --- | --- |
+| **Media Forest (מדיה פורסט)** Israeli airplay year-end charts | Year + popularity for Israeli/Mizrahi songs |
+| **Galgalatz annual chart (מצעד גלגלצ השנתי)** / Hebrew Wikipedia hit lists | Year-stamped annual Israeli hits |
+| **Spotify "Israel Top 50" + editorial Mizrahi playlists / Deezer Israel charts** | Current popularity + ISRC |
+
+Get canonical Hebrew title/artist from Wikidata (Hebrew labels) + MusicBrainz,
+then resolve to YouTube and **keep the per-song human review** (past errors lived here).
+
+## How to use them (summary)
+
+- **Now:** discovery only — pull popularity-ranked candidate lists (esp. Israeli
+  charts for the Hebrew gap) into `candidates_in.csv`, then run the normal
+  `verify.py` → `review.html` pipeline.
+- **Later (decade feature):** add a `release_year` column and backfill from
+  **MusicBrainz + Wikidata** by ISRC/MBID; trust a year only when ≥2 sources
+  agree, human-review disagreements. `release_year` is the *original commercial
+  release year of the recording* — not reissue, remaster, or YouTube upload.
+- **Never:** bulk-import these, or query them live at game time (the <200 ms hot
+  path forbids it). The catalog is always a pre-built, pre-verified, owned table.


### PR DESCRIPTION
## Summary

Two small follow-ups to the merged song-curation tool (#122), both reusable docs/records — no app code:

- **`tools/song-curation/data-sources.md`** — reference list of external metadata/popularity sources (MusicBrainz, Wikidata, Discogs, Spotify, Last.fm, Deezer, Billboard, YouTube Data API, and the Israeli charts — Media Forest / Galgalatz) for *discovering* and later *enriching* songs (year → decade), with a clear note that they're for discovery/cross-check only, never bulk import (the catalog of verified, playable songs stays the single source of truth).
- **`CHANGELOG.md`** — one `### Added` line recording the catalog import (804 → 999 songs).

Per-batch curation working data (song CSVs, `candidates.js`, `prod_catalog.csv`, `upload.sql`, scraped playlist dumps) is deliberately gitignored and not included.

## Test plan

Docs/changelog only — nothing to run. The 195 songs were already uploaded to and verified in the production catalog.