### PR TITLE
Add decade filter to game creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-06-18: Hosts can now **filter songs by decade** when creating a game — tap any of the 60s–20s buttons (multi-select) alongside genres, and only songs from those decades play (genres **and** decades). Leaving decades unpicked keeps every year, exactly as before. For covers, the decade follows the song's original release year, not the cover's.
 - 2026-06-18: Admin song catalog now has an optional **Release year** field (song form + CSV import) and shows each song's year as a **Year column** in the catalog list. This is the groundwork for an upcoming "filter by decade" option when hosting a game.
 - 2026-06-18: Added **195 new songs** to the catalog (804 → 999), curated and human-reviewed across every genre — heaviest on Israeli music: israeli-rock-pop (+47), mizrahit (+35), israeli-pop (+21), israeli-rap-hip-hop (+7), plus current 2024–2026 Hebrew hits, and refreshes to pop (+27), electronic (+22), rock (+15), hip-hop (+15), soundtracks (+5), israeli-cover (+2).
 - 2026-05-24: How-to-play page now opens with a hero illustration showing the three-screen setup at a glance — host's phone with the manager console, TV/laptop running the display + scoreboard + join QR, and team phones with the BUZZ button — so first-time visitors can see how everything connects before reading the steps.

--- a/backend/app/models/games.py
+++ b/backend/app/models/games.py
@@ -12,12 +12,17 @@ TeamName = Annotated[
     str,
     StringConstraints(min_length=1, max_length=30, strip_whitespace=True),
 ]
+# A decade is stored as its start year (the 80s = 1980). Bounds mirror the
+# songs.release_year CHECK; the picker floors release_year to its decade and
+# matches by membership (migration 032).
+Decade = Annotated[int, Field(ge=1900, le=2100)]
 
 
 class CreateGameRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     selected_genres: list[UUID] = Field(min_length=1)
+    selected_decades: list[Decade] = Field(default_factory=list)
 
 
 class CreateGameResponse(BaseModel):
@@ -26,6 +31,7 @@ class CreateGameResponse(BaseModel):
     game_code: str
     status: str
     selected_genres: list[UUID]
+    selected_decades: list[int] = Field(default_factory=list)
     started_at: datetime
     expires_at: datetime
     manager_token: UUID

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -50,12 +50,13 @@ router = APIRouter(tags=["games"])
 
 
 def _insert_game_blocking(
-    client: SupabaseClientLike, code: str, genre_ids: list[str]
+    client: SupabaseClientLike, code: str, genre_ids: list[str], decades: list[int]
 ) -> dict[str, Any]:
     payload = {
         "game_code": code,
         "status": "waiting",
         "selected_genres": genre_ids,
+        "selected_decades": decades,
     }
     with mapped_postgrest_errors():
         resp = client.table("active_games").insert(payload).execute()
@@ -68,7 +69,10 @@ def _insert_game_blocking(
 def _fetch_game_blocking(client: SupabaseClientLike, code: str) -> dict[str, Any]:
     resp = (
         client.table("active_games")
-        .select("game_code,status,selected_genres,started_at,expires_at,ended_at,round_number")
+        .select(
+            "game_code,status,selected_genres,selected_decades,"
+            "started_at,expires_at,ended_at,round_number"
+        )
         .eq("game_code", code)
         .execute()
     )
@@ -140,12 +144,15 @@ def _kick_blocking(client: SupabaseClientLike, code: str, team_id: str) -> None:
 async def create_game(request: Request, body: CreateGameRequest) -> CreateGameResponse:
     client = get_supabase_client()
     genre_ids = [str(g) for g in body.selected_genres]
+    decades = list(body.selected_decades)
 
     inserted: dict[str, Any] = {}
 
     async def insert(code: str) -> None:
         nonlocal inserted
-        inserted = await anyio.to_thread.run_sync(_insert_game_blocking, client, code, genre_ids)
+        inserted = await anyio.to_thread.run_sync(
+            _insert_game_blocking, client, code, genre_ids, decades
+        )
 
     await generate_unique_code(insert)
     return CreateGameResponse.model_validate(inserted)

--- a/db/migrations/032_decade_filter.sql
+++ b/db/migrations/032_decade_filter.sql
@@ -1,0 +1,242 @@
+-- 032_decade_filter.sql
+-- Adds an optional release-decade filter to game creation. A host can now pick a
+-- set of decades (the 80s = 1980, the 90s = 1990, ...) alongside genres; the song
+-- picker then only serves unplayed songs whose genre is selected AND whose
+-- release_year (mig 031) falls in one of the chosen decades.
+--
+-- Storage mirrors selected_genres: a NOT NULL integer[] DEFAULT '{}' on
+-- active_games, set once at POST /games. An empty array means "no decade limit"
+-- (today's behaviour), so the feature is purely additive and existing games and
+-- tests are unaffected.
+--
+-- The picker change is one predicate added to the shared `eligible` CTE in BOTH
+-- select_next_song (mig 028) and peek_next_song (mig 029) -- they must stay in
+-- lockstep, or prebuffer (peek) would cue songs the commit (select) then rejects.
+-- A song's decade is the integer-division floor: (release_year / 10 * 10). A NULL
+-- release_year matches no specific decade, so unknown-year songs are excluded
+-- when a decade is chosen and included when none is. Genres stay required;
+-- decades stay optional, so no new guard.
+--
+-- Both functions keep their exact signature and RETURNS shape, so a plain
+-- CREATE OR REPLACE suffices (no DROP FUNCTION, PostgREST routing untouched).
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE OR REPLACE are re-runnable.
+
+BEGIN;
+
+ALTER TABLE active_games
+  ADD COLUMN IF NOT EXISTS selected_decades integer[] NOT NULL DEFAULT '{}';
+
+-- select_next_song: identical to migration 028 except it loads selected_decades
+-- and filters the `eligible` CTE by decade.
+CREATE OR REPLACE FUNCTION select_next_song(
+  p_game_code      text,
+  p_manager_token  uuid,
+  p_song_id        uuid DEFAULT NULL
+)
+RETURNS TABLE(
+  round_id      uuid,
+  round_number  integer,
+  song_id       uuid,
+  song_title    text,
+  song_artist   text,
+  youtube_id    text,
+  start_time    integer,
+  is_soundtrack boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_expected_token uuid;
+  v_game_ended_at  timestamptz;
+  v_genres         uuid[];
+  v_decades        integer[];
+  v_chosen_song    uuid;
+  v_round_id       uuid;
+  v_round_number   integer;
+BEGIN
+  SELECT ag.manager_token, ag.ended_at, ag.selected_genres, ag.selected_decades
+    INTO v_expected_token, v_game_ended_at, v_genres, v_decades
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_game_ended_at IS NOT NULL THEN
+    RAISE EXCEPTION 'game_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_expected_token IS NULL
+     OR p_manager_token IS NULL
+     OR v_expected_token <> p_manager_token THEN
+    RAISE EXCEPTION 'manager_token_required' USING ERRCODE = '28000';
+  END IF;
+
+  IF v_genres IS NULL OR cardinality(v_genres) = 0 THEN
+    RAISE EXCEPTION 'no_genres_selected' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_song_id IS NOT NULL THEN
+    PERFORM 1 FROM songs WHERE id = p_song_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'song_not_found' USING ERRCODE = 'P0002';
+    END IF;
+    v_chosen_song := p_song_id;
+  ELSE
+    WITH played AS (
+      SELECT gr.song_id AS sid
+        FROM game_rounds gr
+       WHERE gr.game_code = p_game_code
+         AND gr.song_id IS NOT NULL
+    ),
+    eligible AS (
+      SELECT sg.genre_id AS gid, sg.song_id AS sid
+        FROM song_genres sg
+        JOIN songs s ON s.id = sg.song_id
+       WHERE sg.genre_id = ANY (v_genres)
+         AND sg.song_id NOT IN (SELECT played.sid FROM played)
+         AND (
+               cardinality(v_decades) = 0
+               OR (s.release_year / 10 * 10) = ANY (v_decades)
+             )
+    ),
+    chosen_genre AS (
+      SELECT eligible.gid
+        FROM eligible
+       GROUP BY eligible.gid
+       ORDER BY random()
+       LIMIT 1
+    )
+    SELECT e.sid INTO v_chosen_song
+      FROM eligible e
+      JOIN chosen_genre cg ON cg.gid = e.gid
+     ORDER BY random()
+     LIMIT 1;
+
+    IF v_chosen_song IS NULL THEN
+      RAISE EXCEPTION 'no_more_songs' USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  v_round_id := start_round(p_game_code::char(6), v_chosen_song);
+
+  SELECT ag.round_number INTO v_round_number
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  RETURN QUERY
+    SELECT v_round_id,
+           v_round_number,
+           s.id,
+           s.title,
+           s.artist,
+           s.youtube_id::text,
+           s.start_time,
+           EXISTS (
+             SELECT 1
+               FROM song_genres sg
+               JOIN genres g ON g.id = sg.genre_id
+              WHERE sg.song_id = s.id
+                AND g.slug IN ('soundtracks', 'israeli-soundtracks')
+           ) AS is_soundtrack
+      FROM songs s
+     WHERE s.id = v_chosen_song;
+END $$;
+
+GRANT EXECUTE ON FUNCTION select_next_song(text, uuid, uuid)
+  TO anon, authenticated, service_role;
+
+-- peek_next_song: identical to migration 029 except it loads selected_decades
+-- and applies the SAME decade predicate to the `eligible` CTE.
+CREATE OR REPLACE FUNCTION peek_next_song(
+  p_game_code      text,
+  p_manager_token  uuid
+)
+RETURNS TABLE(
+  song_id     uuid,
+  youtube_id  text,
+  start_time  integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_expected_token uuid;
+  v_game_ended_at  timestamptz;
+  v_genres         uuid[];
+  v_decades        integer[];
+  v_chosen_song    uuid;
+BEGIN
+  SELECT ag.manager_token, ag.ended_at, ag.selected_genres, ag.selected_decades
+    INTO v_expected_token, v_game_ended_at, v_genres, v_decades
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_game_ended_at IS NOT NULL THEN
+    RAISE EXCEPTION 'game_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_expected_token IS NULL
+     OR p_manager_token IS NULL
+     OR v_expected_token <> p_manager_token THEN
+    RAISE EXCEPTION 'manager_token_required' USING ERRCODE = '28000';
+  END IF;
+
+  IF v_genres IS NULL OR cardinality(v_genres) = 0 THEN
+    RAISE EXCEPTION 'no_genres_selected' USING ERRCODE = '22023';
+  END IF;
+
+  WITH played AS (
+    SELECT gr.song_id AS sid
+      FROM game_rounds gr
+     WHERE gr.game_code = p_game_code
+       AND gr.song_id IS NOT NULL
+  ),
+  eligible AS (
+    SELECT sg.genre_id AS gid, sg.song_id AS sid
+      FROM song_genres sg
+      JOIN songs s ON s.id = sg.song_id
+     WHERE sg.genre_id = ANY (v_genres)
+       AND sg.song_id NOT IN (SELECT played.sid FROM played)
+       AND (
+             cardinality(v_decades) = 0
+             OR (s.release_year / 10 * 10) = ANY (v_decades)
+           )
+  ),
+  chosen_genre AS (
+    SELECT eligible.gid
+      FROM eligible
+     GROUP BY eligible.gid
+     ORDER BY random()
+     LIMIT 1
+  )
+  SELECT e.sid INTO v_chosen_song
+    FROM eligible e
+    JOIN chosen_genre cg ON cg.gid = e.gid
+   ORDER BY random()
+   LIMIT 1;
+
+  IF v_chosen_song IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    SELECT s.id,
+           s.youtube_id::text,
+           s.start_time
+      FROM songs s
+     WHERE s.id = v_chosen_song;
+END $$;
+
+GRANT EXECUTE ON FUNCTION peek_next_song(text, uuid)
+  TO anon, authenticated, service_role;
+
+COMMIT;

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -44,12 +44,14 @@ Create a new game. **No auth.** Anyone can host. Rate-limited 10/min/IP.
 **Request body**:
 ```json
 {
-  "selected_genres": ["<genre_uuid>", "..."]
+  "selected_genres": ["<genre_uuid>", "..."],
+  "selected_decades": [1980, 1990]
 }
 ```
 
 Validation:
 - `selected_genres`: at least 1 genre UUID
+- `selected_decades` (optional): array of decade start-years (the 80s = `1980`), each in `[1900, 2100]`. Omitted or empty means no year limit. The song picker (`select_next_song`) serves only songs whose `release_year` falls in one of these decades; see `rpc-functions.md §3c`.
 
 Games run for as many rounds as the host wants and end only when the host calls `POST /games/{code}/end`. There is no per-game round limit.
 
@@ -59,6 +61,7 @@ Games run for as many rounds as the host wants and end only when the host calls 
   "game_code": "ABCDEF",
   "status": "waiting",
   "selected_genres": ["..."],
+  "selected_decades": [1980, 1990],
   "started_at": "2026-05-03T14:23:01.234Z",
   "expires_at": "2026-05-03T18:23:01.234Z",
   "manager_token": "1f1a2b3c-4d5e-6f70-8190-a1b2c3d4e5f6"

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -65,6 +65,7 @@ CREATE TABLE active_games (
   status            text NOT NULL DEFAULT 'waiting'
                      CHECK (status IN ('waiting','playing','ended')),
   selected_genres   uuid[] NOT NULL DEFAULT '{}',
+  selected_decades  integer[] NOT NULL DEFAULT '{}',   -- mig 032; decade start-years
   round_number      integer NOT NULL DEFAULT 0,
   current_song_id   uuid REFERENCES songs(id) ON DELETE SET NULL,
   current_round_id  uuid,                              -- FK added below
@@ -186,6 +187,16 @@ WHERE sg.genre_id = ANY($1)
   )
 ORDER BY random() LIMIT 1;
 ```
+
+### `active_games.selected_decades`
+
+Postgres `integer[]` (migration 032), set once at `POST /games` and empty by
+default. Each element is a **decade start-year** (the 80s = `1980`). When
+non-empty, the song picker (`select_next_song` / `peek_next_song`) only serves
+songs whose `release_year` floored to its decade (`release_year / 10 * 10`) is in
+this array — combined with `selected_genres` as **genre AND decade**. Empty means
+no year limit; a `NULL`-year song matches no specific decade (see
+`songs.release_year`). Mirrors `selected_genres`' storage and lifecycle.
 
 ### `active_games.expires_at`
 

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -331,6 +331,7 @@ Behavior:
 - Token + game-state gate runs first (same shape as `award_attempt`): raises `game_not_found` / `game_ended` / `manager_token_required` before any reads of song / round state.
 - Then `no_genres_selected` (`22023`) if `selected_genres` is empty.
 - Random path: picks an unplayed song from `song_genres` constrained to `selected_genres`. Equal-weight per eligible genre, picked via Postgres `random()` in a CTE. Raises `no_more_songs` (`22023`) when the pool is exhausted. (Historically this logic lived in `backend/app/services/song_picker.py`, removed in the dead-code cleanup.)
+- **Decade filter (migration 032):** when `active_games.selected_decades` is non-empty, the `eligible` CTE additionally requires `(songs.release_year / 10 * 10) = ANY(selected_decades)` — the song's decade must be one the host chose. The empty default imposes no year limit. A `NULL` `release_year` matches no specific decade, so unknown-year songs are excluded when a decade is selected and included when none is. `selected_decades` is optional; only `selected_genres` is required.
 - Manual path: caller supplies `p_song_id`; validates it exists in `songs`, raises `song_not_found` (`P0002`) otherwise. No "already played in this game" check (matches the legacy REST manual-pick semantics — Restart-song flow).
 - Delegates round creation to `start_round`, so the prior round is closed defensively, `round_number` advances, and `active_games.current_round_id` / `current_song_id` are wired up.
 - Returns one row with the new round + the picked song's metadata.
@@ -363,7 +364,7 @@ SET search_path = public;
 
 Behavior:
 - Token + game-state gate runs first, **identical** to `select_next_song`: raises `game_not_found` (`P0002`) / `game_ended` (`P0001`) / `manager_token_required` (`28000`) / `no_genres_selected` (`22023`) before returning any candidate.
-- Runs the **same** unplayed-song random picker as `select_next_song`'s random path (exclude already-played, bucket by selected genre, random genre then random song).
+- Runs the **same** unplayed-song random picker as `select_next_song`'s random path (exclude already-played, bucket by selected genre, random genre then random song) — including the decade filter (migration 032), kept in lockstep so a peeked candidate is never one the eventual commit would reject.
 - **Read-only**: no `start_round`, no `game_rounds` insert, no `active_games` mutation — calling it repeatedly never advances the game.
 - **Pool exhausted → returns zero rows, not an error.** The browser treats "no row" as "nothing to prebuffer"; the real `no_more_songs` still surfaces from the eventual `select_next_song` commit.
 - On the actual "Next round" click the browser commits the peeked song via `select_next_song(..., p_song_id => <peeked id>)` (manual-pick path), so the buffered video and the started round can never disagree.

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -106,12 +106,13 @@ describe("api - public routes", () => {
         game_code: "ABCDEF",
         status: "waiting",
         selected_genres: [],
+        selected_decades: [],
         started_at: "2026-05-05T12:00:00Z",
         expires_at: "2026-05-05T16:00:00Z",
         manager_token: "11111111-1111-1111-1111-111111111111",
       }),
     );
-    const res = await createGame({ selected_genres: ["g1"] });
+    const res = await createGame({ selected_genres: ["g1"], selected_decades: [] });
     expect(res.manager_token).toBe("11111111-1111-1111-1111-111111111111");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -143,7 +143,10 @@ export function joinTeam(gameCode: string, name: string): Promise<Team> {
   return request("POST", `/games/${gameCode}/teams`, { body: { name } });
 }
 
-export function createGame(body: { selected_genres: string[] }): Promise<CreateGameResponse> {
+export function createGame(body: {
+  selected_genres: string[];
+  selected_decades: number[];
+}): Promise<CreateGameResponse> {
   return request("POST", "/games", { body });
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface ActiveGame {
   game_code: string;
   status: GameStatus;
   selected_genres: string[];
+  selected_decades: number[];
   round_number: number;
   current_song_id: string | null;
   current_round_id: string | null;
@@ -110,6 +111,7 @@ export interface CreateGameResponse {
   game_code: string;
   status: GameStatus;
   selected_genres: string[];
+  selected_decades: number[];
   started_at: string;
   expires_at: string;
   manager_token: string;

--- a/frontend/src/pages/ManagerCreateGamePage.module.css
+++ b/frontend/src/pages/ManagerCreateGamePage.module.css
@@ -39,6 +39,14 @@
   gap: 0.6rem;
 }
 
+/* Decade chips reuse the .genre / .genreSelected look in a tighter grid; the
+   labels are short ("80s") so they pack into narrow columns. */
+.decades {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+  gap: 0.6rem;
+}
+
 .genre {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/ManagerCreateGamePage.test.tsx
+++ b/frontend/src/pages/ManagerCreateGamePage.test.tsx
@@ -67,6 +67,7 @@ describe("ManagerCreateGamePage", () => {
       game_code: "ZZZZZZ",
       status: "waiting",
       selected_genres: ["g1"],
+      selected_decades: [],
       started_at: "2026-05-05T12:00:00Z",
       expires_at: "2026-05-05T16:00:00Z",
       manager_token: "abc-token-123",
@@ -78,8 +79,39 @@ describe("ManagerCreateGamePage", () => {
     await waitFor(() => expect(screen.getByText("game console")).toBeInTheDocument());
     expect(createGame).toHaveBeenCalledWith({
       selected_genres: ["g1"],
+      selected_decades: [],
     });
     expect(getManagerToken("ZZZZZZ")).toBe("abc-token-123");
+  });
+
+  it("sends selected decades in the create payload; a decade alone needs a genre", async () => {
+    vi.mocked(listGenres).mockResolvedValueOnce([{ id: "g1", name: "Rock", slug: "rock" }]);
+    vi.mocked(createGame).mockResolvedValueOnce({
+      game_code: "ZZZZZZ",
+      status: "waiting",
+      selected_genres: ["g1"],
+      selected_decades: [1980],
+      started_at: "2026-05-05T12:00:00Z",
+      expires_at: "2026-05-05T16:00:00Z",
+      manager_token: "abc-token-123",
+    });
+    renderPage();
+    await waitFor(() => screen.getByText("Rock"));
+    const submit = screen.getByRole("button", { name: /create game/i });
+
+    // Decades are optional: picking one without a genre keeps submit disabled.
+    fireEvent.click(screen.getByLabelText(/80s/i));
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/rock/i));
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(createGame).toHaveBeenCalled());
+    expect(createGame).toHaveBeenCalledWith({
+      selected_genres: ["g1"],
+      selected_decades: [1980],
+    });
   });
 
   it("shows the error message when createGame fails", async () => {

--- a/frontend/src/pages/ManagerCreateGamePage.tsx
+++ b/frontend/src/pages/ManagerCreateGamePage.tsx
@@ -124,10 +124,7 @@ export function ManagerCreateGamePage() {
             {DECADES.map((d) => {
               const isSel = selectedDecades.has(d);
               return (
-                <label
-                  key={d}
-                  className={`${styles.genre} ${isSel ? styles.genreSelected : ""}`}
-                >
+                <label key={d} className={`${styles.genre} ${isSel ? styles.genreSelected : ""}`}>
                   <input type="checkbox" checked={isSel} onChange={() => toggleDecade(d)} />
                   {decadeLabel(d)}
                 </label>

--- a/frontend/src/pages/ManagerCreateGamePage.tsx
+++ b/frontend/src/pages/ManagerCreateGamePage.tsx
@@ -7,12 +7,21 @@ import { setManagerToken } from "../lib/managerToken";
 import type { Genre } from "../lib/types";
 import styles from "./ManagerCreateGamePage.module.css";
 
+// Decades are stored as their start year (the 80s = 1980); the picker floors a
+// song's release_year to its decade and matches by membership (migration 032).
+const DECADES = [1960, 1970, 1980, 1990, 2000, 2010, 2020] as const;
+
+function decadeLabel(decade: number): string {
+  return `${String(decade).slice(2)}s`; // 1980 -> "80s", 2000 -> "00s"
+}
+
 export function ManagerCreateGamePage() {
   const { toast } = useToast();
   const navigate = useNavigate();
 
   const [genres, setGenres] = useState<Genre[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectedDecades, setSelectedDecades] = useState<Set<number>>(new Set());
   const [busy, setBusy] = useState(false);
   const [genresLoading, setGenresLoading] = useState(true);
 
@@ -43,6 +52,15 @@ export function ManagerCreateGamePage() {
     });
   }
 
+  function toggleDecade(decade: number) {
+    setSelectedDecades((prev) => {
+      const next = new Set(prev);
+      if (next.has(decade)) next.delete(decade);
+      else next.add(decade);
+      return next;
+    });
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (selected.size === 0 || busy) return;
@@ -50,6 +68,7 @@ export function ManagerCreateGamePage() {
     try {
       const game = await createGame({
         selected_genres: Array.from(selected),
+        selected_decades: Array.from(selectedDecades),
       });
       setManagerToken(game.game_code, game.manager_token);
       toast(`Game ${game.game_code} created`, { variant: "success" });
@@ -95,6 +114,26 @@ export function ManagerCreateGamePage() {
               })}
             </div>
           )}
+        </div>
+
+        <div className={styles.field}>
+          <span className={styles.label}>
+            Release decade <span className="muted">(optional — any year if none picked)</span>
+          </span>
+          <div className={styles.decades}>
+            {DECADES.map((d) => {
+              const isSel = selectedDecades.has(d);
+              return (
+                <label
+                  key={d}
+                  className={`${styles.genre} ${isSel ? styles.genreSelected : ""}`}
+                >
+                  <input type="checkbox" checked={isSel} onChange={() => toggleDecade(d)} />
+                  {decadeLabel(d)}
+                </label>
+              );
+            })}
+          </div>
         </div>
 
         <div className={styles.actions}>

--- a/frontend/src/test/supabaseMock.ts
+++ b/frontend/src/test/supabaseMock.ts
@@ -192,6 +192,7 @@ export function makeActiveGame(overrides: Partial<ActiveGame> = {}): ActiveGame 
     game_code: "ABCDEF",
     status: "waiting",
     selected_genres: [],
+    selected_decades: [],
     round_number: 0,
     current_song_id: null,
     current_round_id: null,

--- a/tests/backend/test_games_create.py
+++ b/tests/backend/test_games_create.py
@@ -38,6 +38,39 @@ async def test_validation_requires_genres(client) -> None:
     assert resp.json()["error"] == "validation_error"
 
 
+async def test_selected_decades_persisted(client, db) -> None:
+    genres = await fetch_genre_ids(db, slugs=["rock"])
+    resp = await client.post(
+        "/games",
+        json={"selected_genres": [str(genres[0])], "selected_decades": [1980, 1990]},
+    )
+    assert resp.status_code == 201, resp.text
+    assert sorted(resp.json()["selected_decades"]) == [1980, 1990]
+    # It actually lands on the active_games row the picker reads.
+    row = await db.fetchrow(
+        "SELECT selected_decades FROM active_games WHERE game_code = $1",
+        resp.json()["game_code"],
+    )
+    assert sorted(row["selected_decades"]) == [1980, 1990]
+
+
+async def test_selected_decades_default_empty(client, db) -> None:
+    genres = await fetch_genre_ids(db, slugs=["rock"])
+    resp = await client.post("/games", json={"selected_genres": [str(genres[0])]})
+    assert resp.status_code == 201
+    assert resp.json()["selected_decades"] == []
+
+
+async def test_selected_decades_out_of_range_rejected(client, db) -> None:
+    genres = await fetch_genre_ids(db, slugs=["rock"])
+    resp = await client.post(
+        "/games",
+        json={"selected_genres": [str(genres[0])], "selected_decades": [1850]},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "validation_error"
+
+
 async def test_unique_token_per_game(client, db) -> None:
     """Each game's manager_token is independently random."""
     genres = await fetch_genre_ids(db, slugs=["rock"])

--- a/tests/db/_helpers.py
+++ b/tests/db/_helpers.py
@@ -86,22 +86,27 @@ async def create_test_song(
     title: str = "Test Title",
     artist: str = "Test Artist",
     youtube_id: str = "abcdefghijk",
+    release_year: int | None = None,
 ) -> uuid.UUID:
     """Insert one row into songs and return its id.
 
     Soundtrack-ness is derived from genre membership (migration 028), so there
     is no is_soundtrack column to set here; attach the song to the 'soundtracks'
     or 'israeli-soundtracks' genre via song_genres to make it a soundtrack.
+
+    release_year (migration 031) is NULL unless given; pass it to exercise the
+    decade filter (migration 032).
     """
     row = await conn.fetchrow(
         """
-        INSERT INTO songs (title, artist, youtube_id)
-        VALUES ($1, $2, $3)
+        INSERT INTO songs (title, artist, youtube_id, release_year)
+        VALUES ($1, $2, $3, $4)
         RETURNING id
         """,
         title,
         artist,
         youtube_id,
+        release_year,
     )
     assert row is not None
     return row["id"]

--- a/tests/db/test_peek_next_song.py
+++ b/tests/db/test_peek_next_song.py
@@ -212,6 +212,56 @@ async def test_peek_returns_no_rows_when_pool_exhausted(db: asyncpg.Connection) 
 
 
 # ---------------------------------------------------------------------------
+# Decade filter (migration 032) -- must match select_next_song in lockstep
+# ---------------------------------------------------------------------------
+
+
+async def _set_selected_decades(
+    conn: asyncpg.Connection, game_code: str, decades: list[int]
+) -> None:
+    await conn.execute(
+        "UPDATE active_games SET selected_decades = $1::int[] WHERE game_code = $2",
+        decades,
+        game_code,
+    )
+
+
+@pytest.mark.asyncio
+async def test_peek_respects_decade_filter(db: asyncpg.Connection) -> None:
+    """Peek must only ever surface a song inside the selected decade, so the
+    browser never prebuffers a song the commit (select_next_song) would reject."""
+    game_code = await create_test_game(db, status="waiting")
+    token = await fetch_manager_token(db, game_code)
+    rock = (await _genre_ids(db, "rock"))[0]
+    await _set_selected_genres(db, game_code, [rock])
+    s80 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1985)
+    s90 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1995)
+    await _attach_song_to_genre(db, s80, rock)
+    await _attach_song_to_genre(db, s90, rock)
+    await _set_selected_decades(db, game_code, [1980])
+
+    for _ in range(5):
+        rows = await _peek(db, game_code, token)
+        assert len(rows) == 1
+        assert rows[0]["song_id"] == s80
+
+
+@pytest.mark.asyncio
+async def test_peek_returns_no_rows_when_decade_excludes_all(db: asyncpg.Connection) -> None:
+    """When no in-genre song is in the selected decade, peek returns zero rows
+    (not an error) -- the host just doesn't prebuffer."""
+    game_code = await create_test_game(db, status="waiting")
+    token = await fetch_manager_token(db, game_code)
+    rock = (await _genre_ids(db, "rock"))[0]
+    await _set_selected_genres(db, game_code, [rock])
+    s90 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1995)
+    await _attach_song_to_genre(db, s90, rock)
+    await _set_selected_decades(db, game_code, [1980])
+
+    assert await _peek(db, game_code, token) == []
+
+
+# ---------------------------------------------------------------------------
 # Token validation
 # ---------------------------------------------------------------------------
 

--- a/tests/db/test_select_next_song.py
+++ b/tests/db/test_select_next_song.py
@@ -181,6 +181,98 @@ async def test_random_pick_advances_round_number(db: asyncpg.Connection) -> None
 
 
 # ---------------------------------------------------------------------------
+# Decade filter (migration 032)
+# ---------------------------------------------------------------------------
+
+
+async def _set_selected_decades(
+    conn: asyncpg.Connection, game_code: str, decades: list[int]
+) -> None:
+    await conn.execute(
+        "UPDATE active_games SET selected_decades = $1::int[] WHERE game_code = $2",
+        decades,
+        game_code,
+    )
+
+
+async def _seed_rock_game(conn: asyncpg.Connection) -> tuple[str, uuid.UUID, uuid.UUID]:
+    """active_games (waiting) + 'rock' selected, returns (game_code, token, rock_id)."""
+    game_code = await create_test_game(conn, status="waiting")
+    token = await fetch_manager_token(conn, game_code)
+    rock = (await _genre_ids(conn, "rock"))[0]
+    await _set_selected_genres(conn, game_code, [rock])
+    return game_code, token, rock
+
+
+@pytest.mark.asyncio
+async def test_decade_filter_limits_pick_to_selected_decade(db: asyncpg.Connection) -> None:
+    """With the 80s selected, only the 1985 song is eligible; the 1995 song is
+    never served, so the pool exhausts after the one in-decade song."""
+    game_code, token, rock = await _seed_rock_game(db)
+    s80 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1985)
+    s90 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1995)
+    await _attach_song_to_genre(db, s80, rock)
+    await _attach_song_to_genre(db, s90, rock)
+    await _set_selected_decades(db, game_code, [1980])
+
+    assert (await _call(db, game_code, token))[0]["song_id"] == s80
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert "no_more_songs" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_multiple_decades_are_unioned(db: asyncpg.Connection) -> None:
+    """Selecting the 80s and 00s serves songs from either, but never the 90s."""
+    game_code, token, rock = await _seed_rock_game(db)
+    s80 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1988)
+    s90 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1994)
+    s00 = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=2003)
+    for sid in (s80, s90, s00):
+        await _attach_song_to_genre(db, sid, rock)
+    await _set_selected_decades(db, game_code, [1980, 2000])
+
+    picked = {
+        (await _call(db, game_code, token))[0]["song_id"],
+        (await _call(db, game_code, token))[0]["song_id"],
+    }
+    assert picked == {s80, s00}
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert "no_more_songs" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_null_year_song_excluded_when_decade_selected(db: asyncpg.Connection) -> None:
+    """A song with an unknown (NULL) release_year matches no specific decade."""
+    game_code, token, rock = await _seed_rock_game(db)
+    s_null = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=None)
+    await _attach_song_to_genre(db, s_null, rock)
+    await _set_selected_decades(db, game_code, [1990])
+
+    with pytest.raises(asyncpg.PostgresError) as exc:
+        await _call(db, game_code, token)
+    assert "no_more_songs" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_empty_decades_includes_all_years(db: asyncpg.Connection) -> None:
+    """The default empty selected_decades imposes no year limit -- a known-year
+    song and a NULL-year song are both eligible."""
+    game_code, token, rock = await _seed_rock_game(db)
+    s_known = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=1975)
+    s_null = await create_test_song(db, youtube_id=uuid.uuid4().hex[:11], release_year=None)
+    await _attach_song_to_genre(db, s_known, rock)
+    await _attach_song_to_genre(db, s_null, rock)
+
+    picked = {
+        (await _call(db, game_code, token))[0]["song_id"],
+        (await _call(db, game_code, token))[0]["song_id"],
+    }
+    assert picked == {s_known, s_null}
+
+
+# ---------------------------------------------------------------------------
 # is_soundtrack derivation (migration 028)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lets a host **filter the song pool by decade** when creating a game, combined with genres as **genre AND decade**. Builds on #125 (the `release_year` column) — **stacked on `feature/song-release-year`**, so merge #125 first; GitHub will retarget this to `main` automatically.

- **Migration 032**: adds `active_games.selected_decades integer[]` (decade start-years, the 80s = `1980`), and `CREATE OR REPLACE`s both pickers — `select_next_song` (mig 028) and `peek_next_song` (mig 029) — to read it and filter the shared `eligible` CTE by `(release_year / 10 * 10) = ANY(selected_decades)`. Return shapes unchanged (no `DROP`); the two stay in lockstep so prebuffer never cues a song the commit rejects.
- **Semantics**: empty decades = no year limit (today's behavior, purely additive). A `NULL`-year song matches no specific decade, so it's excluded when a decade is chosen and included when none is. Genres stay required; decades stay optional.
- **Backend**: `POST /games` accepts + persists + returns `selected_decades` (`models/games.py`, `routers/games.py`), validated to `[1900, 2100]`.
- **Frontend**: a "Release decade" card of 60s–20s toggle chips on the create page (reusing the genre-chip styling), plumbed through `lib/types.ts` / `lib/api.ts`.

## Test plan

- **DB** (`tests/db`, testcontainers): new decade tests on both pickers — decade limits the pick, multiple decades union (90s correctly excluded), NULL-year excluded when a decade is set, empty decades include all years; peek stays in lockstep and returns zero rows (not an error) when the decade excludes everything. 29 picker tests pass; CI reruns migrations for idempotency.
- **Backend**: `selected_decades` round-trips through `POST /games`; out-of-range → 400; default empty. All game-endpoint + manager-token tests pass (61 green). `ruff check .` and `mypy app` clean.
- **Frontend**: decade chips toggle and are sent in the create payload; a decade alone does not enable submit (genre still required); existing "disabled until a genre is picked" test still green. `eslint`, `tsc`, 324 vitest tests, and `build` all pass.

Docs updated in-PR: `rpc-functions.md` §§3c/3d, `api-contracts.md` §2.2, `data-model.md`. CHANGELOG entry added.

> Note: the filter is only meaningful once `release_year` is backfilled in prod (the operational step after #125 merges), since decade-filtered games exclude unknown-year songs.