### PR TITLE
Add Year column to the admin song catalog list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
-- 2026-06-18: Admin song catalog now has an optional **Release year** field (song form + CSV import), recording each song's original release year. This is the groundwork for an upcoming "filter by decade" option when hosting a game; for covers the year is the song's original release, not the cover's.
+- 2026-06-18: Admin song catalog now has an optional **Release year** field (song form + CSV import) and shows each song's year as a **Year column** in the catalog list. This is the groundwork for an upcoming "filter by decade" option when hosting a game.
 - 2026-06-18: Added **195 new songs** to the catalog (804 → 999), curated and human-reviewed across every genre — heaviest on Israeli music: israeli-rock-pop (+47), mizrahit (+35), israeli-pop (+21), israeli-rap-hip-hop (+7), plus current 2024–2026 Hebrew hits, and refreshes to pop (+27), electronic (+22), rock (+15), hip-hop (+15), soundtracks (+5), israeli-cover (+2).
 - 2026-05-24: How-to-play page now opens with a hero illustration showing the three-screen setup at a glance — host's phone with the manager console, TV/laptop running the display + scoreboard + join QR, and team phones with the BUZZ button — so first-time visitors can see how everything connects before reading the steps.
 - 2026-05-24: New **Israeli Soundtracks** genre, separated from the existing soundtrack bucket so hosts can run a Hebrew-only (or English-only) soundtrack round. Six Israeli titles (גבעת חלפון אינה עונה, גברת פלפלת, נילס הולגרסון, הדרדסים, איזה עולם, הפיג'מות) moved into the new genre.

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -153,18 +153,20 @@ describe("AdminSongsPage: list", () => {
     expect(screen.getByText("aaaaaaaaaaa")).toBeInTheDocument();
   });
 
-  it("renders start_time and the song's explicit genre tags", async () => {
+  it("renders start_time, release year, and the song's explicit genre tags", async () => {
     renderPage();
     await signIn();
-    // Alpha: start_time=0 renders as em-dash; one genre tag (Rock).
+    // Alpha: start_time=0 renders as em-dash; release_year 1980; one genre tag (Rock).
     const alphaRow = screen.getByText("Alpha").closest("tr") as HTMLElement;
     expect(within(alphaRow).getByText("—")).toBeInTheDocument();
+    expect(within(alphaRow).getByText("1980")).toBeInTheDocument();
     expect(within(alphaRow).getByText("Rock")).toBeInTheDocument();
     expect(within(alphaRow).queryByText("Soundtracks")).not.toBeInTheDocument();
-    // Bravo: start_time=12 renders as "12s"; the row reflects only the
-    // genre tags actually stored on the song (Pop + Soundtracks).
+    // Bravo: start_time=12 renders as "12s"; no release_year → em-dash; the row
+    // reflects only the genre tags actually stored on the song (Pop + Soundtracks).
     const bravoRow = screen.getByText("Bravo").closest("tr") as HTMLElement;
     expect(within(bravoRow).getByText("12s")).toBeInTheDocument();
+    expect(within(bravoRow).getByText("—")).toBeInTheDocument();
     expect(within(bravoRow).getByText("Pop")).toBeInTheDocument();
     expect(within(bravoRow).getByText("Soundtracks")).toBeInTheDocument();
   });

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -377,6 +377,7 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
               <th>Artist</th>
               <th>YouTube ID</th>
               <th>Start</th>
+              <th>Year</th>
               <th>Genres</th>
               <th aria-label="Actions" />
             </tr>
@@ -398,6 +399,9 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
                     <Skeleton width="40px" height={16} />
                   </td>
                   <td>
+                    <Skeleton width="40px" height={16} />
+                  </td>
+                  <td>
                     <Skeleton width="120px" height={16} />
                   </td>
                   <td />
@@ -405,7 +409,7 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
               ))
             ) : songs.length === 0 ? (
               <tr>
-                <td colSpan={6} className={styles.empty}>
+                <td colSpan={7} className={styles.empty}>
                   No songs found.
                 </td>
               </tr>
@@ -419,6 +423,9 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
                     <td className={styles.ytId}>{s.youtube_id}</td>
                     <td className={styles.startTime}>
                       {s.start_time > 0 ? `${s.start_time}s` : "—"}
+                    </td>
+                    <td className={styles.startTime}>
+                      {s.release_year != null ? s.release_year : "—"}
                     </td>
                     <td>
                       <div className={styles.genreList}>


### PR DESCRIPTION
## Summary
- Adds a **Year** column to the admin Song catalog table, showing each song's `release_year` (em-dash when unset). The song form and CSV import already supported the field; this surfaces it in the list view too.

## Test plan
- Extended the list-render test to assert the year value (1980) and the em-dash fallback for a yearless song.
- Local: `npm run lint`, `npm run typecheck`, `npm run test:run` (323 tests pass), `npm run build` — all green.