### PR TITLE
Stop genre/decade chips from shaking on the create-game page

### DIFF
--- a/frontend/src/pages/ManagerCreateGamePage.module.css
+++ b/frontend/src/pages/ManagerCreateGamePage.module.css
@@ -77,8 +77,15 @@
   box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
 }
 
+/* Pin the checkbox to a fixed box. A native checkbox with width:auto renders a
+   different intrinsic size when checked vs unchecked (~16px unchecked, ~13px
+   checked), and because the checkbox and label text share a flex row, that size
+   change shoved the text sideways on every toggle — the "text shaking" on check.
+   Explicit width/height + flex:none keep the footprint constant in both states. */
 .genre input {
-  width: auto;
+  flex: none;
+  width: 1rem;
+  height: 1rem;
   padding: 0;
   margin: 0;
   accent-color: var(--color-primary);

--- a/frontend/src/pages/ManagerCreateGamePage.module.css
+++ b/frontend/src/pages/ManagerCreateGamePage.module.css
@@ -66,23 +66,15 @@
     box-shadow 200ms ease;
 }
 
-/* Hover feedback uses box-shadow, not transform. A translateY lift moves the
-   chip's hit-area out from under a pointer resting on its bottom edge, which
-   toggles :hover on/off and makes the chip visibly shake. Shadow gives the
-   same "raised" feel without ever moving the element. */
+/* These chips never move. Feedback is colour/border/shadow only — no transform
+   in any state (:hover or :active). A translateY on :hover moved the chip out
+   from under the pointer and made it shake; a translateY on :active nudged it
+   down on every click, which also reads as a shake. Static is the requirement. */
 .genre:hover {
   border-color: var(--color-primary);
   background: var(--color-primary-soft);
   color: var(--color-primary-strong);
   box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
-}
-
-/* Tactile press feedback, matching the global .btn convention. Safe on :active
-   (not :hover): the state is held for the whole mousedown regardless of pointer
-   position, so the 1px nudge can't toggle itself on and off the way the old
-   hover lift did. */
-.genre:active {
-  transform: translateY(1px);
 }
 
 .genre input {


### PR DESCRIPTION
## Summary

Fixes the "shaking" on the genre and decade buttons on `/manager/create`. Two causes, both addressed:

1. **The real one — label text jumped on check.** The native checkbox (`.genre input`) had `width: auto`, so it rendered at a different intrinsic size when checked vs unchecked (~16px → ~13px). Because the checkbox and the label text share a flex row, that ~3px size change shoved the text sideways every time you toggled a box — the visible "text shaking." Fixed by pinning the checkbox to a fixed `1rem × 1rem` box with `flex: none`, so its footprint is identical in both states and the text never moves.

2. **A secondary movement** from an earlier iteration: a `transform: translateY(1px)` press effect on `:active` nudged the whole chip down on each click. Removed — the chips now have no `transform` in any state.

Net: the chips and their text are completely static; feedback is colour/border/shadow only.

## Verification

Tested at runtime on a local dev build, toggling a decade chip repeatedly:
- Checkbox stays a constant 16×16 in both checked and unchecked states.
- The label text's position has 0px range (horizontal and vertical) across multiple checks.
- No element on the page moves on hover, press, or check.

## Test plan

- `/manager/create`: check/uncheck any genre or decade button — the label text stays perfectly still; only the box fill and selected highlight change.
- `npx prettier --check` passes on the edited CSS.