### PR TITLE
Fix admin Songs list capping at 1000 songs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-06-24: The admin **Songs** list no longer caps at 1000. Once the catalog passed 1000 songs the page fetched only the first 1000 (by title) over the REST API and reported "1000" as the total; it now pages in the database (`range`) and reads the exact count, so the true total shows and every song is reachable. (Gameplay was never affected — song selection runs inside Postgres, not over the REST API.)
 - 2026-06-19: Genre and decade buttons on the **Host a game** page no longer show a stray blue focus ring around the checkbox after you tap one (the ring still appears for keyboard navigation, for accessibility).
 - 2026-06-19: Genre and decade buttons on the **Host a game** page no longer jitter/"shake" when you click one. The hover effect lifted the button by 1px, which could move it out from under the cursor at its bottom edge and rapidly toggle the hover on and off; the lift is now a shadow that doesn't move the button.
 - 2026-06-16: The host's **−3** point toast now appears whenever a Wrong buzz actually deducts points. Previously, once any answer had been scored in a round, the host's −3 toast was hidden for every later wrong buzz that round — even though the team still lost 3 points (the free-guess waiver only applies to the single buzz immediately after a correct answer). Scores were always correct on the scoreboard and team devices; only the host's pop-up feedback was missing.
@@ -33,6 +34,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Added
 
+- 2026-06-24: Added **26 new songs** to the catalog (999 → 1025) — the most-watched YouTube tracks from eight famous artists, human-reviewed: The Beatles, Pink Floyd (rock), Beyoncé, Rihanna, Lady Gaga (pop), and רביד פלוטניק, טונה (Israeli rap/hip-hop) plus שלמה ארצי (Israeli rock-pop).
 - 2026-06-23: Hosts can now **export the songs that played** from the end-of-game screen — open them all as a single YouTube playlist link, or download a self-contained HTML file that lists every song in play order with a clickable YouTube link.
 - 2026-06-18: Hosts can now **filter songs by decade** when creating a game — tap any of the 60s–20s buttons (multi-select) alongside genres, and only songs from those decades play (genres **and** decades). Leaving decades unpicked keeps every year, exactly as before. For covers, the decade follows the song's original release year, not the cover's.
 - 2026-06-18: Admin song catalog now has an optional **Release year** field (song form + CSV import) and shows each song's year as a **Year column** in the catalog list. This is the groundwork for an upcoming "filter by decade" option when hosting a game.

--- a/backend/app/routers/admin_songs.py
+++ b/backend/app/routers/admin_songs.py
@@ -73,6 +73,8 @@ def _list_blocking(
     search: str | None,
     genre: str | None,
 ) -> dict[str, Any]:
+    start = max(0, (page - 1) * per_page)
+    end = start + per_page - 1  # range() is inclusive on both ends
     if genre:
         gen_resp = client.table("genres").select("id").eq("slug", genre).execute()
         gen_rows = gen_resp.data or []
@@ -83,22 +85,26 @@ def _list_blocking(
         ids = [r["song_id"] for r in (sg_resp.data or [])]
         if not ids:
             return {"items": [], "page": page, "per_page": per_page, "total": 0}
-        query = client.table("songs").select(SONG_COLUMNS).in_("id", ids)
+        query = client.table("songs").select(SONG_COLUMNS, count="exact").in_("id", ids)
     else:
-        query = client.table("songs").select(SONG_COLUMNS)
+        query = client.table("songs").select(SONG_COLUMNS, count="exact")
 
     if search:
         query = query.ilike("title", f"%{search}%")
 
-    resp = query.order("title").execute()
+    # Page in the database with range() and read the true total from the
+    # exact-count header. The previous approach fetched every matching row and
+    # counted/sliced in Python, which silently capped both the returned list
+    # and `total` at PostgREST's default 1000-row ceiling once the catalog
+    # passed 1000 songs (gameplay was unaffected — song selection runs inside
+    # Postgres, not over PostgREST).
+    resp = query.order("title").range(start, end).execute()
     rows = [dict(r) for r in (resp.data or [])]
-    total = len(rows)
-    start = max(0, (page - 1) * per_page)
-    end = start + per_page
-    page_rows = rows[start:end]
-    _attach_genres(client, page_rows)
+    # count="exact" always populates resp.count (the Content-Range total).
+    total = resp.count
+    _attach_genres(client, rows)
     return {
-        "items": page_rows,
+        "items": rows,
         "page": page,
         "per_page": per_page,
         "total": total,

--- a/tests/backend/_fake_supabase.py
+++ b/tests/backend/_fake_supabase.py
@@ -97,6 +97,7 @@ def _map_pg_exc(exc: Exception) -> FakeAPIError:
 @dataclass
 class FakeResponse:
     data: list[dict[str, Any]] | dict[str, Any] | Any
+    count: int | None = None
 
 
 class _Query:
@@ -112,12 +113,15 @@ class _Query:
         self._limit: int | None = None
         self._order: str | None = None
         self._on_conflict: str | None = None
+        self._count: str | None = None
+        self._range: tuple[int, int] | None = None
 
     # builder methods -----------------------------------------------------
 
-    def select(self, cols: str = "*") -> "_Query":
+    def select(self, cols: str = "*", count: str | None = None) -> "_Query":
         self._op = "select"
         self._cols = cols
+        self._count = count
         return self
 
     def insert(self, values: dict[str, Any] | list[dict[str, Any]]) -> "_Query":
@@ -159,6 +163,11 @@ class _Query:
 
     def limit(self, n: int) -> "_Query":
         self._limit = n
+        return self
+
+    def range(self, start: int, end: int) -> "_Query":
+        # PostgREST range() is inclusive on both ends, 0-based.
+        self._range = (start, end)
         return self
 
     def order(self, col: str) -> "_Query":
@@ -207,7 +216,9 @@ class FakeSupabaseClient:
         conn = self._connect()
         try:
             if q._op == "select":
-                return FakeResponse(self._do_select(conn, q))
+                rows = self._do_select(conn, q)
+                count = self._do_count(conn, q) if q._count else None
+                return FakeResponse(rows, count)
             if q._op == "insert":
                 return FakeResponse(self._do_insert(conn, q))
             if q._op == "update":
@@ -247,13 +258,27 @@ class FakeSupabaseClient:
         sql = f"SELECT {q._cols} FROM {q._table}{where}"
         if q._order:
             sql += f" ORDER BY {q._order}"
-        if q._limit is not None:
+        if q._range is not None:
+            rstart, rend = q._range
+            limit = max(0, rend - rstart + 1)
+            sql += f" LIMIT {limit} OFFSET {rstart}"
+        elif q._limit is not None:
             sql += f" LIMIT {q._limit}"
         try:
             rows = self._runner.run(conn.fetch(sql, *params))
         except asyncpg.PostgresError as exc:
             raise _map_pg_exc(exc) from exc
         return [_record_to_dict(r) for r in rows]
+
+    def _do_count(self, conn: Any, q: _Query) -> int:
+        """count="exact": total matching rows, ignoring range/limit."""
+        where, params = self._build_where(q)
+        sql = f"SELECT count(*) AS n FROM {q._table}{where}"
+        try:
+            rec = self._runner.run(conn.fetchrow(sql, *params))
+        except asyncpg.PostgresError as exc:
+            raise _map_pg_exc(exc) from exc
+        return int(rec["n"]) if rec else 0
 
     def _normalize_values(
         self, values: dict[str, Any] | list[dict[str, Any]] | None

--- a/tests/backend/test_admin_songs_crud.py
+++ b/tests/backend/test_admin_songs_crud.py
@@ -157,6 +157,24 @@ async def test_list_pagination_and_search(admin_client, db) -> None:
     assert "BBB Second" in titles
 
 
+async def test_list_pages_through_full_total(admin_client, db) -> None:
+    # Five sortable titles; page through 2 at a time. Guards the regression
+    # where the list fetched every row and counted/sliced in Python — which
+    # capped both the window and `total` at PostgREST's 1000-row ceiling.
+    for n in ("1", "2", "3", "4", "5"):
+        await insert_song(db, title=f"Zpage {n}", genre_slugs=["rock"])
+    pages = [
+        (await admin_client.get(f"/admin/songs?search=Zpage&per_page=2&page={p}")).json()
+        for p in (1, 2, 3)
+    ]
+    # `total` is the exact count of all matches, not just the returned page.
+    assert all(pg["total"] == 5 for pg in pages)
+    assert [len(pg["items"]) for pg in pages] == [2, 2, 1]
+    # Server-side range() returns the correct, ordered, non-overlapping window.
+    titles = [s["title"] for pg in pages for s in pg["items"]]
+    assert titles == [f"Zpage {n}" for n in ("1", "2", "3", "4", "5")]
+
+
 async def test_list_genre_filter(admin_client, db) -> None:
     await insert_song(db, title="RockSong", genre_slugs=["rock"])
     await insert_song(db, title="PopSong", genre_slugs=["pop"])
@@ -169,6 +187,15 @@ async def test_list_genre_filter(admin_client, db) -> None:
 
 async def test_list_genre_filter_unknown_returns_empty(admin_client) -> None:
     resp = await admin_client.get("/admin/songs?genre=nonexistent_slug")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+    assert resp.json()["total"] == 0
+
+
+async def test_list_genre_real_but_empty_pool_returns_empty(admin_client, db) -> None:
+    # `jazz` is a real seeded genre, but no song is tagged with it here, so its
+    # song pool is empty (distinct from the unknown-slug case above).
+    resp = await admin_client.get("/admin/songs?genre=jazz")
     assert resp.status_code == 200
     assert resp.json()["items"] == []
     assert resp.json()["total"] == 0


### PR DESCRIPTION
## Summary

The admin **Songs** list page silently capped at 1000 songs. `_list_blocking` fetched *every* matching row over PostgREST, then counted and sliced in Python:

```python
resp  = query.order("title").execute()   # PostgREST default max-rows = 1000
total = len(rows)                          # counts the (capped) array
```

Once the catalog passed 1000 songs (it's now 1025), PostgREST returned only the first 1000 by title, so the page showed `total = 1000` and the songs sorting after the 1000th title were unreachable in the admin UI.

The fix pages **in the database** with `range()` and reads the true total from the `count="exact"` header:

```python
query = client.table("songs").select(SONG_COLUMNS, count="exact")...
resp  = query.order("title").range(start, end).execute()
total = resp.count
```

**Gameplay was never affected** — song selection runs inside Postgres (`select_next_song` / `peek_next_song`), which has no REST row cap. This was purely the admin management list.

The test fake (`_fake_supabase.py`) gained `.range()`, the `count` kwarg on `.select()`, and `FakeResponse.count` to mirror the real client surface.

## Test plan

- `ruff check .`, `ruff format --check .`, `mypy app` — all clean.
- New `test_list_pages_through_full_total`: inserts 5 songs, pages 2 at a time, asserts `total == 5` on every page (not capped to `per_page`) and that `range()` returns the correct ordered, non-overlapping windows.
- New `test_list_genre_real_but_empty_pool_returns_empty`: covers the real-genre/empty-pool branch.
- Existing list/pagination/search/genre tests still pass.
- `_list_blocking` is fully covered; module coverage 91.8% locally (gate is 90%).