### PR TITLE
Simplify how-to-play steps into a two-phase Set up / Play flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-06-24: The **How to Play** page's "Steps to run a game" section is now a scannable two-phase flow instead of seven dense paragraphs — a **Set up** group (one-time) and a **Play** group (every round), each step trimmed to a single line, with the "audio plays from the host's phone" caveat pulled out into its own callout. Faster to grok at a glance for first-time hosts.
 - 2026-06-19: The decade filter on the **Host a game** page now labels the 2000s and 2010s in full ("2000s", "2010s") instead of the ambiguous "00s"/"10s"; the 60s–90s keep their familiar shorthand.
 - 2026-06-19: The decade filter on the **Host a game** page is now a row of toggle pills instead of checkbox cards — a compact, optional refinement that lays out cleanly at every screen size (one row on desktop, a balanced 4 + 3 on phones, with no stray chip stranded on its own line).
 - 2026-06-16: **Songs now start the instant the host taps, on every round including the first.** The host console quietly prebuffers the upcoming song in a hidden second YouTube player — during the current round for later rounds, and on the lobby/"waiting" screen for the very first song — so **Start game** / **Next round** resume an already-loaded video instead of waiting ~1 second for YouTube to buffer from scratch.

--- a/frontend/src/pages/HowToPlayPage.module.css
+++ b/frontend/src/pages/HowToPlayPage.module.css
@@ -176,69 +176,133 @@
   font-weight: 500;
 }
 
-/* Steps section */
+/* Steps section — two-phase flow */
 
-.stepsList {
+.phaseLabel {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  max-width: 720px;
+  margin: 0 auto 1rem;
+}
+
+.flow + .phaseLabel {
+  margin-top: 2.25rem;
+}
+
+.phaseName {
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.phaseLabelPlay .phaseName {
+  color: #059669;
+}
+
+.phaseMeta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-mute);
+}
+
+.flow {
   list-style: none;
+  max-width: 720px;
   margin: 0 auto;
   padding: 0;
-  max-width: 760px;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  counter-reset: step;
 }
 
-.stepRow {
+.flowRow {
   display: flex;
-  align-items: flex-start;
-  gap: 1.25rem;
-  padding: 1.4rem 1.5rem;
-  background: #ffffff;
-  border-radius: 18px;
-  border: 2px solid rgba(59, 130, 246, 0.08);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+  align-items: center;
+  gap: 1.1rem;
+  padding: 0.55rem 0;
+  position: relative;
 }
 
-.stepNumber {
+.flowNum {
   flex-shrink: 0;
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.35rem;
   font-weight: 800;
-  box-shadow: 0 4px 14px rgba(59, 130, 246, 0.28);
+  font-size: 1.1rem;
+  color: #fff;
+  z-index: 1;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
 }
 
-.stepBody {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+.flowPlay .flowNum {
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+/* vertical connector threaded through the number circles */
+.flowRow:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  left: 19px;
+  top: 50%;
+  bottom: -0.55rem;
+  width: 2px;
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.flowPlay .flowRow:not(:last-child)::before {
+  background: rgba(16, 185, 129, 0.25);
+}
+
+.flowText {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.45;
   min-width: 0;
 }
 
-.stepTitle {
-  font-size: 1.2rem;
+.flowName {
   font-weight: 700;
   color: #0f172a;
-  margin: 0;
-  letter-spacing: -0.01em;
 }
 
-.stepText {
-  font-size: 1rem;
+.flowDesc {
   color: var(--color-text-dim);
-  margin: 0;
-  line-height: 1.55;
   font-weight: 500;
 }
 
-.stepText strong {
+.flowDesc strong {
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.audioNote {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  max-width: 720px;
+  margin: 1.75rem auto 0;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: rgba(6, 182, 212, 0.08);
+  border: 1px solid rgba(6, 182, 212, 0.25);
+  color: var(--color-text-dim);
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.audioIcon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.audioNote strong {
   color: #0f172a;
   font-weight: 700;
 }
@@ -392,14 +456,19 @@
     padding: 0.85rem 1rem;
     font-size: 1rem;
   }
-  .stepRow {
-    gap: 1rem;
-    padding: 1.2rem 1.1rem;
+  .flowRow {
+    gap: 0.9rem;
   }
-  .stepNumber {
-    width: 42px;
-    height: 42px;
-    font-size: 1.2rem;
+  .flowNum {
+    width: 36px;
+    height: 36px;
+    font-size: 1rem;
+  }
+  .flowRow:not(:last-child)::before {
+    left: 17px;
+  }
+  .flowText {
+    font-size: 1rem;
   }
   .faqRow {
     padding: 1rem 1.1rem;

--- a/frontend/src/pages/HowToPlayPage.test.tsx
+++ b/frontend/src/pages/HowToPlayPage.test.tsx
@@ -17,28 +17,47 @@ describe("HowToPlayPage", () => {
     expect(screen.getByRole("heading", { name: /rules & faq/i })).toBeInTheDocument();
   });
 
+  it("groups the steps into a Set up phase and a Play phase", () => {
+    render(
+      <MemoryRouter>
+        <HowToPlayPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/^set up$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^play$/i)).toBeInTheDocument();
+  });
+
   it("renders all seven steps in order with visible numbers", () => {
     render(
       <MemoryRouter>
         <HowToPlayPage />
       </MemoryRouter>,
     );
-    const stepHeadings = [
+    const stepTitles = [
       /host a game/i,
-      /pick genres and create/i,
-      /open the display screen/i,
-      /teams join from their phones/i,
-      /start the game/i,
-      /buzz and judge/i,
-      /award a bonus/i,
+      /^pick genres$/i,
+      /open the display/i,
+      /^teams join$/i,
+      /^start$/i,
+      /buzz & judge/i,
+      /^bonus$/i,
     ];
-    for (const name of stepHeadings) {
-      expect(screen.getByRole("heading", { level: 3, name })).toBeInTheDocument();
+    for (const name of stepTitles) {
+      expect(screen.getByText(name)).toBeInTheDocument();
     }
-    // Numbers 1–7 are rendered as text in the step circles.
+    // Numbers 1–7 are rendered as text in the step circles (1–4 setup, 5–7 play).
     for (let i = 1; i <= 7; i++) {
       expect(screen.getByText(String(i))).toBeInTheDocument();
     }
+  });
+
+  it("calls out that audio plays from the host's phone", () => {
+    render(
+      <MemoryRouter>
+        <HowToPlayPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/audio plays from the host's phone/i)).toBeInTheDocument();
   });
 
   it("surfaces the key gameplay rules in the FAQ", () => {

--- a/frontend/src/pages/HowToPlayPage.tsx
+++ b/frontend/src/pages/HowToPlayPage.tsx
@@ -3,69 +3,49 @@ import { Logo } from "../components/Logo";
 import { DisplayIcon, ManagerIcon, TeamIcon } from "../components/RoleIcons";
 import styles from "./HowToPlayPage.module.css";
 
-const STEPS: ReadonlyArray<{ title: string; body: React.ReactNode }> = [
+type Step = { title: string; body: React.ReactNode };
+
+const SETUP_STEPS: ReadonlyArray<Step> = [
   {
     title: "Host a game",
+    body: "from the home page",
+  },
+  {
+    title: "Pick genres",
     body: (
       <>
-        From the home page, tap <strong>Host a game</strong>.
+        choose your music; get a 6-letter <strong>code</strong>
       </>
     ),
   },
   {
-    title: "Pick genres and create",
+    title: "Open the Display",
+    body: "put the join QR + scoreboard on a TV everyone sees",
+  },
+  {
+    title: "Teams join",
+    body: "each team scans the QR on one phone",
+  },
+];
+
+const PLAY_STEPS: ReadonlyArray<Step> = [
+  {
+    title: "Start",
     body: (
       <>
-        Choose the music genres you want. Sound Clash hands you a 6-letter{" "}
-        <strong>game code</strong>.
+        tap <strong>Start game</strong> — the first song plays
       </>
     ),
   },
   {
-    title: "Open the Display screen",
-    body: (
-      <>
-        On a TV or laptop everyone in the room can see, open <strong>Display screen</strong> and
-        enter the code. It shows the join QR and the live scoreboard. (The song itself plays from
-        the host's device — see the next step.)
-      </>
-    ),
+    title: "Buzz & judge",
+    body: "first team to buzz answers out loud; the host scores it",
   },
   {
-    title: "Teams join from their phones",
+    title: "Bonus",
     body: (
       <>
-        Each team needs one phone. Scan the QR on the display, or open soundclash.org and tap{" "}
-        <strong>Join a game</strong>.
-      </>
-    ),
-  },
-  {
-    title: "Start the game",
-    body: (
-      <>
-        Once the teams are in, the host taps <strong>Start game</strong> and the first song plays.
-        The music comes out of the <strong>host's own device</strong>, so connect it to the room's
-        speakers (or keep the host near everyone).
-      </>
-    ),
-  },
-  {
-    title: "Buzz and judge",
-    body: (
-      <>
-        The first team to buzz answers out loud. The host taps <strong>Correct Song</strong> (+10),{" "}
-        <strong>Correct Artist</strong> (+5), or <strong>Wrong</strong> (−3). The team that just
-        answered keeps the floor to also try the other half.
-      </>
-    ),
-  },
-  {
-    title: "Award a bonus (optional)",
-    body: (
-      <>
-        At any moment the host can tap <strong>+4 Bonus</strong> and pick a team — for great
-        singing, dancing, or a fun trivia detail. It's independent of rounds.
+        optional: give <strong>+4</strong> to any team, anytime
       </>
     ),
   },
@@ -104,6 +84,32 @@ const FAQ: ReadonlyArray<{ term: string; def: React.ReactNode }> = [
   },
 ];
 
+function StepFlow({
+  steps,
+  startAt,
+  variant,
+}: {
+  steps: ReadonlyArray<Step>;
+  startAt: number;
+  variant: "setup" | "play";
+}) {
+  return (
+    <ol className={`${styles.flow} ${variant === "play" ? styles.flowPlay : ""}`}>
+      {steps.map((step, idx) => (
+        <li key={step.title} className={styles.flowRow}>
+          <span className={styles.flowNum} aria-hidden="true">
+            {startAt + idx}
+          </span>
+          <p className={styles.flowText}>
+            <strong className={styles.flowName}>{step.title}</strong>{" "}
+            <span className={styles.flowDesc}>{step.body}</span>
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 export function HowToPlayPage() {
   return (
     <div className={styles.page}>
@@ -119,8 +125,7 @@ export function HowToPlayPage() {
             <section className={styles.intro}>
               <h1 className={styles.title}>How to Play</h1>
               <p className={styles.subtitle}>
-                Roles, the seven steps to run a game, scoring, and the rules that come up most
-                often.
+                Roles, the quick setup, scoring, and the rules that come up most often.
               </p>
               <img
                 src="/how-to-play-hero.png"
@@ -168,19 +173,28 @@ export function HowToPlayPage() {
 
             <section className={styles.section}>
               <h2 className={styles.sectionTitle}>Steps to run a game</h2>
-              <ol className={styles.stepsList}>
-                {STEPS.map((step, idx) => (
-                  <li key={step.title} className={styles.stepRow}>
-                    <span className={styles.stepNumber} aria-hidden="true">
-                      {idx + 1}
-                    </span>
-                    <div className={styles.stepBody}>
-                      <h3 className={styles.stepTitle}>{step.title}</h3>
-                      <p className={styles.stepText}>{step.body}</p>
-                    </div>
-                  </li>
-                ))}
-              </ol>
+
+              <div className={styles.phaseLabel}>
+                <span className={styles.phaseName}>Set up</span>
+                <span className={styles.phaseMeta}>once, about 2 min</span>
+              </div>
+              <StepFlow steps={SETUP_STEPS} startAt={1} variant="setup" />
+
+              <div className={`${styles.phaseLabel} ${styles.phaseLabelPlay}`}>
+                <span className={styles.phaseName}>Play</span>
+                <span className={styles.phaseMeta}>every round</span>
+              </div>
+              <StepFlow steps={PLAY_STEPS} startAt={5} variant="play" />
+
+              <p className={styles.audioNote}>
+                <span className={styles.audioIcon} aria-hidden="true">
+                  🔊
+                </span>
+                <span>
+                  <strong>Audio plays from the host's phone</strong> — connect it to the room's
+                  speakers, or keep the host near everyone.
+                </span>
+              </p>
             </section>
 
             <section className={styles.section}>

--- a/frontend/src/pages/HowToPlayPage.tsx
+++ b/frontend/src/pages/HowToPlayPage.tsx
@@ -14,7 +14,7 @@ const SETUP_STEPS: ReadonlyArray<Step> = [
     title: "Pick genres",
     body: (
       <>
-        choose your music; get a 6-letter <strong>code</strong>
+        choose your music and get a 6-letter <strong>code</strong>
       </>
     ),
   },
@@ -33,19 +33,19 @@ const PLAY_STEPS: ReadonlyArray<Step> = [
     title: "Start",
     body: (
       <>
-        tap <strong>Start game</strong> — the first song plays
+        tap <strong>Start game</strong> and the first song plays
       </>
     ),
   },
   {
     title: "Buzz & judge",
-    body: "first team to buzz answers out loud; the host scores it",
+    body: "first team to buzz answers out loud, then the host scores it",
   },
   {
     title: "Bonus",
     body: (
       <>
-        optional: give <strong>+4</strong> to any team, anytime
+        give <strong>+4</strong> to any team, anytime (optional)
       </>
     ),
   },
@@ -56,8 +56,8 @@ const FAQ: ReadonlyArray<{ term: string; def: React.ReactNode }> = [
     term: "Free guess after a correct answer",
     def: (
       <>
-        Got the title (+10)? You can take a shot at the artist with no risk — the very next wrong
-        buzz in the round costs <strong>0</strong> instead of −3.
+        Got the title (+10)? You can take a shot at the artist with no risk. The very next wrong
+        buzz in the round costs <strong>0</strong> instead of 3 points.
       </>
     ),
   },
@@ -73,7 +73,7 @@ const FAQ: ReadonlyArray<{ term: string; def: React.ReactNode }> = [
     term: "Bonus anytime",
     def: (
       <>
-        The host can grant <strong>+4</strong> to any team at any moment — for trivia, singing,
+        The host can grant <strong>+4</strong> to any team at any moment, for trivia, singing,
         dancing, or sportsmanship.
       </>
     ),
@@ -191,7 +191,7 @@ export function HowToPlayPage() {
                   🔊
                 </span>
                 <span>
-                  <strong>Audio plays from the host's phone</strong> — connect it to the room's
+                  <strong>Audio plays from the host's phone.</strong> Connect it to the room's
                   speakers, or keep the host near everyone.
                 </span>
               </p>
@@ -214,7 +214,7 @@ export function HowToPlayPage() {
                 </li>
                 <li className={styles.scoringRow}>
                   <span className={`${styles.chip} ${styles.chipBonus}`}>+4</span>
-                  <span>Manager bonus — the host can award +4 to any team at any time.</span>
+                  <span>Manager bonus. The host can award +4 to any team at any time.</span>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
## Summary

Reworks the **Steps to run a game** section of the How to Play page so first-time hosts can grok the setup at a glance instead of reading seven dense paragraphs.

- Each step is trimmed to a single scannable line.
- The seven steps are grouped into two labelled phases — **Set up** (one-time, ~2 min) and **Play** (every round) — rendered as a connected vertical flow with phase-coloured number circles (blue for setup, green for play).
- The one caveat that actually trips people up — audio plays from the host's phone — is pulled out of the step prose into its own callout.
- Scoring detail that used to be crammed into the "Buzz and judge" step is dropped from the step (it's already covered in full by the dedicated **Scoring** section right below).

No change to Roles, Scoring, or Rules & FAQ sections.

## Test plan

- `npm run typecheck`, `npm run lint`, `npm run test:coverage`, `npm run build` all pass locally.
- Updated `HowToPlayPage.test.tsx`: asserts the two phase labels, all seven step titles, the 1–7 number badges, and the new audio callout.
- Manually verified the production build at desktop (1100px) and mobile (390px) widths — the flow stacks cleanly on phones.