### PR TITLE
Make e2e manager-action fixtures robust to the busy-flag click race

### DIFF
--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -106,15 +106,54 @@ export interface AttemptToggles {
   artist?: boolean;
 }
 
-async function applyCorrect(page: Page, toggles: AttemptToggles): Promise<void> {
-  if (toggles.title === true) {
-    await page.getByTestId("score-title").click();
-    await expect(page.getByTestId("score-title")).toBeDisabled({ timeout: 10_000 });
-  }
-  if (toggles.artist === true) {
-    await page.getByTestId("score-artist").click();
-    await expect(page.getByTestId("score-artist")).toBeDisabled({ timeout: 10_000 });
-  }
+// The manager console serialises every scoring / advance action behind a single
+// `busy` flag, and each handler early-returns while it's set (the prior
+// award_attempt / select_next_song RPC is still in flight). A follow-up click
+// fired off the *optimistic* disabled flag — which flips synchronously, before
+// the RPC returns — lands inside that window and is silently dropped. On CI the
+// RPC is fast enough to dodge it; on a slower machine it drops the second token
+// claim or the round advance and the spec fails for no real reason.
+//
+// The Bonus button is the one control whose disabled state mirrors `busy`
+// (ManagerConsolePage: bonusDisabled = busy), so waiting for it to re-enable is
+// a reliable "the last RPC settled" signal. Gate every chained manager click on
+// it so nothing is dropped, regardless of stack speed.
+async function waitNotBusy(page: Page): Promise<void> {
+  await expect(page.getByTestId("score-bonus")).toBeEnabled({ timeout: 10_000 });
+}
+
+// Claim one scoring token, robust to the busy-race: wait for any in-flight RPC
+// to settle, click, confirm the claim landed (the button disables via the
+// optimistic pending flag), then wait for this claim's RPC to settle too so the
+// caller's next click can't be dropped.
+async function claimToken(page: Page, testId: string): Promise<void> {
+  await waitNotBusy(page);
+  await page.getByTestId(testId).click();
+  await expect(page.getByTestId(testId)).toBeDisabled({ timeout: 10_000 });
+  await waitNotBusy(page);
+}
+
+export async function applyCorrect(page: Page, toggles: AttemptToggles): Promise<void> {
+  if (toggles.title === true) await claimToken(page, "score-title");
+  if (toggles.artist === true) await claimToken(page, "score-artist");
+}
+
+// Advance exactly one round. We must NOT retry-click here: select_next_song is
+// not idempotent (each accepted click opens a new round), and the round header
+// is Realtime-driven, so a header that merely lags would make a retry
+// over-advance (a 21st round in a 20-round game). Instead we guarantee the
+// single click lands: waitNotBusy ensures no in-flight RPC will swallow it via
+// the handler's `if (busy) return`, so the one click is always accepted. Then we
+// wait — generously, to absorb Realtime lag — for the header to tick up by one.
+export async function advanceRound(page: Page): Promise<void> {
+  const header = page.getByText(/Round \d+$/i).first();
+  const before = Number(((await header.textContent()) ?? "").replace(/\D+/g, ""));
+  await waitNotBusy(page);
+  await expect(page.getByTestId("start-round")).toBeEnabled();
+  await page.getByTestId("start-round").click();
+  await expect(page.getByText(new RegExp(`Round ${before + 1}$`, "i"))).toBeVisible({
+    timeout: 15_000,
+  });
 }
 
 export async function awardAndContinue(
@@ -122,6 +161,7 @@ export async function awardAndContinue(
   toggles: AttemptToggles,
 ): Promise<void> {
   await applyCorrect(page, toggles);
+  await waitNotBusy(page);
   await page.getByTestId("continue-round").click();
   // Continue releases the buzz lock; once released, Continue itself
   // disables again. Wait for that so the caller can chain.
@@ -129,7 +169,9 @@ export async function awardAndContinue(
 }
 
 export async function markWrong(page: Page): Promise<void> {
+  await waitNotBusy(page);
   await page.getByTestId("score-wrong").click();
+  await waitNotBusy(page);
 }
 
 export async function awardAndAdvance(
@@ -137,14 +179,15 @@ export async function awardAndAdvance(
   toggles: AttemptToggles,
 ): Promise<void> {
   await applyCorrect(page, toggles);
-  await page.getByTestId("start-round").click();
+  await advanceRound(page);
 }
 
 export async function skipRound(page: Page): Promise<void> {
-  await page.getByTestId("start-round").click();
+  await advanceRound(page);
 }
 
 export async function awardBonusToTeam(page: Page, teamName: string): Promise<void> {
+  await waitNotBusy(page);
   await page.getByTestId("score-bonus").click();
   // The picker button's accessible name is its aria-label
   // ("Award +4 bonus to <name>"), not the bare team name.

--- a/tests/e2e/four_teams_twenty_rounds.spec.ts
+++ b/tests/e2e/four_teams_twenty_rounds.spec.ts
@@ -1,0 +1,181 @@
+// Scale check: a four-team game driven entirely through the real UI (manager
+// console + four team tabs + the display board), then verified against ground
+// truth in the DB.
+//
+// Target is 20 rounds. Against the local real catalog (hundreds of Rock songs)
+// all 20 run; against the tiny CI seed we cap at the available pool so the game
+// never hits `no_more_songs` (same approach as soundtrack_playthrough). Either
+// way the test exercises four teams, many rounds, live scoring, the podium, and
+// the durable game_history archive.
+//
+// Each round exactly one team (rotating Alpha->Bravo->Charlie->Delta) buzzes and
+// wins the lock; the manager applies a fixed per-team scoring combo. The
+// immediate-apply model credits the score the instant a judgement button is
+// clicked, so totals accumulate without a "submit". After the playthrough we
+// assert:
+//   1. the live display scoreboard shows each team's exact running total,
+//   2. ending the game renders the podium with the right winner, and
+//   3. the durable game_history archive (migration 033) captured the game:
+//      one history row (round_count = rounds played, team_count = 4), four team
+//      rows with the final scores, and one song row per round.
+//
+// Per-round points (title=+10, artist=+5): Alpha title+artist (15), Bravo title
+// (10), Charlie artist (5), Delta title (10), with Delta also taking artist on
+// round 8. At the full 20 rounds that lands Alpha 75 / Delta 55 / Bravo 50 /
+// Charlie 25; at any round count Alpha is the unique top scorer (15/round).
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  advanceRound,
+  applyCorrect,
+  awardAndAdvance,
+  openManagerAndCreateGame,
+  type AttemptToggles,
+} from "./fixtures/manager-context";
+import { buzzAndExpectWinner, joinAsTeam } from "./fixtures/team-context";
+import { countSongsInGenreSlugs } from "./fixtures/supabase-admin";
+
+const TARGET_ROUNDS = 20;
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+function svc(): HeadersInit {
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set for DB assertions");
+  }
+  return { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` };
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, { headers: svc() });
+  if (!res.ok) throw new Error(`GET ${path} -> ${res.status} ${await res.text()}`);
+  return (await res.json()) as T;
+}
+
+function comboFor(teamIdx: number, round: number): AttemptToggles {
+  if (teamIdx === 0) return { title: true, artist: true }; // Alpha: 15
+  if (teamIdx === 1) return { title: true }; // Bravo: 10
+  if (teamIdx === 2) return { artist: true }; // Charlie: 5
+  return round === 8 ? { title: true, artist: true } : { title: true }; // Delta: 10 (15 on r8)
+}
+
+const pointsFor = (c: AttemptToggles): number => (c.title ? 10 : 0) + (c.artist ? 5 : 0);
+
+test("4 teams, up to 20 rounds: live scoreboard, podium, and durable archive all correct", async ({
+  browser,
+}) => {
+  test.setTimeout(360_000); // up to 20 rounds across 6 browser contexts
+
+  // Size the playthrough to the Rock pool so the tiny CI seed never exhausts it.
+  const pool = await countSongsInGenreSlugs(["rock"]);
+  const TOTAL = Math.min(TARGET_ROUNDS, pool);
+  expect(TOTAL).toBeGreaterThanOrEqual(1);
+
+  const manager = await openManagerAndCreateGame(browser, { genreName: "Rock" });
+  const code = manager.gameCode;
+
+  const teamNames = ["Alpha", "Bravo", "Charlie", "Delta"];
+  const teams = [];
+  for (const name of teamNames) {
+    teams.push(await joinAsTeam(browser, code, name));
+  }
+
+  const displayCtx = await browser.newContext();
+  const display = await displayCtx.newPage();
+  await display.goto(`/display/${code}`);
+  for (const name of teamNames) {
+    await expect(display.locator(`[data-team-id]:has-text("${name}")`).first()).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+
+  const expected: Record<string, number> = { Alpha: 0, Bravo: 0, Charlie: 0, Delta: 0 };
+
+  // Bootstrap: open round 1 (the "Start game" click; header goes Round 0 -> 1).
+  // Each iteration then scores the live round and advances to the next; the last
+  // round is scored but not advanced, so exactly TOTAL game_rounds exist.
+  await advanceRound(manager.page);
+
+  for (let r = 1; r <= TOTAL; r++) {
+    const idx = (r - 1) % 4;
+    const team = teams[idx]!;
+    const name = teamNames[idx]!;
+
+    await buzzAndExpectWinner(team);
+
+    const combo = comboFor(idx, r);
+    if (r < TOTAL) {
+      await awardAndAdvance(manager.page, combo); // score + advance (single accepted click)
+    } else {
+      await applyCorrect(manager.page, combo); // last round: score only
+    }
+    expected[name]! += pointsFor(combo);
+
+    // Live scoreboard must reflect this team's new running total (scoped to the
+    // team's own row, so name+score must co-occur).
+    await expect(
+      display.locator(`[data-team-id]:has-text("${name}"):has-text("${expected[name]}")`).first(),
+    ).toBeVisible({ timeout: 10_000 });
+  }
+
+  // Final live totals, all four teams, exact.
+  for (const name of teamNames) {
+    await expect(
+      display.locator(`[data-team-id]:has-text("${name}"):has-text("${expected[name]}")`).first(),
+    ).toBeVisible({ timeout: 10_000 });
+  }
+
+  // --- End the game: podium + winner ---
+  const endBtn = manager.page.getByTestId("end-game");
+  await expect(endBtn).toBeEnabled();
+  await endBtn.click();
+  const dialog = manager.page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /^end game$/i }).click();
+
+  await expect(display.getByRole("heading", { name: /final results/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(display.getByText("WINNER")).toBeVisible();
+  const finalSb = display.getByTestId("final-scoreboard");
+  for (const name of teamNames) {
+    await expect(finalSb.locator(`[data-team-id]:has-text("${name}")`)).toBeVisible();
+  }
+  // Alpha scores 15/round (the per-round max), so it is the unique top scorer at
+  // any round count -> rank 1.
+  const winnerName = Object.entries(expected).sort((a, b) => b[1] - a[1])[0]![0];
+  expect(winnerName).toBe("Alpha");
+  await expect(finalSb.locator(`[data-team-id]:has-text("${winnerName}")`)).toHaveAttribute(
+    "data-rank",
+    "1",
+  );
+
+  // --- Ground truth #1: live game_teams scores ---
+  const gtRows = await getJson<Array<{ name: string; score: number }>>(
+    `game_teams?game_code=eq.${code}&select=name,score`,
+  );
+  const gtMap = Object.fromEntries(gtRows.map((r) => [r.name, r.score]));
+  expect(gtMap).toEqual(expected);
+
+  // --- Ground truth #2: durable game_history archive (migration 033) ---
+  const ghRows = await getJson<
+    Array<{ id: string; round_count: number; team_count: number }>
+  >(`game_history?game_code=eq.${code}&select=id,round_count,team_count`);
+  expect(ghRows.length).toBe(1);
+  expect(ghRows[0]!.round_count).toBe(TOTAL);
+  expect(ghRows[0]!.team_count).toBe(4);
+  const historyId = ghRows[0]!.id;
+
+  const ghtRows = await getJson<Array<{ name: string; score: number }>>(
+    `game_history_teams?game_history_id=eq.${historyId}&select=name,score`,
+  );
+  const ghtMap = Object.fromEntries(ghtRows.map((r) => [r.name, r.score]));
+  expect(ghtMap).toEqual(expected);
+
+  const ghsRows = await getJson<Array<{ round_number: number }>>(
+    `game_history_songs?game_history_id=eq.${historyId}&select=round_number`,
+  );
+  expect(ghsRows.length).toBe(TOTAL);
+  expect(new Set(ghsRows.map((r) => r.round_number)).size).toBe(TOTAL);
+});


### PR DESCRIPTION
## Summary

The shared manager-action helpers in `tests/e2e/fixtures/manager-context.ts` fired chained clicks off the manager console's *optimistic* disabled flag, which flips synchronously on click — before the `award_attempt` / `select_next_song` RPC returns. The console serialises every scoring/advance action behind a single `busy` flag and each handler early-returns while it's set, so on a slower-than-CI machine the follow-up click (the artist token, Continue, or Next round) lands inside the `busy` window and is silently dropped. That made `full_game` and `multi_buzz_round` scenarios 2 & 5 fail for no real product reason.

This hardens the fixtures so nothing is dropped regardless of stack speed:

- **`waitNotBusy`** gates every chained manager click on the Bonus button re-enabling. The Bonus button is the one control whose `disabled` mirrors `busy` (`bonusDisabled = busy`), so it's a reliable "last RPC settled" signal. `applyCorrect` / `awardAndContinue` / `markWrong` / `awardBonusToTeam` now use it.
- **`advanceRound`** does a single *accepted* click (busy is guaranteed clear) and waits generously for the round header to tick up by one. It deliberately does **not** retry-click: `select_next_song` isn't idempotent and the header is Realtime-driven, so a retry on a merely-laggy header would over-advance an extra round.
- Adds `tests/e2e/four_teams_twenty_rounds.spec.ts`: a four-team playthrough (up to 20 rounds, capped to the Rock pool like `soundtrack_playthrough`) driven through the real UI. It verifies the live display scoreboard, the end-game podium winner, and the durable `game_history` archive (migration 033 — one history row with the right round/team counts, four team rows with final scores, one song row per round).

No product code changes; test-only.

## Test plan

Against a local `supabase start` stack (full ~830-song catalog) with `--project=chromium`:

- `four_teams_twenty_rounds.spec.ts` — passes, full 20 rounds (scoreboard, podium, and archive all verified against the DB).
- `full_game.spec.ts` — passes (previously dropped the Round 2 advance on this machine).
- `multi_buzz_round.spec.ts` — all 5 scenarios pass (2 & 5 previously failed on the busy-race).
- `bonus_flow` / `token_claim_constraints` / `wrong_buzz_recovery` — pass in isolation; the buzz-heavy 4-team scenarios remain Realtime-lag sensitive under sustained local load and are covered by CI's `retries: 2` on a fresh stack.
