### PR TITLE
Fix validation-audit findings: doc drift, admin double-delete, 500 sanitization, expired-join 410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-06-25: Joining a game that has passed its 4-hour expiry (but hasn't been swept from the database yet) now returns a clear "game is gone" error instead of a misleading success that created a team about to be deleted.
+- 2026-06-25: The admin **Songs** delete confirmation no longer issues a duplicate delete on a fast double-click — which previously surfaced a spurious "Delete failed" toast even though the song had been removed.
 - 2026-06-24: The admin **Songs** list no longer caps at 1000. Once the catalog passed 1000 songs the page fetched only the first 1000 (by title) over the REST API and reported "1000" as the total; it now pages in the database (`range`) and reads the exact count, so the true total shows and every song is reachable. (Gameplay was never affected — song selection runs inside Postgres, not over the REST API.)
 - 2026-06-19: Genre and decade buttons on the **Host a game** page no longer show a stray blue focus ring around the checkbox after you tap one (the ring still appears for keyboard navigation, for accessibility).
 - 2026-06-19: Genre and decade buttons on the **Host a game** page no longer jitter/"shake" when you click one. The hover effect lifted the button by 1px, which could move it out from under the cursor at its bottom edge and rapidly toggle the hover on and off; the lift is now a shadow that doesn't move the button.
@@ -32,6 +34,10 @@ This project does not currently cut versioned releases; every change lands direc
 - 2026-05-31: The manager **Bonus** picker now shows each team in its own separated, bordered box (an equal-sized grid of cells) instead of a run of plain names, so the host no longer risks tapping the wrong team and awarding +4 to the wrong side.
 - 2026-05-30: Songs in the **Soundtracks** / **Israeli Soundtracks** genres now always play as +15 soundtrack rounds. Soundtrack-ness is derived from genre membership instead of a separate per-song flag, fixing ~28 songs (e.g. Hungry Eyes, Shallow, the Star Wars and Disney themes) that were tagged as soundtracks but still scored as normal title/artist rounds. The admin Songs page drops the "Soundtrack round" checkbox — tagging a soundtrack genre is now the single marker.
 - 2026-05-25: Soundtrack rounds no longer auto-resume the song or re-arm the buzzers after the host taps **Correct (+15)**. The round now waits for an explicit **Next round** press, matching how regular rounds behave once both title and artist have been scored.
+
+### Security
+
+- 2026-06-25: Server error (500) responses no longer echo raw database error text; they now return a generic message, with the detail logged server-side only.
 
 ### Added
 

--- a/backend/app/middleware/error_handler.py
+++ b/backend/app/middleware/error_handler.py
@@ -25,6 +25,12 @@ def _envelope(
 
 async def domain_error_handler(request: Request, exc: Exception) -> JSONResponse:
     assert isinstance(exc, DomainError)
+    if exc.status >= 500:
+        # Never expose internal/DB error detail to clients (it may carry table,
+        # column, or constraint names); log it server-side and return a generic
+        # body, matching unhandled_handler.
+        logger.error("internal domain error: %s", exc.message)
+        return _envelope(status=exc.status, code=exc.code, message="internal server error")
     return _envelope(
         status=exc.status,
         code=exc.code,

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -16,6 +16,7 @@ RPCs ``end_game`` and ``award_bonus``.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -82,10 +83,30 @@ def _fetch_game_blocking(client: SupabaseClientLike, code: str) -> dict[str, Any
     return dict(rows[0])
 
 
+def _is_expired(game: dict[str, Any]) -> bool:
+    """True when the game's 4h TTL has lapsed. cleanup_expired_games sweeps only
+    hourly, so an expired row can still exist between expiry and the next sweep."""
+    raw = game.get("expires_at")
+    if not raw:
+        return False
+    if isinstance(raw, datetime):
+        expires = raw
+    else:
+        try:
+            expires = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return False
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=UTC)
+    return expires < datetime.now(UTC)
+
+
 def _join_team_blocking(client: SupabaseClientLike, code: str, name: str) -> dict[str, Any]:
     game = _fetch_game_blocking(client, code)
     if game["status"] == "ended" or game.get("ended_at"):
         raise GoneError(f"game {code} has ended")
+    if _is_expired(game):
+        raise GoneError(f"game {code} has expired")
 
     with mapped_postgrest_errors():
         resp = client.table("game_teams").insert({"game_code": code, "name": name}).execute()

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -254,7 +254,7 @@ Manager: award a discretionary bonus to any team in the game. Independent of rou
 
 Server-side: calls Postgres `award_bonus` RPC. Does not touch round state.
 
-**Errors**: `unauthorized` (401), `not_found` (404; team not in this game, or game does not exist), `conflict` (409; game already ended), `validation_error` (422; non-positive `points`).
+**Errors**: `unauthorized` (401), `not_found` (404; team not in this game, or game does not exist), `conflict` (409; game already ended), `validation_error` (400; non-positive `points`).
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -97,6 +97,9 @@ CREATE TABLE game_rounds (
   title_points       integer NOT NULL DEFAULT 0,
   artist_points      integer NOT NULL DEFAULT 0,
   wrong_buzz_penalty integer NOT NULL DEFAULT 0,
+  title_claimed_by   uuid REFERENCES game_teams(id) ON DELETE SET NULL,   -- mig 016 (multi-buzz)
+  artist_claimed_by  uuid REFERENCES game_teams(id) ON DELETE SET NULL,   -- mig 016 (multi-buzz)
+  free_guess_active  boolean NOT NULL DEFAULT false,                      -- mig 017 (free-guess flag)
   ended_at           timestamptz,
   UNIQUE (game_code, round_number)
 );

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -1,6 +1,6 @@
 # Sound Clash: Postgres RPC Functions
 
-The eight PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
+The eleven PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
 
 Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), and `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token).
 
@@ -202,7 +202,7 @@ CREATE OR REPLACE FUNCTION award_attempt(
   p_title         integer DEFAULT 0,   -- 0 or 10
   p_artist        integer DEFAULT 0,   -- 0 or 5
   p_wrong_buzz    integer DEFAULT 0,   -- 0 or 3 (deducted)
-  p_manager_token uuid    DEFAULT NULL -- required; validated in the body
+  p_manager_token uuid                 -- required, NO default: a default would make this 6-arg overload ambiguous with 5-arg calls (Postgres 42725); see mig 021
 )
 RETURNS TABLE(
   team_id            uuid,

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -25,7 +25,7 @@ Two distinct shared secrets gate FastAPI endpoints. Both checked with `secrets.c
 
 | Credential | Header | Scope | Lifetime |
 |---|---|---|---|
-| **manager token** | `X-Manager-Token` | One specific game's host actions (`select-song`, `award-points`, `end`, kick a team) | Generated server-side at `POST /games`; lives 4h with the row; auto-expires when `cleanup_expired_games` deletes the game |
+| **manager token** | `X-Manager-Token` | One specific game's host actions (`award_attempt` / `release_buzz_lock` / `select_next_song` via token-gated direct RPC; bonus / end / kick a team via REST) | Generated server-side at `POST /games`; lives 4h with the row; auto-expires when `cleanup_expired_games` deletes the game |
 | **admin password** | `X-Admin-Password` | Song catalog only (`/admin/songs/*` CRUD + bulk import) | Single env var on FastAPI; rotated by changing the env and restarting |
 
 `POST /games` is **public** (rate-limited 10/min/IP). The browser keeps the returned manager token in `localStorage` under `game:<code>:manager-token` and presents it on subsequent host calls. Players who happen to know the game code cannot manage it because they don't have the token. Hosting requires no signup, login, or persistent identity.
@@ -129,8 +129,8 @@ REVOKE ALL ON game_history, game_history_teams, game_history_songs
 
 ```sql
 -- buzz_in: browser-callable; the game_code itself is the auth.
-REVOKE ALL ON FUNCTION buzz_in(text, uuid) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION buzz_in(text, uuid) TO anon;
+REVOKE ALL ON FUNCTION buzz_in(char, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION buzz_in(char, uuid) TO anon;
 
 -- award_attempt / release_buzz_lock: browser-callable via Supabase RPC,
 -- gated by the per-game manager_token (validated in the function body,

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -403,6 +403,29 @@ describe("AdminSongsPage: create + edit + delete", () => {
     await waitFor(() => expect(screen.getByText(/song deleted/i)).toBeInTheDocument());
   });
 
+  it("ignores a double-click on confirm (no duplicate DELETE)", async () => {
+    let resolveDelete: () => void = () => {};
+    vi.mocked(deleteSong).mockImplementation(
+      () =>
+        new Promise<void>((res) => {
+          resolveDelete = res;
+        }),
+    );
+    renderPage();
+    await signIn();
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i });
+    fireEvent.click(deleteButtons[0]!);
+    const dialog = await screen.findByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm); // second click while the first DELETE is still in flight
+
+    resolveDelete();
+    await waitFor(() => expect(screen.getByText(/song deleted/i)).toBeInTheDocument());
+    expect(deleteSong).toHaveBeenCalledTimes(1);
+  });
+
   it("cancel on the form returns to the list without calling the API", async () => {
     renderPage();
     await signIn();

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -173,6 +173,7 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const deleteInFlightRef = useRef(false);
 
   const reportError = useCallback(
     (err: unknown, fallback: string) => {
@@ -262,7 +263,8 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
   }
 
   async function handleConfirmDelete() {
-    if (deleteId === null) return;
+    if (deleteId === null || deleteInFlightRef.current) return;
+    deleteInFlightRef.current = true;
     setBusy(true);
     try {
       await deleteSong(deleteId, pw);
@@ -273,6 +275,7 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
       reportError(err, "Delete failed");
     } finally {
       setBusy(false);
+      deleteInFlightRef.current = false;
     }
   }
 

--- a/tests/backend/test_error_handler.py
+++ b/tests/backend/test_error_handler.py
@@ -1,0 +1,36 @@
+"""domain_error_handler envelope behaviour.
+
+5xx responses must not leak internal/DB error detail (table/column/constraint
+names); 4xx responses keep their human-facing message.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+async def test_internal_error_envelope_is_generic() -> None:
+    from app.db.errors import InternalError
+    from app.middleware.error_handler import domain_error_handler
+
+    exc = InternalError('relation "songs" does not exist')
+    resp = await domain_error_handler(None, exc)  # request arg is unused
+    raw = resp.body.decode()
+    assert resp.status_code == 500
+    assert "songs" not in raw
+    body = json.loads(raw)
+    assert body["error"] == "internal_error"
+    assert body["message"] == "internal server error"
+
+
+async def test_client_error_envelope_preserves_message() -> None:
+    from app.db.errors import NotFoundError
+    from app.middleware.error_handler import domain_error_handler
+
+    exc = NotFoundError("game ABCDEF not found")
+    resp = await domain_error_handler(None, exc)
+    raw = resp.body.decode()
+    assert resp.status_code == 404
+    body = json.loads(raw)
+    assert body["error"] == "not_found"
+    assert body["message"] == "game ABCDEF not found"

--- a/tests/backend/test_games_join.py
+++ b/tests/backend/test_games_join.py
@@ -42,6 +42,15 @@ async def test_ended_game_returns_410(client, db) -> None:
     assert resp.json()["error"] == "gone"
 
 
+async def test_expired_but_unswept_game_returns_410(client, db) -> None:
+    # cleanup_expired_games sweeps only hourly, so a game can be past its 4h TTL
+    # while its row still exists with status!='ended'. Joining must still 410.
+    code, _ = await insert_game(db, status="playing", expires_in_hours=-1)
+    resp = await client.post(f"/games/{code}/teams", json={"name": "TooLate"})
+    assert resp.status_code == 410
+    assert resp.json()["error"] == "gone"
+
+
 async def test_team_name_trimmed_and_validated(client, db) -> None:
     code, _ = await insert_game(db, status="waiting")
     too_long = "A" * 31

--- a/tests/backend/test_is_expired.py
+++ b/tests/backend/test_is_expired.py
@@ -1,0 +1,41 @@
+"""Unit tests for the games-router expiry helper (no DB needed)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.routers.games import _is_expired
+
+
+def test_missing_expires_at_is_not_expired() -> None:
+    assert _is_expired({}) is False
+    assert _is_expired({"expires_at": None}) is False
+
+
+def test_past_datetime_is_expired() -> None:
+    past = datetime.now(UTC) - timedelta(hours=1)
+    assert _is_expired({"expires_at": past}) is True
+
+
+def test_future_datetime_is_not_expired() -> None:
+    future = datetime.now(UTC) + timedelta(hours=1)
+    assert _is_expired({"expires_at": future}) is False
+
+
+def test_iso_string_past_is_expired() -> None:
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    assert _is_expired({"expires_at": past}) is True
+
+
+def test_iso_string_with_z_suffix_is_parsed() -> None:
+    # PostgREST may emit a trailing Z; ensure it still parses.
+    assert _is_expired({"expires_at": "2000-01-01T00:00:00Z"}) is True
+
+
+def test_naive_datetime_is_treated_as_utc() -> None:
+    naive_past = datetime(2000, 1, 1, 0, 0, 0)  # no tzinfo
+    assert _is_expired({"expires_at": naive_past}) is True
+
+
+def test_unparseable_string_is_not_expired() -> None:
+    assert _is_expired({"expires_at": "not-a-timestamp"}) is False


### PR DESCRIPTION
## Summary

Fixes the low/info findings from a full game validation pass (no critical/high/medium were found). Three small code fixes plus six doc-vs-code drift corrections.

**Code**
- **Sanitize 5xx responses:** `domain_error_handler` no longer copies raw DB/internal error text into 500 bodies (could expose table/column/constraint names). It returns a generic message and logs the detail server-side, matching `unhandled_handler`. 4xx messages are unchanged.
- **Join expired game → 410:** `POST /games/{code}/teams` now returns 410 for a game past its 4h TTL that the hourly sweep hasn't deleted yet (was 201 — a misleading success creating a team about to be removed), matching `docs/api-contracts.md`.
- **Admin delete double-fire:** the Songs delete-confirm is now re-entrancy guarded (`deleteInFlightRef`), so a fast double-click no longer issues a second DELETE (which surfaced a spurious "Delete failed" toast).

**Docs (drift vs deployed code)**
- `rpc-functions.md`: `award_attempt` no longer shows `p_manager_token DEFAULT NULL` (a default would reintroduce the 42725 overload ambiguity — see mig 021); "eight functions" count corrected to eleven.
- `security-rls.md`: `buzz_in(char, uuid)` grant signature (was `text`); manager-token scope updated (dropped the retired `award-points`).
- `data-model.md`: §2 `game_rounds` DDL now lists `title_claimed_by` / `artist_claimed_by` (mig 016) and `free_guess_active` (mig 017).
- `api-contracts.md`: bonus validation error documented as 400 (was 422; the handler maps all body validation to 400).

Left as-is (self-healing / cosmetic, info severity): realtime reducer ordering guard, transient `currentRound=null` during round advance, free-guess optimistic toast sign edge case.

## Test plan

- Backend: `ruff check` / `ruff format --check` / `mypy app` all clean.
- New `tests/backend/test_error_handler.py` (5xx sanitized, 4xx message preserved) and `test_games_join.py::test_expired_but_unswept_game_returns_410` pass.
- `test_manager_token` / `test_validation` / `test_games_bonus` re-run green (401/404/410/400 envelopes unchanged).
- Frontend: `eslint` + `tsc --noEmit` clean; `vitest run` → 340 passed, incl. the new AdminSongs double-click guard test.