### PR TITLE
Fix link previews: point og:image/og:url at the www host (apex has no HTTPS)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,7 +26,7 @@
     <link rel="dns-prefetch" href="https://i.ytimg.com" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://soundclash.org/" />
+    <meta property="og:url" content="https://www.soundclash.org/" />
     <meta property="og:title" content="Sound Clash" />
     <meta
       property="og:description"
@@ -39,8 +39,8 @@
          must live in the static index.html (the SPA serves it for every route).
          1200x630 JPEG, ~55 KB — kept well under WhatsApp's ~300 KB render
          ceiling. Regenerate from tools/og-image/ if the brand changes. -->
-    <meta property="og:image" content="https://soundclash.org/og-image.jpg" />
-    <meta property="og:image:secure_url" content="https://soundclash.org/og-image.jpg" />
+    <meta property="og:image" content="https://www.soundclash.org/og-image.jpg" />
+    <meta property="og:image:secure_url" content="https://www.soundclash.org/og-image.jpg" />
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -55,7 +55,7 @@
       name="twitter:description"
       content="Real-time multiplayer music trivia. Buzz in, name the tune, win the round."
     />
-    <meta name="twitter:image" content="https://soundclash.org/og-image.jpg" />
+    <meta name="twitter:image" content="https://www.soundclash.org/og-image.jpg" />
     <meta
       name="twitter:image:alt"
       content="Sound Clash — real-time multiplayer music trivia buzzer game"

--- a/tools/og-image/README.md
+++ b/tools/og-image/README.md
@@ -28,7 +28,9 @@ It is referenced by the `og:image` / `twitter:image` tags in
   `index.html` for every route, so one card covers `soundclash.org` and every
   `/join/<code>` link.
 - **Absolute https URL.** Crawlers fetch the image directly, so the tag points at
-  `https://soundclash.org/og-image.jpg`, not a relative path.
+  `https://www.soundclash.org/og-image.jpg`, not a relative path. (Note: the
+  bare apex `soundclash.org` only redirects over HTTP and has no HTTPS listener,
+  so the tag must use the `www` host that Cloudflare Pages actually serves.)
 - **JPEG, not PNG, and small.** WhatsApp silently refuses to render preview
   images much over ~300 KB. The gradient-heavy card is ~415 KB as PNG but ~55 KB
   as JPEG with no visible quality loss.
@@ -40,6 +42,6 @@ It is referenced by the `og:image` / `twitter:image` tags in
 After deploying a change to the image or tags, WhatsApp and the other platforms
 keep showing the **old** preview for a while — they cache per-URL aggressively
 and there is no public purge button for WhatsApp. To check the new card without
-waiting, share a one-off variant URL (e.g. `soundclash.org/?v=2`) or run the URL
+waiting, share a one-off variant URL (e.g. `www.soundclash.org/?v=2`) or run the URL
 through the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/),
 which forces a re-scrape on shared crawler infrastructure.


### PR DESCRIPTION
## Summary

The link-preview card from #141 never rendered in WhatsApp — it spun for ~15 s and showed nothing. Root cause is a **domain/DNS** issue, not the tags themselves:

- `www.soundclash.org` → CNAME → `sound-clash.pages.dev` → **Cloudflare Pages**. HTTPS works.
- `soundclash.org` (apex) → A record `162.255.119.87` → **Namecheap URL-forwarding**, which **only 301-redirects on HTTP (port 80)** and has **no HTTPS listener** — port 443 just hangs until timeout.

The `og:image` / `og:url` / `twitter:image` tags all pointed at the **apex over HTTPS** (`https://soundclash.org/og-image.jpg`). When a crawler fetched them it stalled on the dead 443 port → no image, no card.

This PR repoints all four absolute tags to the `www` host that Cloudflare Pages actually serves:

- `og:url`, `og:image`, `og:image:secure_url`, `twitter:image` → `https://www.soundclash.org/...`
- Documents the apex-has-no-HTTPS constraint in `tools/og-image/README.md`.

Verified `https://www.soundclash.org/og-image.jpg` returns `200 image/jpeg` and the www page is reachable by the `facebookexternalhit`/WhatsApp user-agent.

## Out of scope (infra follow-up, not code)

The bare apex `https://soundclash.org/` is unreachable over HTTPS for **everyone**, not just crawlers — anyone who types or shares the bare domain hits the same hang. The durable fix is to make Cloudflare serve the apex: add `soundclash.org` as a custom domain on the `sound-clash` Pages project and repoint the apex DNS at Cloudflare (CNAME-flattening / ALIAS to `sound-clash.pages.dev`), replacing the Namecheap HTTP-only redirect. Until that's done, share `www.` links.

## Test plan

- `npm run build` passes; built `dist/index.html` carries the `www` `og:image`.
- After deploy: re-fetch `https://www.soundclash.org/` as the crawler and confirm `og:image` → `www`; confirm a `www.soundclash.org/?v=1` link unfurls a card in WhatsApp (fresh URL avoids the cached empty preview).
