### PR TITLE
Immutable asset caching + Supabase/api resource hints (load)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Changed
 
+- 2026-07-04: **Faster loads, especially repeat loads.** The browser now caches the app's content-hashed code and styles permanently instead of re-checking all 5-7 files with the server on every single load (including a player's mid-game refresh), so a return visit is near-instant. The page also pre-warms its connection to the game database and the API the moment it opens, shaving the network handshake off the path from scanning the QR to a working BUZZ screen.
 - 2026-06-25: The installable **app icon** is now a clean, Apple-style white tile with blue equalizer bars (replacing the dark navy icon) and ships at higher resolution, including a new 1024px size. The **link-preview card** shared on WhatsApp / iMessage / Slack / etc. is now rendered at 2× resolution (2400×1260) so it stays crisp instead of soft after those apps re-compress it.
 - 2026-06-24: The **How to Play** page's "Steps to run a game" section is now a scannable two-phase flow instead of seven dense paragraphs — a **Set up** group (one-time) and a **Play** group (every round), each step trimmed to a single line, with the "audio plays from the host's phone" caveat pulled out into its own callout. Faster to grok at a glance for first-time hosts.
 - 2026-06-19: The decade filter on the **Host a game** page now labels the 2000s and 2010s in full ("2000s", "2010s") instead of the ambiguous "00s"/"10s"; the 60s–90s keep their familiar shorthand.

--- a/docs/planning/phases/phase-1-perf-load.md
+++ b/docs/planning/phases/phase-1-perf-load.md
@@ -19,14 +19,14 @@
 ## Tasks
 
 ### T1.1 · Immutable + tiered HTTP caching `[S]` — `I-Cache`
-- [ ] `frontend/public/_headers`: add `/assets/*` → `Cache-Control: public, max-age=31536000, immutable`.
-- [ ] Add `/icons/*`, `og-image.jpg`, `how-to-play-hero.*`, `manifest.webmanifest` → `max-age=86400`.
-- [ ] Verify locally (`curl -I`) that hashed assets get `immutable` and `index.html` stays `no-cache`.
-- [ ] Keep `sw.js` cache-nothing; update its comment to note caching is handled at the HTTP layer now (T-DeadCode-adjacent).
+- [x] `frontend/public/_headers`: add `/assets/*` → `Cache-Control: public, max-age=31536000, immutable`.
+- [x] Add `/icons/*`, `og-image.jpg`, `how-to-play-hero.*`, `manifest.webmanifest` → `max-age=86400`.
+- [x] Verify locally (`curl -I` against `wrangler pages dev dist`) that hashed assets get `immutable` and `index.html` stays `no-cache`.
+- [x] Keep `sw.js` cache-nothing; update its comment to note caching is handled at the HTTP layer now (T-DeadCode-adjacent).
 
 ### T1.2 · Resource hints `[S]` — `I-Preconnect`
-- [ ] `frontend/index.html`: `preconnect` + `dns-prefetch` for the Supabase project host and `api.soundclash.org` (both `crossorigin` — supabase-js uses CORS fetch + WS).
-- [ ] Fix YouTube hints: drop `crossorigin` from `www.youtube.com`; add non-crossorigin `youtube-nocookie.com` and `s.ytimg.com`.
+- [x] `frontend/index.html`: `preconnect` + `dns-prefetch` for the Supabase project host and `api.soundclash.org` (both `crossorigin` — supabase-js uses CORS fetch + WS).
+- [x] Fix YouTube hints: drop `crossorigin` from `www.youtube.com`; add non-crossorigin `youtube-nocookie.com` and `s.ytimg.com`.
 
 ### T1.3 · Hydrate before subscribe `[S]` — `I-Hydrate`
 - [ ] `useGameChannel.ts`: fire `void hydrate()` immediately after building the channel; keep the SUBSCRIBED re-hydrate.

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -223,7 +223,7 @@ async def create_game(...):
 
 ## 7. CSP and HTTP Headers
 
-Frontend served by Cloudflare Pages. Configure via `_headers` file:
+Frontend served by Cloudflare Pages. Configure via `frontend/public/_headers`:
 
 ```
 /*
@@ -231,13 +231,24 @@ Frontend served by Cloudflare Pages. Configure via `_headers` file:
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://o*.ingest.sentry.io
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.grafana.net
+
+# content-hashed build output: cache forever, never revalidate
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# un-hashed static (each of /icons/*, /og-image.jpg, /how-to-play-hero.*,
+# /manifest.webmanifest is its own block): cache a day
+/icons/*
+  Cache-Control: public, max-age=86400
 ```
 
 Notes:
 - `'unsafe-inline'` for scripts is needed by Vite's runtime + YouTube IFrame Player. Tighten in a future hardening pass with hashes.
 - `frame-src` lists both `https://www.youtube.com` and `https://www.youtube-nocookie.com`. The IFrame Player runs in privacy-enhanced mode (`host: "https://www.youtube-nocookie.com"`) to suppress the doubleclick conversion-tracking pixels; the `youtube.com` entry remains because the IFrame API JS itself still loads from there.
-- `connect-src` allows Supabase (REST + Realtime), backend API, and Sentry ingest only.
+- `connect-src` allows Supabase (REST + Realtime), backend API, Sentry ingest (both `*.ingest.sentry.io` and the EU `*.ingest.de.sentry.io` region), and Grafana Faro (`*.grafana.net`).
+- **Caching:** content-hashed `/assets/*` are served `immutable` (a fresh hash on every change makes revalidation pointless, so the browser never re-checks them); the un-hashed static assets (`/icons/*`, `/og-image.jpg`, `/how-to-play-hero.*`, `/manifest.webmanifest`) get `max-age=86400`; and `index.html`, every SPA route, and `sw.js` are deliberately left on the platform default (`max-age=0, must-revalidate`) so a new deploy is always picked up and never served stale over a live game.
+- **Resource hints:** `index.html` `preconnect`s the Supabase project host and `api.soundclash.org` (both `crossorigin`, since supabase-js and the REST wrapper use CORS) plus the YouTube origins (`www.youtube.com`, `www.youtube-nocookie.com`, non-`crossorigin`), warming DNS+TLS before the join hydrate / buzz RPC / first song.
 
 Backend (FastAPI) sets:
 - `Strict-Transport-Security: max-age=31536000; includeSubDomains` (Render terminates TLS; HSTS still useful)

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -127,7 +127,7 @@ Pick the region closest to the primary user geography. For an Israel-based maint
 - Output directory: `frontend/dist`.
 - Environment variables (set in Cloudflare dashboard): `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_API_URL`.
 - Custom domain: `soundclash.org` (apex via Cloudflare DNS CNAME flattening).
-- `_headers` file in repo defines CSP and security headers (see `security-rls.md` §7).
+- `_headers` file in repo defines CSP, security headers, and static-asset caching (immutable content-hashed `/assets/*`; see `security-rls.md` §7).
 
 ## 5. DNS: Cloudflare
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,13 +16,30 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
 
+    <!-- Warm the two origins EVERY player hits before they can buzz: the
+         Supabase project (join hydrate GETs, the Realtime WebSocket, the buzz
+         RPC) and our FastAPI backend (the join POST). Both are reached over
+         CORS (supabase-js fetch + WS, our fetch wrapper), so preconnect
+         crossorigin. This is the highest-value hint — it overlaps DNS+TLS+TCP
+         setup with bundle download and parse. -->
+    <link rel="preconnect" href="https://jvfddxuaqcsrguibkymp.supabase.co" crossorigin />
+    <link rel="preconnect" href="https://api.soundclash.org" crossorigin />
+    <link rel="dns-prefetch" href="https://jvfddxuaqcsrguibkymp.supabase.co" />
+    <link rel="dns-prefetch" href="https://api.soundclash.org" />
+
     <!-- Warm DNS/TLS to YouTube before the IFrame Player mounts on the first
-         round. The script itself is still injected by YouTubePlayer.tsx; we
-         just shave the connection setup off the user-perceived song-start
-         latency. -->
-    <link rel="preconnect" href="https://www.youtube.com" crossorigin />
-    <link rel="preconnect" href="https://i.ytimg.com" crossorigin />
+         round (host + display only; the script is still injected by
+         YouTubePlayer.tsx). These are non-CORS subresources/embeds: the
+         iframe_api script (www.youtube.com), the embed iframe + widget
+         postMessage (www.youtube-nocookie.com), the widget JS (s.ytimg.com),
+         and thumbnails (i.ytimg.com). preconnect WITHOUT crossorigin — a
+         crossorigin socket would sit unused since none of these consumers send
+         CORS credentials (the old crossorigin youtube preconnect was dead). -->
+    <link rel="preconnect" href="https://www.youtube.com" />
+    <link rel="preconnect" href="https://www.youtube-nocookie.com" />
     <link rel="dns-prefetch" href="https://www.youtube.com" />
+    <link rel="dns-prefetch" href="https://www.youtube-nocookie.com" />
+    <link rel="dns-prefetch" href="https://s.ytimg.com" />
     <link rel="dns-prefetch" href="https://i.ytimg.com" />
 
     <meta property="og:type" content="website" />

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -4,3 +4,30 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Content-Security-Policy: default-src 'self'; script-src 'self' https://www.youtube.com https://s.ytimg.com 'unsafe-inline'; img-src 'self' data: https://i.ytimg.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.soundclash.org https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.grafana.net
+
+# Content-hashed build output. Vite writes a new filename whenever a chunk's
+# bytes change, so a cached copy can never be stale: cache it forever and skip
+# revalidation entirely. Previously these fell through to the platform default
+# (max-age=0, must-revalidate), costing a 304 round-trip per asset on every
+# load, including a player's mid-game refresh.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Un-hashed static assets: their URL is stable across deploys, so they can only
+# be busted by a new deploy, not a content hash. Cache for a day (a stale icon,
+# hero image, or manifest for under 24h is harmless, and index.html, which is
+# never cached, still picks up a fresh deploy immediately). sw.js is
+# deliberately NOT listed: it must always be fetched fresh so a new deploy's
+# worker activates (see public/sw.js).
+/icons/*
+  Cache-Control: public, max-age=86400
+/og-image.jpg
+  Cache-Control: public, max-age=86400
+/how-to-play-hero.*
+  Cache-Control: public, max-age=86400
+/manifest.webmanifest
+  Cache-Control: public, max-age=86400
+
+# index.html and every SPA route are intentionally left on the platform default
+# (max-age=0, must-revalidate): the HTML must revalidate on every load so a
+# deploy is picked up mid-session and never served stale over a live game.

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -10,6 +10,10 @@
  * the app shell would risk serving a stale bundle in the middle of a live game.
  * So this worker caches NOTHING and never intercepts a request.
  *
+ * Asset caching is handled entirely at the HTTP layer instead (see
+ * public/_headers): content-hashed /assets/* are served immutable, while
+ * index.html and this worker stay no-cache so a new deploy is always picked up.
+ *
  *  - install:  skipWaiting() so a new deploy's worker activates immediately.
  *  - activate: delete any caches a previous version may have created (acts as a
  *              built-in kill-switch) and take control of open clients.


### PR DESCRIPTION
## Summary

Phase 1 (load & time-to-playable), PR (A): HTTP caching + resource hints. No behavior/UI change; pure load-path speedups. Part of the production-readiness plan (`docs/planning/phases/phase-1-perf-load.md`, T1.1 + T1.2).

- **Immutable caching for `/assets/*`** (`_headers`): content-hashed Vite output is now `public, max-age=31536000, immutable`. Previously everything fell through to the platform default (`max-age=0, must-revalidate`), so every load — including a player's mid-game refresh — paid a 304 revalidation round-trip per asset.
- **Tiered caching for un-hashed static** (`/icons/*`, `/og-image.jpg`, `/how-to-play-hero.*`, `/manifest.webmanifest`): `max-age=86400`.
- **`index.html`, SPA routes, and `sw.js` stay no-cache** (platform default) so a deploy is always picked up and never served stale over a live game. `sw.js` comment updated to note caching now lives at the HTTP layer.
- **Resource hints** (`index.html`): `preconnect` + `dns-prefetch` for the Supabase project host and `api.soundclash.org` (both `crossorigin` — supabase-js + REST wrapper use CORS), warming DNS+TLS+TCP before the join hydrate / buzz RPC / join POST. Fixed the YouTube hints: dropped the dead `crossorigin` from `www.youtube.com`, added the real embed origin `www.youtube-nocookie.com` and the widget host `s.ytimg.com`.
- Docs: reconciled `security-rls.md` §7 (`_headers` now shows the live CSP + the caching/hints policy) and `tech-stack.md`. CHANGELOG entry under `[Unreleased] › Changed`.

Baseline (prod, before): every asset served `max-age=0, must-revalidate` (confirmed by `curl -I`); join-page FCP ~828ms; only YouTube preconnected.

## Test plan

- `npm run lint && npm run typecheck && npm run test:run` — all green (340 tests).
- `npm run build` — clean; `_headers` copied to `dist/` verbatim; no bundle-size change (this PR touches only static/config).
- **Authoritative header check via `wrangler pages dev dist`** (same `_headers` engine as Cloudflare Pages) — parsed 6 valid header rules; `curl -I` confirms:
  - `/assets/*.js`, `/assets/*.css` → `public, max-age=31536000, immutable`
  - `/icons/*`, `/manifest.webmanifest`, `/og-image.jpg` → `public, max-age=86400`
  - `/` (index.html) and `/sw.js` → `public, max-age=0, must-revalidate`
- Post-deploy: will re-confirm the same via `curl -I` against prod, and verify no console regressions on the join/team/display pages.

Note: the `security-rls.md` §7 CSP block was already stale (showed the pre-#126 `o*.ingest.sentry.io`); since this PR rewrites that exact block for caching, I reconciled it to the CSP that's actually deployed. No CSP behavior change.