### PR TITLE
Load genres directly from Supabase (fix >5s Host-form stall on cold backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-07-04: **The "Host a game" genre picker no longer stalls behind a cold backend.** The genre list now loads directly from the database (which is always warm) instead of through the app server, whose free-tier container sleeps after ~15 min idle and could take several seconds to wake — previously making the genres take 5+ seconds to appear when hosting after a quiet spell. Creating the game itself still uses the app server (and is still pre-warmed on the home page).
 - 2026-06-25: Joining a game that has passed its 4-hour expiry (but hasn't been swept from the database yet) now returns a clear "game is gone" error instead of a misleading success that created a team about to be deleted.
 - 2026-06-25: The admin **Songs** delete confirmation no longer issues a duplicate delete on a fast double-click — which previously surfaced a spurious "Delete failed" toast even though the song had been removed.
 - 2026-06-24: The admin **Songs** list no longer caps at 1000. Once the catalog passed 1000 songs the page fetched only the first 1000 (by title) over the REST API and reported "1000" as the total; it now pages in the database (`range`) and reads the exact count, so the true total shows and every song is reachable. (Gameplay was never affected — song selection runs inside Postgres, not over the REST API.)

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -303,6 +303,8 @@ Public. List all genres.
 ]
 ```
 
+> **Note:** the SPA no longer calls this endpoint. The "Host a game" genre picker reads the anon-readable `genres` table **directly from Supabase** (`from('genres').select('id,name,slug').order('name')`) so it never waits on a cold Render container. This endpoint is retained for smoke tests and any external caller; its contract is unchanged.
+
 ---
 
 ### 2.10 Admin Songs CRUD

--- a/docs/planning/phases/phase-1-perf-load.md
+++ b/docs/planning/phases/phase-1-perf-load.md
@@ -55,6 +55,9 @@
 ### T1.8 · Measurement `[S]`
 - [ ] Capture join-to-playable before/after (Playwright MCP against prod, or Lighthouse): time from `/join/:code` navigation to BUZZ button interactive. Record numbers in the PR so the win is provable.
 
+### T1.9 · Genres direct from Supabase `[S]` — `I-GenreWarm` (surfaced in execution)
+- [x] Maintainer reported the "Host a game" genre picker taking >5s on a cold Render container. Root cause: `listGenres()` went through Render's `/genres` (2-30s cold start) even though `genres` is an anon-readable table. Fix: `listGenres()` now reads genres **directly from Supabase** (`from('genres').select('id,name,slug').order('name')`), same reasoning as keeping the buzzer off Render. Endpoint retained for smoke/external. (`fix/genres-direct-supabase`)
+
 ---
 
 ## Decisions touched

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -18,11 +18,27 @@ import {
 } from "./api";
 import type { SongWritePayload } from "./types";
 
+// listGenres reads genres straight from Supabase (no Render cold start), so we
+// mock the supabase client's `from("genres").select(...).order(...)` chain.
+// Every other endpoint still goes through fetch (mocked below).
+const supabaseMocks = vi.hoisted(() => {
+  const order = vi.fn();
+  const select = vi.fn(() => ({ order }));
+  const from = vi.fn(() => ({ select }));
+  return { order, select, from };
+});
+vi.mock("./supabase", () => ({
+  supabase: { from: supabaseMocks.from },
+}));
+
 const fetchMock = vi.fn();
 
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
+  supabaseMocks.from.mockClear();
+  supabaseMocks.select.mockClear();
+  supabaseMocks.order.mockReset();
   __resetListGenresCacheForTests();
 });
 
@@ -52,34 +68,50 @@ describe("api - public routes", () => {
     expect(headers["X-Manager-Token"]).toBeUndefined();
   });
 
-  it("listGenres GETs /genres", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, [{ id: "g1", name: "Rock", slug: "rock" }]));
+  it("listGenres reads genres directly from Supabase (not via fetch/Render)", async () => {
+    supabaseMocks.order.mockResolvedValueOnce({
+      data: [{ id: "g1", name: "Rock", slug: "rock" }],
+      error: null,
+    });
     const res = await listGenres();
     expect(res).toHaveLength(1);
+    expect(supabaseMocks.from).toHaveBeenCalledWith("genres");
+    expect(supabaseMocks.select).toHaveBeenCalledWith("id,name,slug");
+    expect(supabaseMocks.order).toHaveBeenCalledWith("name");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("listGenres memoizes the result so a second call does not hit the network", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, [{ id: "g1", name: "Rock", slug: "rock" }]));
+    supabaseMocks.order.mockResolvedValueOnce({
+      data: [{ id: "g1", name: "Rock", slug: "rock" }],
+      error: null,
+    });
     const first = await listGenres();
     const second = await listGenres();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(supabaseMocks.order).toHaveBeenCalledTimes(1);
     expect(second).toEqual(first);
   });
 
   it("listGenres dedupes concurrent calls (single in-flight request)", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, [{ id: "g1", name: "Rock", slug: "rock" }]));
+    supabaseMocks.order.mockResolvedValueOnce({
+      data: [{ id: "g1", name: "Rock", slug: "rock" }],
+      error: null,
+    });
     const [a, b] = await Promise.all([listGenres(), listGenres()]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(supabaseMocks.order).toHaveBeenCalledTimes(1);
     expect(a).toEqual(b);
   });
 
-  it("listGenres retries after a failed fetch (cache stays empty on error)", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("network down"));
+  it("listGenres surfaces a Supabase error and retries (cache stays empty on error)", async () => {
+    supabaseMocks.order.mockResolvedValueOnce({ data: null, error: { message: "network down" } });
     await expect(listGenres()).rejects.toThrow(/network down/);
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, [{ id: "g1", name: "Rock", slug: "rock" }]));
+    supabaseMocks.order.mockResolvedValueOnce({
+      data: [{ id: "g1", name: "Rock", slug: "rock" }],
+      error: null,
+    });
     const res = await listGenres();
     expect(res).toHaveLength(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(supabaseMocks.order).toHaveBeenCalledTimes(2);
   });
 
   it("joinTeam POSTs name to the right URL", async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -130,10 +130,7 @@ export function listGenres(): Promise<Genre[]> {
   if (inflightGenres) return inflightGenres;
   inflightGenres = (async () => {
     try {
-      const { data, error } = await supabase
-        .from("genres")
-        .select("id,name,slug")
-        .order("name");
+      const { data, error } = await supabase.from("genres").select("id,name,slug").order("name");
       if (error) throw new Error(error.message);
       const result = (data ?? []) as Genre[];
       cachedGenres = result;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { env } from "./env";
+import { supabase } from "./supabase";
 import { tracedFetch } from "./telemetry";
 import type {
   ApiErrorBody,
@@ -110,11 +111,17 @@ export function getHealth(): Promise<{
   return request("GET", "/health");
 }
 
-// Genres are static for the duration of a session, so we memoize the first
-// successful fetch. HomePage prefetches in the background while the user is
-// reading the landing copy, so by the time they click Host and reach
-// ManagerCreateGamePage the list is already in memory and the form renders
-// without waiting on the Render-hosted backend.
+// Genres are a small, static, anon-readable catalog table, so we fetch them
+// DIRECTLY from Supabase (Postgres in Frankfurt, always warm) rather than
+// through the Render-hosted `/genres` endpoint. Render's free tier cold-starts
+// 2-30s, and the "Host a game" form blocks on this list — a cold backend made
+// the genre picker take >5s to appear. Supabase returns the same rows in
+// ~150ms whether or not Render is awake. This is the same reasoning that keeps
+// the buzzer and the hydrate off Render: no cold start in a user-perceived
+// path. The result is memoized for the session, and HomePage prefetches it in
+// the background so the picker is usually already in memory by the time the
+// host clicks through. (The `/genres` REST endpoint still exists for smoke
+// tests and any external caller; the browser just no longer depends on it.)
 let cachedGenres: Genre[] | null = null;
 let inflightGenres: Promise<Genre[]> | null = null;
 
@@ -123,7 +130,12 @@ export function listGenres(): Promise<Genre[]> {
   if (inflightGenres) return inflightGenres;
   inflightGenres = (async () => {
     try {
-      const result = await request<Genre[]>("GET", "/genres");
+      const { data, error } = await supabase
+        .from("genres")
+        .select("id,name,slug")
+        .order("name");
+      if (error) throw new Error(error.message);
+      const result = (data ?? []) as Genre[];
       cachedGenres = result;
       return result;
     } finally {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,15 +7,17 @@ import styles from "./HomePage.module.css";
 
 export function HomePage() {
   useEffect(() => {
-    // Pre-warm the Render-hosted backend. Its free-tier container spins down
-    // after ~15 min idle, so the next request (Create / Join / Display)
-    // would otherwise stall the user for 2-30s on cold start. We fire two
-    // throwaway requests in the background:
-    //   1. /health wakes the container.
-    //   2. /genres warms it AND seeds the listGenres cache so the manager's
-    //      "Host a game" form has its options ready when they click through.
-    // Errors are ignored — if pre-warm fails, the user just hits the same
-    // cold start they would have hit before. No worse, often much better.
+    // Pre-warm on landing so the next step is fast. Two background requests:
+    //   1. getHealth() wakes the Render backend. Its free-tier container spins
+    //      down after ~15 min idle, so the create-game / join POST would
+    //      otherwise stall the user 2-30s on cold start; pinging /health now
+    //      warms the container ahead of that click.
+    //   2. listGenres() seeds the genre cache. Genres load straight from
+    //      Supabase (not Render), so it's already fast and cold-start-free;
+    //      prefetching here just means the "Host a game" picker is already in
+    //      memory on arrival.
+    // Errors are ignored — a failed pre-warm just means the user hits the same
+    // path they would have anyway. No worse, often much better.
     void getHealth().catch(() => undefined);
     void listGenres().catch(() => undefined);
   }, []);


### PR DESCRIPTION
## Summary

Fixes a maintainer-reported issue: the "Host a game" genre picker took 5+ seconds to appear. Surfaced during Phase 1 execution (recorded as task T1.9 in `phase-1-perf-load.md`).

**Root cause:** `listGenres()` fetched the genre list through the Render-hosted `GET /genres` endpoint. Render's free tier spins the container down after ~15 min idle, so a cold backend took 2-30s to wake — and the genre picker blocks on that list. Genres are a tiny, static, anon-readable catalog table, so routing them through a cold-startable Python server put Render in a user-perceived path (the exact thing the architecture avoids for the buzzer/hydrate).

**Fix:** `listGenres()` now reads genres **directly from Supabase** (`from('genres').select('id,name,slug').order('name')`) — Postgres in Frankfurt, always warm, ~150ms whether or not Render is awake. The session-level memoization and HomePage prefetch are unchanged. Creating the game itself still goes through Render (still pre-warmed via `getHealth()` on the home page).

- The REST `GET /genres` endpoint is **retained** (smoke tests / external callers); the browser just no longer depends on it. `api-contracts.md` §2.9 notes this.
- `genres` is anon-readable (`anon_read_genres` policy + grant, migration 006), and `connect-src` already allows `*.supabase.co`, so no schema/RLS/CSP change is needed.

## Test plan

- `npm run lint && npm run typecheck && npm run test:run` — all green (342 tests).
- `npm run build` — clean.
- `api.test.ts`: the four `listGenres` tests rewritten to assert it queries Supabase (`from('genres').select('id,name,slug').order('name')`), memoizes, dedupes concurrent calls, surfaces a Supabase error and retries — and that it does **not** hit `fetch`/Render. `ManagerCreateGamePage.test.tsx` is unchanged (it mocks the whole `api` module).
- Verified the exact query returns valid data from **prod** Supabase directly (curl to `/rest/v1/genres` returned the genre rows).
- Post-deploy: will load prod `/manager/create` and confirm the genres render with the network request going to `*.supabase.co` (not `api.soundclash.org`).
