### PR TITLE
Kill the silent dropped-click on the host console + pendingContinue (T2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project does not currently cut versioned releases; every change lands direc
 
 ### Fixed
 
+- 2026-07-05: **Rapid, distinct host taps no longer get silently dropped.** Tapping one scoring button and then quickly a *different* one (e.g. **Correct Song** then **Wrong**) could previously drop the second tap if it landed while the first was still committing — the host had to notice nothing happened and tap again. Each button now guards only its own action, so two distinct taps always both register. (A same-button double-tap is still de-duplicated, as before.) The host's **Continue** button also no longer briefly flickers enabled right after you tap it.
 - 2026-07-04: **The "Host a game" genre picker no longer stalls behind a cold backend.** The genre list now loads directly from the database (which is always warm) instead of through the app server, whose free-tier container sleeps after ~15 min idle and could take several seconds to wake — previously making the genres take 5+ seconds to appear when hosting after a quiet spell. Creating the game itself still uses the app server (and is still pre-warmed on the home page).
 - 2026-06-25: Joining a game that has passed its 4-hour expiry (but hasn't been swept from the database yet) now returns a clear "game is gone" error instead of a misleading success that created a team about to be deleted.
 - 2026-06-25: The admin **Songs** delete confirmation no longer issues a duplicate delete on a fast double-click — which previously surfaced a spurious "Delete failed" toast even though the song had been removed.

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -990,7 +990,9 @@ describe("ManagerConsolePage", () => {
     await waitFor(() => expect(btn).toBeEnabled());
   });
 
-  it("Continue round does not depend on busy (no flash); auto-disables when lock clears", async () => {
+  it("Continue stays disabled through the RPC -> Realtime handoff (no flash)", async () => {
+    // pendingContinue mirrors pendingWrong: after the click Continue must stay
+    // disabled until Realtime clears the buzz lock, with no enable-in-between.
     setHydrate({
       game: makeActiveGame({
         status: "playing",
@@ -1013,15 +1015,99 @@ describe("ManagerConsolePage", () => {
     const continueBtn = screen.getByTestId("continue-round");
     expect(continueBtn).toBeEnabled();
     fireEvent.click(continueBtn);
-    // Mid-RPC: the button is still enabled. The previous implementation
-    // would have shown disabled here (busy=true) -- now we drop busy from
-    // the gate and rely solely on the semantic state.
-    expect(continueBtn).toBeEnabled();
+    // pendingContinue flips the disabled prop synchronously.
+    expect(continueBtn).toBeDisabled();
     await act(async () => {
       resolveRpc(undefined);
     });
-    // After Realtime clears buzzed_team_id, the semantic gate takes over.
-    expect(continueBtn).toBeEnabled(); // still enabled (state hasn't flowed)
+    // RPC resolved but the lock hasn't cleared over Realtime yet -- still
+    // disabled (this is where the old busy toggle would have flashed enabled).
+    expect(continueBtn).toBeDisabled();
+    // Realtime clears the buzz lock; the semantic gate (!lockedTeam) now keeps
+    // Continue disabled (nothing left to continue).
+    await act(async () => {
+      fireGame(
+        makePayload<ActiveGame>("active_games", "UPDATE", {
+          new: makeActiveGame({
+            status: "playing",
+            buzzed_team_id: null,
+            current_round_id: "r1",
+          }),
+          old: makeActiveGame({
+            status: "playing",
+            buzzed_team_id: "t1",
+            current_round_id: "r1",
+          }),
+        }),
+      );
+    });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it("rapid Correct Song then Wrong both fire — no silent busy drop (F-P1-8/F-P2-2)", async () => {
+    // Regression: the shared `busy` gate dropped a distinct second click that
+    // landed inside the first action's window. With busy off the hot handlers,
+    // both distinct actions must fire.
+    setHydrate({
+      game: makeActiveGame({
+        status: "playing",
+        buzzed_team_id: "t1",
+        current_round_id: "r1",
+      }),
+      teams: [makeTeam({ id: "t1", name: "Alice" })],
+      rounds: [makeRound({ id: "r1" })],
+    });
+    let resolve1!: (v: never) => void;
+    let resolve2!: (v: never) => void;
+    vi.mocked(awardAttemptDirect)
+      .mockReturnValueOnce(
+        new Promise((res) => {
+          resolve1 = res as (v: never) => void;
+        }) as never,
+      )
+      .mockReturnValueOnce(
+        new Promise((res) => {
+          resolve2 = res as (v: never) => void;
+        }) as never,
+      );
+    renderConsole();
+    await act(async () => {
+      await fireSubscribed();
+    });
+    // Correct Song, then immediately Wrong -- distinct actions, first RPC still
+    // in flight.
+    fireEvent.click(screen.getByTestId("score-title"));
+    fireEvent.click(screen.getByTestId("score-wrong"));
+    expect(awardAttemptDirect).toHaveBeenCalledTimes(2);
+    expect(awardAttemptDirect).toHaveBeenNthCalledWith(1, "ABCDEF", TOKEN, "r1", {
+      title_correct: true,
+      artist_correct: false,
+      wrong_buzz: false,
+    });
+    expect(awardAttemptDirect).toHaveBeenNthCalledWith(2, "ABCDEF", TOKEN, "r1", {
+      title_correct: false,
+      artist_correct: false,
+      wrong_buzz: true,
+    });
+    // Let both awaits settle so no state updates land after the test.
+    await act(async () => {
+      resolve1({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: 10,
+        team_total_score: 10,
+        title_claimed_by: "t1",
+        artist_claimed_by: null,
+      } as never);
+      resolve2({
+        round_id: "r1",
+        team_id: "t1",
+        points_awarded: -3,
+        team_total_score: 7,
+        title_claimed_by: "t1",
+        artist_claimed_by: null,
+      } as never);
+    });
   });
 
   // ---- synchronous double-click guard: useRef in-flight locks ----

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -85,30 +85,33 @@ export function ManagerConsolePage() {
   const [endConfirmOpen, setEndConfirmOpen] = useState(false);
   const [bonusOpen, setBonusOpen] = useState(false);
 
-  // Optimistic "we just clicked this" markers for the three scoring buttons,
+  // Optimistic "we just clicked this" markers for the per-round action buttons,
   // each holding the round id the click happened on. They bridge the ~50-
-  // 100ms gap between the award_attempt RPC returning and the Realtime
-  // UPDATE on game_rounds (title_claimed_by / artist_claimed_by) or
-  // active_games (buzzed_team_id) arriving -- without them the disabled
-  // prop momentarily flips back to false (since `busy` cleared but the
-  // semantic gate hadn't tightened yet), which the user sees as a "double
-  // flash" on the button. The flag is naturally self-clearing on round
-  // change (stale id won't equal the new round.id) and gets reset by the
-  // effect below for tidiness. Cleared in each handler's catch on failure
-  // so a transient RPC error doesn't leave the button permanently disabled.
+  // 100ms gap between the RPC returning and the Realtime UPDATE on game_rounds
+  // (title_claimed_by / artist_claimed_by) or active_games (buzzed_team_id)
+  // arriving -- keeping the button disabled across that gap so it doesn't flash
+  // enabled in the window. The flag is naturally self-clearing on round change
+  // (stale id won't equal the new round.id) and gets reset by the effects
+  // below for tidiness. Cleared in each handler's catch on failure so a
+  // transient RPC error doesn't leave the button permanently disabled.
+  // pendingContinue mirrors pendingWrong: Continue releases the buzz lock, so
+  // it stays disabled until the Realtime UPDATE clears buzzed_team_id.
   const [pendingTitle, setPendingTitle] = useState<string | null>(null);
   const [pendingArtist, setPendingArtist] = useState<string | null>(null);
   const [pendingWrong, setPendingWrong] = useState<string | null>(null);
+  const [pendingContinue, setPendingContinue] = useState<string | null>(null);
 
-  // Synchronous in-flight locks per action. useState (`busy`) is captured in
-  // the handler closure at render time, so two clicks fired in the same
-  // React tick both read `busy=false` and both proceed -- React's batching
-  // hides the first setBusy(true) from the second handler. useRef.current
-  // mutates synchronously, so the second click sees `true` and bails. Cheap
-  // belt-and-suspenders alongside the existing `busy` early-return; matters
-  // most for handleNextRound, where a duplicate fire would insert an orphan
-  // game_rounds row (the other actions are idempotent via the SQL function's
-  // already-claimed / no-buzz-to-score branches).
+  // Synchronous in-flight locks, one PER ACTION. These are the sole guard
+  // against a same-action double-fire now that the shared `busy` gate is off
+  // the hot handlers (removing it is what stops a *distinct* second click --
+  // e.g. Correct Song then quickly Wrong -- from being silently dropped inside
+  // the first action's window; see F-P1-8 / F-P2-2). useState can't do this
+  // job: `busy` is captured in the closure at render time, so two clicks in
+  // one React tick both read the stale value; useRef.current mutates
+  // synchronously, so the second same-action click sees `true` and bails.
+  // Matters most for handleNextRound, where a duplicate fire would insert an
+  // orphan game_rounds row (the other actions are idempotent via the SQL
+  // function's already-claimed / no-buzz-to-score branches).
   const titleInFlightRef = useRef(false);
   const artistInFlightRef = useRef(false);
   const wrongInFlightRef = useRef(false);
@@ -150,16 +153,18 @@ export function ManagerConsolePage() {
     setPendingTitle(null);
     setPendingArtist(null);
     setPendingWrong(null);
+    setPendingContinue(null);
   }, [currentRoundId]);
 
-  // Wrong releases the buzz lock, so a follow-up buzz in the same round
-  // must re-enable the Wrong button. `pendingWrong` only bridges the gap
-  // between the RPC returning and the Realtime UPDATE on buzzed_team_id;
-  // once that UPDATE has landed (lock cleared) the flag has done its job
-  // and has to drop or the next buzz's Wrong click stays blocked.
+  // Wrong and Continue both release the buzz lock, so a follow-up buzz in the
+  // same round must re-enable their buttons. `pendingWrong` / `pendingContinue`
+  // only bridge the gap between the RPC returning and the Realtime UPDATE on
+  // buzzed_team_id; once that UPDATE has landed (lock cleared) the flags have
+  // done their job and must drop or the next buzz's click stays blocked.
   useEffect(() => {
     if (state?.game.buzzed_team_id == null) {
       setPendingWrong(null);
+      setPendingContinue(null);
     }
   }, [state?.game.buzzed_team_id]);
 
@@ -370,7 +375,7 @@ export function ManagerConsolePage() {
 
   async function handleCorrectTitle() {
     if (titleInFlightRef.current) return;
-    if (!state?.currentRound || busy || !managerToken) return;
+    if (!state?.currentRound || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
     titleInFlightRef.current = true;
     const roundId = state.currentRound.id;
@@ -381,7 +386,6 @@ export function ManagerConsolePage() {
     // (after which the semantic gate takes over) -- no enable/disable
     // flicker in the gap.
     setPendingTitle(roundId);
-    setBusy(true);
     markScoreStart(gameCode, roundId, "title");
     try {
       await applyAttempt(roundId, {
@@ -394,21 +398,19 @@ export function ManagerConsolePage() {
       setPendingTitle(null);
       reportError(err);
     } finally {
-      setBusy(false);
       titleInFlightRef.current = false;
     }
   }
 
   async function handleCorrectArtist() {
     if (artistInFlightRef.current) return;
-    if (!state?.currentRound || busy || !managerToken) return;
+    if (!state?.currentRound || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
     artistInFlightRef.current = true;
     const roundId = state.currentRound.id;
     const teamName = buzzedTeamName();
     if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
     setPendingArtist(roundId);
-    setBusy(true);
     markScoreStart(gameCode, roundId, "artist");
     try {
       await applyAttempt(roundId, {
@@ -421,7 +423,6 @@ export function ManagerConsolePage() {
       setPendingArtist(null);
       reportError(err);
     } finally {
-      setBusy(false);
       artistInFlightRef.current = false;
     }
   }
@@ -436,7 +437,7 @@ export function ManagerConsolePage() {
   // mirroring how a regular round behaves once both title + artist are claimed.
   async function handleCorrectSoundtrack() {
     if (titleInFlightRef.current || artistInFlightRef.current) return;
-    if (!state?.currentRound || busy || !managerToken) return;
+    if (!state?.currentRound || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
     titleInFlightRef.current = true;
     artistInFlightRef.current = true;
@@ -445,7 +446,6 @@ export function ManagerConsolePage() {
     if (teamName) toast(`+15 to ${teamName}`, { variant: "success" });
     setPendingTitle(roundId);
     setPendingArtist(roundId);
-    setBusy(true);
     markScoreStart(gameCode, roundId, "soundtrack");
     try {
       await applyAttempt(roundId, {
@@ -459,7 +459,6 @@ export function ManagerConsolePage() {
       setPendingArtist(null);
       reportError(err);
     } finally {
-      setBusy(false);
       titleInFlightRef.current = false;
       artistInFlightRef.current = false;
     }
@@ -467,20 +466,22 @@ export function ManagerConsolePage() {
 
   async function handleContinueRound() {
     if (continueInFlightRef.current) return;
-    if (busy || !managerToken) return;
+    if (!managerToken) return;
     continueInFlightRef.current = true;
     // Optimistic toast fires before the RPC so the click feels instant; the
     // Realtime UPDATE on active_games.buzzed_team_id is still the source of
     // truth for re-arming the buzzers.
     toast("Round continued", { variant: "info" });
-    setBusy(true);
+    // Keep Continue disabled until the lock actually clears via Realtime, the
+    // same handoff pendingWrong uses -- no enable/disable flash in the gap.
+    setPendingContinue(state?.currentRound?.id ?? null);
     try {
       await releaseBuzzLockDirect(gameCode, managerToken);
       activePlayer()?.play();
     } catch (err) {
+      setPendingContinue(null);
       reportError(err);
     } finally {
-      setBusy(false);
       continueInFlightRef.current = false;
     }
   }
@@ -497,7 +498,7 @@ export function ManagerConsolePage() {
   // song paused with the lock still held -- the manager can simply retry.
   async function handleWrong() {
     if (wrongInFlightRef.current) return;
-    if (!state?.currentRound || busy || !managerToken) return;
+    if (!state?.currentRound || !managerToken) return;
     if (!state.game.buzzed_team_id) return;
     wrongInFlightRef.current = true;
     const roundId = state.currentRound.id;
@@ -505,7 +506,6 @@ export function ManagerConsolePage() {
     const freeGuess = state.currentRound.free_guess_active;
     if (teamName && !freeGuess) toast(`-3 to ${teamName}`, { variant: "info" });
     setPendingWrong(roundId);
-    setBusy(true);
     try {
       await applyAttempt(roundId, {
         title_correct: false,
@@ -517,14 +517,13 @@ export function ManagerConsolePage() {
       setPendingWrong(null);
       reportError(err);
     } finally {
-      setBusy(false);
       wrongInFlightRef.current = false;
     }
   }
 
   async function handleNextRound() {
     if (nextRoundInFlightRef.current) return;
-    if (busy || !managerToken) return;
+    if (!managerToken) return;
     nextRoundInFlightRef.current = true;
     // Bump the preload epoch so any in-flight peek is discarded rather than
     // buffering into a player we're about to repurpose.
@@ -535,7 +534,6 @@ export function ManagerConsolePage() {
     songStartRef.current = songStart;
     // Optimistic toast confirms the click immediately.
     toast("Loading next round...", { variant: "info" });
-    setBusy(true);
     // Snapshot + clear the prebuffered song now so a late preload can't reuse it.
     const preloaded = preloadRef.current;
     preloadRef.current = null;
@@ -606,7 +604,6 @@ export function ManagerConsolePage() {
       if (committedPreloaded) activePlayer()?.stop();
       reportError(err);
     } finally {
-      setBusy(false);
       nextRoundInFlightRef.current = false;
     }
   }
@@ -732,16 +729,16 @@ export function ManagerConsolePage() {
 
   const statusClass = game.status === "playing" ? styles.statusPlaying : styles.statusWaiting;
 
-  // Disabled props deliberately do NOT read `busy`: a click-driven busy
-  // toggle creates a visible disable->enable->disable flash between the
-  // RPC returning (~150ms) and the Realtime UPDATE landing (~200-300ms).
-  // The scoring buttons use a pending-flag handoff (set on click, cleared
-  // automatically when the round changes) so they stay disabled across
-  // that gap. Continue / Next round just trust their semantic gate
-  // (lockedTeam / player.ready) and rely on the handler-side `busy`
-  // early-return to no-op rapid double-clicks. End game and Bonus still
-  // gate on busy because they fire less often and the flash is
-  // imperceptible there.
+  // Disabled props deliberately do NOT read `busy`: a shared click-driven busy
+  // toggle both created a visible disable->enable->disable flash AND silently
+  // dropped a *distinct* second click that landed inside the first action's
+  // window (Correct Song then quickly Wrong -- F-P1-8 / F-P2-2). Each per-round
+  // action instead uses its own pending-flag handoff (set on click, cleared
+  // when the round changes or the lock clears) so it stays disabled across the
+  // RPC->Realtime gap without blocking a different action; a same-action
+  // double-fire is caught synchronously by that action's inFlightRef. End game
+  // and Bonus still gate on `busy` because they fire at most once or twice per
+  // game and any flash there is imperceptible.
   const isSoundtrackRound = currentSong?.is_soundtrack === true;
   // Soundtrack rounds ask players to name the film/show, which is stored in
   // `artist`; that's the answer the host judges and the only text the display
@@ -768,7 +765,7 @@ export function ManagerConsolePage() {
     pendingTitle === round?.id ||
     pendingArtist === round?.id;
   const wrongActionDisabled = !lockedTeam || pendingWrong === round?.id;
-  const continueDisabled = !lockedTeam;
+  const continueDisabled = !lockedTeam || pendingContinue === round?.id;
   const nextRoundDisabled = !player.ready;
   // Bonus is independent of buzz state — it stays actionable as long as the
   // page isn't mid-request. (It must NOT be wrapped in an aria-disabled


### PR DESCRIPTION
## Summary

Phase 2 · T2.5 (`F-P1-8`, `F-P2-2`). Kill the silent dropped-click on the host
console and remove the last enable→disable flash.

The hot scoring/advance handlers (`handleCorrectTitle`, `handleCorrectArtist`,
`handleCorrectSoundtrack`, `handleWrong`, `handleContinueRound`, `handleNextRound`)
shared one `busy` state flag. A **distinct** second click that landed inside the
first action's `busy` window was silently dropped (documented in
`.claude/rules/lessons-learned.md`, 2026-06-24: the e2e "busy-flag dropped-click
race"). A human notices nothing happened and re-taps; on a slow round the drop is
invisible.

- **Removed the shared `busy` gate** (and its `setBusy` toggles) from those six
  handlers. Each already has its own synchronous `useRef` in-flight lock
  (`titleInFlightRef`, …, `nextRoundInFlightRef`) which still de-duplicates a
  **same-action** double-fire — the guard that actually matters (e.g. no orphan
  `game_rounds` row from a double Next-round). `busy` now gates only **End game**
  and **Bonus**, which fire at most once or twice per game.
- **Added `pendingContinue`** (round-scoped, mirrors `pendingWrong`): set on the
  Continue click, cleared when the round changes or the Realtime UPDATE clears
  `buzzed_team_id`, and included in `continueDisabled`. Continue now stays disabled
  cleanly across the RPC→Realtime gap instead of flickering enabled.

No scoring-logic change; the SQL functions and optimistic toasts are untouched.

## Test plan

- `npm run format:check && npm run lint && npm run typecheck` — clean.
- `npm run test:run` — 365 pass. Updated/added tests:
  - **rapid Correct Song then Wrong both fire** — proves the distinct second click
    is no longer dropped (2 `awardAttemptDirect` calls with the two flag sets).
  - **Continue stays disabled through the RPC→Realtime handoff (no flash)** —
    replaces the old "Continue does not depend on busy" test; Continue now disables
    on click (pendingContinue) and stays disabled until the lock clears.
  - Existing per-action useRef double-click-guard tests (Correct Song / Continue /
    Next round fire exactly once) still pass — same-action de-dup is intact.
- This directly relieves the e2e busy-flag click-race flakiness noted in
  lessons-learned; the local `four_teams_twenty_rounds` / `multi_buzz_round` specs
  exercise rapid scoring in CI.
