### PR TITLE
Phase 3 · T3.1: drop dead game_rounds mirror-write from buzz_in

### DIFF
--- a/db/migrations/035_buzz_in_drop_round_update.sql
+++ b/db/migrations/035_buzz_in_drop_round_update.sql
@@ -1,0 +1,62 @@
+-- 035_buzz_in_drop_round_update.sql
+-- Perf (Phase 3, I-Buzz1UPDATE): drop the now-dead game_rounds write from buzz_in.
+--
+-- Migration 011 taught buzz_in to also write `game_rounds.buzzed_team_id` so the
+-- since-replaced award_points could credit the winning team by reading it back.
+-- That reader is long gone: award_attempt (mig 016 onward) reads the held lock
+-- off active_games.buzzed_team_id, and every UI page reads active_games too.
+-- Nothing in the running system reads game_rounds.buzzed_team_id anymore -- the
+-- only remaining comparison is the frontend's roundEqual(), which now simply sees
+-- NULL === NULL and is inert.
+--
+-- Why it matters: game_rounds is in the supabase_realtime publication with
+-- REPLICA IDENTITY FULL, so that mirror-write broadcast a full game_rounds row (a
+-- no-op ROUND_CHANGE) to every subscribed client on EVERY buzz -- doubling the
+-- buzz-path Realtime fan-out and forcing a wasted re-render pass on all clients.
+-- Dropping the write halves buzz-path events. active_games.buzzed_team_id (the
+-- actual lock, read by the UI and by award_attempt) is untouched, so the buzzer
+-- semantics and the atomic compare-and-set are byte-for-byte identical: the
+-- buzz-race test (10 concurrent -> 1 winner, looped) stays the headline gate.
+--
+-- CREATE OR REPLACE keeps the (char(6), uuid) signature, so PostgREST routing of
+-- the browser's supabase.rpc('buzz_in', ...) call is unchanged. The
+-- game_rounds.buzzed_team_id COLUMN is retained (nullable, now vestigial) to keep
+-- this a non-destructive, purely additive perf change.
+--
+-- Idempotent: CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION buzz_in(
+  p_game_code char(6),
+  p_team_id   uuid
+)
+RETURNS TABLE(locked boolean, locked_team_id uuid, locked_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_locked_at timestamptz;
+BEGIN
+  -- Atomic compare-and-set on active_games: only the first concurrent caller to
+  -- satisfy buzzed_team_id IS NULL wins the UPDATE (Postgres MVCC + row lock make
+  -- this race-safe; see realtime-design.md §4). RETURNING captures the resulting
+  -- locked_at for the return value.
+  UPDATE active_games ag
+     SET buzzed_team_id = p_team_id,
+         locked_at      = now()
+   WHERE ag.game_code = p_game_code
+     AND ag.status = 'playing'
+     AND ag.buzzed_team_id IS NULL
+  RETURNING ag.locked_at INTO v_locked_at;
+
+  IF FOUND THEN
+    RETURN QUERY SELECT true, p_team_id, v_locked_at;
+  ELSE
+    -- Already locked by someone else (or game not playable). Return the existing
+    -- winner so the client can render "X buzzed first".
+    RETURN QUERY
+    SELECT false, ag.buzzed_team_id, ag.locked_at
+      FROM active_games ag
+     WHERE ag.game_code = p_game_code;
+  END IF;
+END $$;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -105,7 +105,7 @@ CREATE TABLE game_rounds (
   round_number    integer NOT NULL,
   song_id         uuid REFERENCES songs(id) ON DELETE SET NULL,
   started_at      timestamptz NOT NULL DEFAULT now(),
-  buzzed_team_id  uuid REFERENCES game_teams(id) ON DELETE SET NULL,
+  buzzed_team_id  uuid REFERENCES game_teams(id) ON DELETE SET NULL,   -- vestigial since mig 035 (no longer written); see §4
   title_points       integer NOT NULL DEFAULT 0,
   artist_points      integer NOT NULL DEFAULT 0,
   wrong_buzz_penalty integer NOT NULL DEFAULT 0,
@@ -262,7 +262,11 @@ Default `started_at + 4 hours`. Read-only after game creation. The pg_cron sweep
 
 ### `active_games.buzzed_team_id` and `locked_at`
 
-These two columns implement the buzzer lock. Both are NULL when no team holds the buzz. Set together by the `buzz_in` RPC. Cleared together by `start_round`, `award_attempt`, and `end_round`.
+These two columns implement the buzzer lock. Both are NULL when no team holds the buzz. Set together by the `buzz_in` RPC. Cleared together by `start_round`, `award_attempt`, and `end_round`. This is the **only** buzzer lock the running system reads (the UI pages and `award_attempt` all read it here).
+
+### `game_rounds.buzzed_team_id` — vestigial (mig 035)
+
+Migration 011 had `buzz_in` mirror the winning team onto `game_rounds.buzzed_team_id` so the since-retired `award_points` could credit the score by reading it back. `award_points` was replaced by `award_attempt` (mig 016), which reads the lock off `active_games` instead, so nothing has read this column since. Migration 035 dropped the mirror-write from `buzz_in` — it was pure Realtime waste (`game_rounds` is published with REPLICA IDENTITY FULL, so the write fanned a no-op `ROUND_CHANGE` out to every client on **every buzz**). The column is retained as a nullable field (no destructive schema change) but is now always NULL in the running system; the only remaining reference is the frontend `roundEqual()` comparison, which is inert against a perpetually-NULL value.
 
 ### `game_secrets.manager_token`
 

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -2,7 +2,7 @@
 
 The eleven PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
 
-Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), and `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token).
+Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token), and `db/migrations/035_buzz_in_drop_round_update.sql` (dropped the now-dead `game_rounds.buzzed_team_id` mirror-write from `buzz_in` to halve buzz-path Realtime fan-out).
 
 ## 0. Conventions
 
@@ -17,6 +17,11 @@ Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db
 The hot path. Called by browsers via PostgREST. <100ms RTT.
 
 ```sql
+-- Current body as of migration 035. Earlier (mig 011) the function also
+-- mirror-wrote game_rounds.buzzed_team_id for the since-retired award_points;
+-- that write was pure Realtime waste (game_rounds is published with REPLICA
+-- IDENTITY FULL, so it broadcast a no-op ROUND_CHANGE to every client on every
+-- buzz) and is dropped. Nothing reads game_rounds.buzzed_team_id now.
 CREATE OR REPLACE FUNCTION buzz_in(
   p_game_code char(6),
   p_team_id   uuid
@@ -27,30 +32,20 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 DECLARE
-  v_round_id  uuid;
   v_locked_at timestamptz;
 BEGIN
-  -- Atomic conditional UPDATE on active_games. RETURNING captures the
-  -- current_round_id so we can mirror the lock onto game_rounds, and
-  -- the resulting locked_at for the function's return value.
+  -- Atomic conditional UPDATE on active_games. Only the first concurrent caller
+  -- to satisfy buzzed_team_id IS NULL wins. RETURNING captures the resulting
+  -- locked_at for the function's return value.
   UPDATE active_games ag
      SET buzzed_team_id = p_team_id,
          locked_at      = now()
    WHERE ag.game_code = p_game_code
      AND ag.status = 'playing'
      AND ag.buzzed_team_id IS NULL
-  RETURNING ag.current_round_id, ag.locked_at INTO v_round_id, v_locked_at;
+  RETURNING ag.locked_at INTO v_locked_at;
 
   IF FOUND THEN
-    -- Mirror the lock onto the round so award_points can credit the
-    -- team. active_games.buzzed_team_id is reset to NULL after each
-    -- round; game_rounds.buzzed_team_id is the durable record.
-    IF v_round_id IS NOT NULL THEN
-      UPDATE game_rounds
-         SET buzzed_team_id = p_team_id
-       WHERE id = v_round_id;
-    END IF;
-
     RETURN QUERY SELECT true, p_team_id, v_locked_at;
   ELSE
     -- Lock already held or game not playable; return current state so
@@ -65,6 +60,8 @@ END $$;
 REVOKE ALL ON FUNCTION buzz_in(char, uuid) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION buzz_in(char, uuid) TO anon;
 ```
+
+The lock lives **only** on `active_games` (`buzzed_team_id` + `locked_at`). `game_rounds.buzzed_team_id` is a vestigial nullable column, no longer written by any function (see `data-model.md §4`).
 
 ### Race correctness
 

--- a/tests/db/test_buzz_in_edge_cases.py
+++ b/tests/db/test_buzz_in_edge_cases.py
@@ -10,7 +10,7 @@ import uuid
 import asyncpg
 import pytest
 
-from ._helpers import call_buzz_in, create_test_game, create_test_team
+from ._helpers import call_buzz_in, create_test_game, create_test_song, create_test_team
 
 pytestmark = pytest.mark.needs_docker
 
@@ -67,3 +67,31 @@ async def test_buzz_when_lock_already_held_returns_holder(
     assert loss["locked"] is False
     assert loss["locked_team_id"] == first
     assert loss["locked_at"] == win["locked_at"]
+
+
+@pytest.mark.asyncio
+async def test_buzz_sets_active_games_lock_only_not_round(
+    db: asyncpg.Connection,
+) -> None:
+    """Migration 035: buzz_in records the lock ONLY on active_games. The dead
+    mirror-write to game_rounds.buzzed_team_id (mig 011, for the retired
+    award_points) is gone -- that column stays NULL, and the buzz-path no longer
+    broadcasts a redundant game_rounds ROUND_CHANGE on every buzz."""
+    game_code = await create_test_game(db, status="playing")
+    team_id = await create_test_team(db, game_code)
+    song_id = await create_test_song(db)
+    round_id = await db.fetchval("SELECT start_round($1, $2)", game_code, song_id)
+
+    win = await call_buzz_in(db, game_code, team_id)
+    assert win is not None and win["locked"] is True
+
+    # The lock lives on active_games...
+    active_lock = await db.fetchval(
+        "SELECT buzzed_team_id FROM active_games WHERE game_code = $1", game_code
+    )
+    assert active_lock == team_id
+    # ...and buzz_in no longer touches game_rounds.buzzed_team_id.
+    round_lock = await db.fetchval(
+        "SELECT buzzed_team_id FROM game_rounds WHERE id = $1", round_id
+    )
+    assert round_lock is None


### PR DESCRIPTION
## Summary

Phase 3 · T3.1 (`I-Buzz1UPDATE`). Migration 035 replaces `buzz_in` with a body that no longer mirror-writes `game_rounds.buzzed_team_id`.

That write was added by mig 011 so the since-retired `award_points` could credit the winning team by reading it back. `award_points` was replaced by `award_attempt` (mig 016), which reads the held lock off `active_games.buzzed_team_id` instead — nothing has read `game_rounds.buzzed_team_id` since. Because `game_rounds` is in the `supabase_realtime` publication with `REPLICA IDENTITY FULL`, the dead write broadcast a full no-op `ROUND_CHANGE` row to every subscribed client **on every buzz**, doubling buzz-path Realtime fan-out and forcing a wasted re-render on all clients.

- The atomic compare-and-set on `active_games` is byte-for-byte identical, so buzzer semantics and race correctness are unchanged.
- `CREATE OR REPLACE` keeps the `(char(6), uuid)` signature — PostgREST routing of the browser's `supabase.rpc('buzz_in', ...)` is unchanged.
- The `game_rounds.buzzed_team_id` column is retained (nullable, now vestigial) — no destructive schema change. The only remaining reference is the frontend `roundEqual()` comparison, which is inert against a perpetually-NULL value.

Docs updated in the same PR: `rpc-functions.md §1` (new body + lineage), `data-model.md §4` (vestigial-column note + DDL comment).

No user-visible behavior change (no CHANGELOG entry): buzz outcomes are identical; this removes wasted events, not a feature.

## Test plan

- **Buzz-race gate (headline):** `tests/db/test_buzz_in_race.py` green via testcontainers; plus 100 rounds × 10 concurrent `buzz_in` against a migrated local Supabase stack (real `supabase_realtime` publication + `REPLICA IDENTITY FULL` present) → exactly one winner every round.
- New regression test `test_buzz_sets_active_games_lock_only_not_round`: after `buzz_in`, `active_games.buzzed_team_id == team` while `game_rounds.buzzed_team_id IS NULL`.
- `test_buzz_in_edge_cases.py` + `test_award_attempt.py` green (35 passed).
- Migration idempotency: applied to a fresh local Supabase stack, then re-applied 035 twice with no error; `pg_get_functiondef` confirms the deployed body contains no `UPDATE game_rounds`.
