### PR TITLE
Phase 3 · T3.2: collapse award_attempt writes into one UPDATE...RETURNING

### DIFF
--- a/db/migrations/036_award_attempt_collapse_writes.sql
+++ b/db/migrations/036_award_attempt_collapse_writes.sql
@@ -1,0 +1,207 @@
+-- 036_award_attempt_collapse_writes.sql
+-- Perf (Phase 3, I-Award1UPDATE): collapse award_attempt's per-round writes into
+-- one game_rounds UPDATE and fold the trailing SELECTs into RETURNING.
+--
+-- Before (mig 034 body): a single "Correct Song" click ran up to FOUR writes to
+-- game_rounds -- one for the title claim, a redundant standalone free_guess_active
+-- write (fired on EVERY call even when the value was unchanged), plus separate
+-- artist / wrong_buzz writes on the relevant paths -- then two trailing SELECTs to
+-- re-read the team score and the token-claim columns for the return row. Each
+-- game_rounds UPDATE is a separate Realtime ROUND_CHANGE fanned out to every
+-- client (game_rounds is published with REPLICA IDENTITY FULL), and the SELECTs
+-- are extra round-trips inside the hot manager click.
+--
+-- After: one combined UPDATE computes every changed column from branch vars via
+-- CASE, writes game_rounds at most ONCE per attempt, and RETURNs the resulting
+-- claim columns straight into the locals -- so a Correct Song emits ONE
+-- ROUND_CHANGE instead of two, and the no-op "Continue" (no toggles, no wrong,
+-- free_guess unchanged) emits ZERO game_rounds writes instead of one. The team
+-- score read folds into the score UPDATE's RETURNING on the scoring path.
+--
+-- Behavior is preserved exactly: the CASE ELSE branches keep each unset column at
+-- its current value, and the write is skipped only when nothing would change
+-- (no title/artist/wrong AND free_guess_active already equals its new value), in
+-- which case the claim columns are unchanged and the values read at the top of the
+-- function are still the correct return values. All the guard/validation logic,
+-- the free-guess flag rules (mig 017), the wrong-buzz -3 waiver, the attempts-row
+-- insert, and the buzz-lock handling (mig 018/019: wrong clears, correct refreshes
+-- locked_at, no-op leaves it untouched) are unchanged.
+--
+-- Signature is IDENTICAL to mig 034's 6-arg tokenised award_attempt (no DEFAULTs;
+-- adding one would make the overload ambiguous -- see the mig-021 lesson). The
+-- token lookup still LEFT JOINs game_secrets (mig 034). CREATE OR REPLACE keeps
+-- PostgREST routing and the anon EXECUTE grant intact.
+--
+-- Idempotent: CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION award_attempt(
+  p_game_code     text,
+  p_round_id      uuid,
+  p_title         integer,
+  p_artist        integer,
+  p_wrong_buzz    integer,
+  p_manager_token uuid
+)
+RETURNS TABLE(
+  team_id              uuid,
+  points_delta         integer,
+  team_total_score     integer,
+  title_claimed_by     uuid,
+  artist_claimed_by    uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id          uuid;
+  v_round_ended      timestamptz;
+  v_title_claimed    uuid;
+  v_artist_claimed   uuid;
+  v_free_guess       boolean;
+  v_outcome          text;
+  v_delta            integer;
+  v_score            integer;
+  v_new_free_guess   boolean;
+  v_expected_token   uuid;
+  v_game_ended_at    timestamptz;
+BEGIN
+  -- Token check happens first, before any reads/writes that could leak
+  -- information about a game's state to an unauthenticated caller.
+  SELECT gs.manager_token, ag.ended_at
+    INTO v_expected_token, v_game_ended_at
+    FROM active_games ag
+    LEFT JOIN game_secrets gs ON gs.game_code = ag.game_code
+   WHERE ag.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'game_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_game_ended_at IS NOT NULL THEN
+    RAISE EXCEPTION 'game_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_expected_token IS NULL
+     OR p_manager_token IS NULL
+     OR v_expected_token <> p_manager_token THEN
+    RAISE EXCEPTION 'manager_token_required' USING ERRCODE = '28000';
+  END IF;
+
+  -- Snapshot the round's current claim + free-guess state up front. These serve
+  -- both the validation below and, when the combined write is skipped, the
+  -- return values (unchanged claims).
+  SELECT gr.ended_at, gr.title_claimed_by, gr.artist_claimed_by, gr.free_guess_active
+    INTO v_round_ended, v_title_claimed, v_artist_claimed, v_free_guess
+    FROM game_rounds gr
+   WHERE gr.id = p_round_id AND gr.game_code = p_game_code;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'round_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_round_ended IS NOT NULL THEN
+    RAISE EXCEPTION 'round_already_ended' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT ag.buzzed_team_id INTO v_team_id
+    FROM active_games ag
+   WHERE ag.game_code = p_game_code;
+
+  IF v_team_id IS NULL THEN
+    RAISE EXCEPTION 'no_buzz_to_score' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0
+     AND (COALESCE(p_title, 0) > 0 OR COALESCE(p_artist, 0) > 0) THEN
+    RAISE EXCEPTION 'wrong_buzz_with_correct' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_title, 0) > 0 AND v_title_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'title_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+  IF COALESCE(p_artist, 0) > 0 AND v_artist_claimed IS NOT NULL THEN
+    RAISE EXCEPTION 'artist_already_claimed' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    IF v_free_guess THEN
+      v_delta := 0;
+    ELSE
+      v_delta := -p_wrong_buzz;
+    END IF;
+    v_outcome := 'wrong';
+  ELSIF COALESCE(p_title, 0) > 0 AND COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_title + p_artist;
+    v_outcome := 'title_artist';
+  ELSIF COALESCE(p_title, 0) > 0 THEN
+    v_delta := p_title;
+    v_outcome := 'title';
+  ELSIF COALESCE(p_artist, 0) > 0 THEN
+    v_delta := p_artist;
+    v_outcome := 'artist';
+  ELSE
+    v_delta := 0;
+    v_outcome := NULL;
+  END IF;
+
+  IF v_outcome IN ('title', 'artist', 'title_artist') THEN
+    v_new_free_guess := true;
+  ELSE
+    v_new_free_guess := false;
+  END IF;
+
+  -- Apply the score change and read back the new total in one statement on the
+  -- scoring path; only fall back to a plain read when the score is unchanged
+  -- (wrong-with-free-guess, or a no-op continue).
+  IF v_delta <> 0 THEN
+    UPDATE game_teams SET score = score + v_delta WHERE id = v_team_id
+    RETURNING score INTO v_score;
+  ELSE
+    SELECT gt.score INTO v_score FROM game_teams gt WHERE gt.id = v_team_id;
+  END IF;
+
+  -- One combined game_rounds write. Each column keeps its current value unless
+  -- this attempt changes it (CASE ELSE gr.<col>); free_guess_active is always
+  -- recomputed. The whole statement is skipped when nothing changes, so a no-op
+  -- Continue emits no ROUND_CHANGE. RETURNING feeds the return row without a
+  -- second SELECT. The `gr` alias qualifies column reads so they are never
+  -- ambiguous with the same-named RETURNS TABLE output columns.
+  IF COALESCE(p_title, 0) > 0
+     OR COALESCE(p_artist, 0) > 0
+     OR COALESCE(p_wrong_buzz, 0) > 0
+     OR v_new_free_guess IS DISTINCT FROM COALESCE(v_free_guess, false) THEN
+    UPDATE game_rounds gr
+       SET title_claimed_by   = CASE WHEN COALESCE(p_title, 0) > 0  THEN v_team_id ELSE gr.title_claimed_by END,
+           title_points       = CASE WHEN COALESCE(p_title, 0) > 0  THEN p_title   ELSE gr.title_points END,
+           artist_claimed_by  = CASE WHEN COALESCE(p_artist, 0) > 0 THEN v_team_id ELSE gr.artist_claimed_by END,
+           artist_points      = CASE WHEN COALESCE(p_artist, 0) > 0 THEN p_artist  ELSE gr.artist_points END,
+           wrong_buzz_penalty = CASE WHEN COALESCE(p_wrong_buzz, 0) > 0 THEN p_wrong_buzz ELSE gr.wrong_buzz_penalty END,
+           free_guess_active  = v_new_free_guess
+     WHERE gr.id = p_round_id
+    RETURNING gr.title_claimed_by, gr.artist_claimed_by
+      INTO v_title_claimed, v_artist_claimed;
+  END IF;
+
+  IF v_outcome IS NOT NULL THEN
+    INSERT INTO game_round_attempts (round_id, game_code, team_id, outcome, points_delta)
+    VALUES (p_round_id, p_game_code, v_team_id, v_outcome, v_delta);
+  END IF;
+
+  IF COALESCE(p_wrong_buzz, 0) > 0 THEN
+    UPDATE active_games
+       SET buzzed_team_id = NULL, locked_at = NULL
+     WHERE game_code = p_game_code;
+  ELSIF v_outcome IN ('title', 'artist', 'title_artist') THEN
+    UPDATE active_games
+       SET locked_at = now()
+     WHERE game_code = p_game_code;
+  END IF;
+
+  RETURN QUERY SELECT v_team_id, v_delta, COALESCE(v_score, 0),
+                      v_title_claimed, v_artist_claimed;
+END $$;
+
+-- Re-grant EXECUTE (idempotent; CREATE OR REPLACE already preserved it).
+GRANT EXECUTE ON FUNCTION award_attempt(text, uuid, integer, integer, integer, uuid)
+  TO anon, authenticated, service_role;

--- a/docs/rpc-functions.md
+++ b/docs/rpc-functions.md
@@ -2,7 +2,7 @@
 
 The eleven PL/pgSQL functions that hold the system's logic. Each is callable as a Postgres function and exposed via Supabase PostgREST RPC. Together they encode every state-changing operation in the game.
 
-Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token), and `db/migrations/035_buzz_in_drop_round_update.sql` (dropped the now-dead `game_rounds.buzzed_team_id` mirror-write from `buzz_in` to halve buzz-path Realtime fan-out).
+Functions live in `db/migrations/005_rpc_functions.sql` (the original five), `db/migrations/014_scoring_revamp.sql` (added `award_bonus`, retired `source/timeout` shape of the old award function), `db/migrations/016_multi_buzz_rounds.sql` (replaced the one-shot `award_points` with multi-buzz `award_attempt` + `end_round`), `db/migrations/018_split_attempt_release.sql` (split scoring from buzz-lock release: added `release_buzz_lock` and scoped `award_attempt`'s lock-clear to the wrong-buzz path), `db/migrations/019_refresh_locked_at_on_correct.sql` (`award_attempt` refreshes `locked_at` on a correct attempt so the floor-holding team's answer countdown restarts for the remaining token), `db/migrations/035_buzz_in_drop_round_update.sql` (dropped the now-dead `game_rounds.buzzed_team_id` mirror-write from `buzz_in` to halve buzz-path Realtime fan-out), and `db/migrations/036_award_attempt_collapse_writes.sql` (collapsed `award_attempt`'s per-round writes into one combined `UPDATE … RETURNING`).
 
 ## 0. Conventions
 
@@ -196,10 +196,10 @@ Called **direct from the manager browser** via Supabase PostgREST RPC (as of mig
 CREATE OR REPLACE FUNCTION award_attempt(
   p_game_code     text,
   p_round_id      uuid,
-  p_title         integer DEFAULT 0,   -- 0 or 10
-  p_artist        integer DEFAULT 0,   -- 0 or 5
-  p_wrong_buzz    integer DEFAULT 0,   -- 0 or 3 (deducted)
-  p_manager_token uuid                 -- required, NO default: a default would make this 6-arg overload ambiguous with 5-arg calls (Postgres 42725); see mig 021
+  p_title         integer,             -- 0 or 10
+  p_artist        integer,             -- 0 or 5
+  p_wrong_buzz    integer,             -- 0 or 3 (deducted)
+  p_manager_token uuid                 -- NONE of the 6 args carry a DEFAULT: a default on any would make this 6-arg overload ambiguous with 5-arg calls (Postgres 42725); see mig 021. The frontend always sends all six.
 )
 RETURNS TABLE(
   team_id            uuid,
@@ -221,6 +221,7 @@ Behavior:
 - `p_wrong_buzz > 0 AND (p_title > 0 OR p_artist > 0)` → raises `P0001 wrong_buzz_with_correct`.
 - `p_title > 0` while `title_claimed_by` is already set → raises `P0001 title_already_claimed`. Same shape for `artist_already_claimed`.
 - On success: applies score delta to the buzzed team, marks `title_claimed_by` / `artist_claimed_by` if applicable, and inserts a `game_round_attempts` row.
+- **Write shape** (migration 036): all per-round column changes (title/artist claim + points, `wrong_buzz_penalty`, `free_guess_active`) are committed in **one** combined `UPDATE game_rounds` computed from branch vars via `CASE` (each unchanged column keeps its value); the statement is **skipped entirely** when nothing changes (no toggles, no wrong, `free_guess_active` unchanged), so a no-op Continue emits zero `game_rounds` writes. The team-score read and the returned claim columns fold into `RETURNING` (the score UPDATE's on the scoring path, the combined UPDATE's for the claims) rather than trailing `SELECT`s. This is a pure Realtime/round-trip economy change — a Correct Song emits one `ROUND_CHANGE` instead of two — with identical scoring behavior.
 - **Buzz-lock handling** (migration 018, refined by migration 019): only the wrong-buzz path clears `active_games.buzzed_team_id` and `locked_at`. A correct `title` / `artist` / `title_artist` attempt leaves `buzzed_team_id` in place — the answering team retains the floor for the other token until the manager presses Continue (`release_buzz_lock`) or Wrong, or until `start_round` defensively clears the lock for the next song — but it **refreshes `locked_at = now()`** so the clients' answer countdown restarts for the remaining token (migration 019). The no-op continue case (no toggles, no `wrong_buzz`) leaves the lock untouched. Before 018 the lock was always cleared regardless of outcome.
 - **Free-guess flag** (`game_rounds.free_guess_active`, migration 017): if `p_wrong_buzz > 0` AND `free_guess_active = true`, the penalty is waived (`points_delta = 0`); the attempt is still recorded with `outcome = 'wrong'`. After processing, the function sets `free_guess_active = true` if the outcome was correct (`title` / `artist` / `title_artist`) and `false` otherwise. So the flag is consumed by every attempt and re-armed by every correct one.
 

--- a/tests/db/test_award_attempt.py
+++ b/tests/db/test_award_attempt.py
@@ -368,6 +368,75 @@ async def test_award_attempt_free_guess_reactivates_on_subsequent_correct(
     assert rows[0]["points_delta"] == 0
 
 
+# ----- migration 036: collapse writes into one combined UPDATE ---------------
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_combined_update_preserves_unset_columns(
+    db: asyncpg.Connection,
+) -> None:
+    """Migration 036 folds the per-token writes into one CASE-based UPDATE. A
+    title-only attempt must set title_claimed_by/title_points + free_guess_active
+    while leaving the artist columns and wrong_buzz_penalty untouched; a later
+    wrong on the same round must flip free_guess_active off and stamp the penalty
+    while KEEPING the earlier title claim."""
+    game_code = await create_test_game(db, status="playing")
+    t1 = await create_test_team(db, game_code, name="T1")
+    t2 = await create_test_team(db, game_code, name="T2")
+    round_id = await _start_round_and_buzz(db, game_code, t1)
+
+    await _attempt(db, game_code, round_id, 10, 0, 0)
+    row = await db.fetchrow(
+        "SELECT title_claimed_by, title_points, artist_claimed_by, artist_points, "
+        "wrong_buzz_penalty, free_guess_active FROM game_rounds WHERE id = $1",
+        round_id,
+    )
+    assert row["title_claimed_by"] == t1
+    assert row["title_points"] == 10
+    assert row["artist_claimed_by"] is None      # untouched by a title-only attempt
+    assert row["artist_points"] == 0
+    assert row["wrong_buzz_penalty"] == 0
+    assert row["free_guess_active"] is True       # armed by the correct attempt
+
+    # A wrong on the same round: penalty is waived (free-guess), free_guess flips
+    # off, and the earlier title claim is preserved (CASE ELSE keeps it).
+    await _force_buzz(db, game_code, round_id, t2)
+    await _attempt(db, game_code, round_id, 0, 0, 3)
+    row2 = await db.fetchrow(
+        "SELECT title_claimed_by, wrong_buzz_penalty, free_guess_active "
+        "FROM game_rounds WHERE id = $1",
+        round_id,
+    )
+    assert row2["title_claimed_by"] == t1         # unchanged
+    assert row2["wrong_buzz_penalty"] == 3
+    assert row2["free_guess_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_award_attempt_noop_continue_writes_nothing_to_round(
+    db: asyncpg.Connection,
+) -> None:
+    """A no-toggle, no-wrong call with free_guess already false must not write
+    game_rounds at all (mig 036): the round row is byte-identical afterwards, so
+    no redundant ROUND_CHANGE is fanned out."""
+    game_code = await create_test_game(db, status="playing")
+    team_id = await create_test_team(db, game_code)
+    round_id = await _start_round_and_buzz(db, game_code, team_id)
+
+    before = await db.fetchrow(
+        "SELECT title_claimed_by, artist_claimed_by, title_points, artist_points, "
+        "wrong_buzz_penalty, free_guess_active FROM game_rounds WHERE id = $1",
+        round_id,
+    )
+    await _attempt(db, game_code, round_id, 0, 0, 0)
+    after = await db.fetchrow(
+        "SELECT title_claimed_by, artist_claimed_by, title_points, artist_points, "
+        "wrong_buzz_penalty, free_guess_active FROM game_rounds WHERE id = $1",
+        round_id,
+    )
+    assert dict(before) == dict(after)
+
+
 # ----- migration 018: split scoring from buzz-lock release ------------------
 
 


### PR DESCRIPTION
## Summary

Phase 3 · T3.2 (`I-Award1UPDATE`). Migration 036 collapses `award_attempt`'s per-round writes.

Before (mig 034 body), a single "Correct Song" click ran up to **four** `UPDATE game_rounds` statements — the title claim, a redundant standalone `free_guess_active` write (fired on *every* call, even when unchanged), plus artist / wrong-buzz writes on their paths — then **two trailing `SELECT`s** to re-read the team score and the token-claim columns for the return row. Each `game_rounds` UPDATE is a separate Realtime `ROUND_CHANGE` fanned out to every client (`game_rounds` is published with `REPLICA IDENTITY FULL`), and the SELECTs are extra round-trips inside the hot manager click.

After: **one** combined `UPDATE game_rounds` computes every changed column from branch vars via `CASE` (each unset column keeps its value via `ELSE gr.<col>`), and `RETURNING` feeds the claim columns straight back — no trailing SELECT. The team score reads back through the score UPDATE's `RETURNING` on the scoring path. The combined write is **skipped entirely** when nothing changes, so:

- **Correct Song / Artist / soundtrack**: one `ROUND_CHANGE` instead of two.
- **No-op Continue** (no toggles, no wrong, `free_guess_active` already false): **zero** `game_rounds` writes instead of one.

Behavior is preserved exactly — all guards, the free-guess −3 waiver (mig 017), the attempts-row insert, and the buzz-lock handling (mig 018/019: wrong clears, correct refreshes `locked_at`, no-op leaves it untouched) are unchanged. The 6-arg tokenised signature is identical (no DEFAULTs — mig-021 lesson); the token lookup still `LEFT JOIN`s `game_secrets` (mig 034). Docs: `rpc-functions.md §3` (write-shape note + corrected the stale `DEFAULT 0` drift in the signature block).

No user-visible behavior change (no CHANGELOG entry): scores, toasts, and round flow are identical; this removes wasted events + reads.

## Test plan

- `tests/db/test_award_attempt.py` green via testcontainers (31 passed), including every existing scenario (title / artist / both / soundtrack / wrong / free-guess / no-op continue / locked_at refresh / token validation).
- Two new tests: `test_award_attempt_combined_update_preserves_unset_columns` (title-only leaves artist columns + penalty untouched, arms free-guess; a later wrong flips free-guess off and stamps the penalty while keeping the title claim) and `test_award_attempt_noop_continue_writes_nothing_to_round` (round row byte-identical after a no-op continue).
- Migration idempotency: applied to a local Supabase stack, re-applied 036 twice with no error; `pg_get_functiondef` confirms the deployed body contains exactly **one** `UPDATE game_rounds` (down from up to four).
- `run-stress` + `run-e2e` labels: buzz-race 100× loop and the Playwright multi-context suite (which exercises `award_attempt` via `multi_buzz_round`) run on this PR.
