### PR TITLE
Phase 3 · T3.3: drop game_round_attempts from Realtime publication + RLS-lock it

### DIFF
--- a/db/migrations/037_lock_down_game_round_attempts.sql
+++ b/db/migrations/037_lock_down_game_round_attempts.sql
@@ -1,0 +1,54 @@
+-- 037_lock_down_game_round_attempts.sql
+-- Perf + defense-in-depth (Phase 3, I-AttemptsPub / T-AttemptsRLS):
+--   (1) remove game_round_attempts from the supabase_realtime publication, and
+--   (2) enable RLS + revoke anon/authenticated base privileges on it.
+--
+-- game_round_attempts (mig 016) records one row per scored buzz for future
+-- analytics (e.g. an X-Streaks flame badge). Mig 016 added it to the
+-- supabase_realtime publication with REPLICA IDENTITY FULL -- but NOTHING
+-- subscribes to it: the frontend's useGameChannel subscribes only to
+-- active_games / game_teams / game_rounds. So Supabase WAL-decodes and broadcasts
+-- a full attempts row on every scored buzz for zero consumers -- pure
+-- Realtime-quota + WAL waste. Drop it from the publication. If X-Streaks is ever
+-- built it re-adds the table to the publication deliberately, as part of that
+-- feature (see docs/planning/03-features.md).
+--
+-- While here, close a latent gap: mig 016 created game_round_attempts WITHOUT
+-- enabling RLS, and mig 006 never granted it to anon -- but hosted Supabase's
+-- bootstrap auto-grants base privileges on every new public table to
+-- anon/authenticated, so on prod anon could read (and write) this table directly,
+-- with no RLS to stop it. It holds no secrets (analytics only) and the app never
+-- reads it, so impact was low, but this applies the same posture as game_secrets
+-- (mig 034) and game_history* (mig 033): RLS ON with no policy (deny-all) + an
+-- explicit REVOKE so anon gets a hard permission-denied rather than an
+-- RLS-empty result. The award_attempt INSERT is unaffected -- it runs SECURITY
+-- DEFINER as the table owner, bypassing both RLS and GRANTs.
+--
+-- The anon/authenticated roles are created by earlier migrations (006/020/033),
+-- which always run before this one, so no defensive CREATE ROLE is needed here
+-- (mirrors mig 034).
+--
+-- Idempotent: the publication drop is guarded on current membership; ENABLE RLS
+-- / REVOKE / GRANT are naturally idempotent.
+
+-- 1. Remove from the Realtime publication (guarded: only when present, and only
+--    when the publication exists at all -- vanilla Postgres in testcontainers has
+--    no supabase_realtime publication).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+     AND EXISTS (
+       SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime' AND schemaname = 'public'
+          AND tablename = 'game_round_attempts'
+     ) THEN
+    ALTER PUBLICATION supabase_realtime DROP TABLE public.game_round_attempts;
+  END IF;
+END $$;
+
+-- 2. Lock it down. RLS ON with no policy => anon/authenticated see nothing;
+--    REVOKE the base privileges hosted-Supabase auto-grants. Keep service_role
+--    able to read it for future analytics; award_attempt inserts as owner.
+ALTER TABLE game_round_attempts ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON game_round_attempts FROM anon, authenticated;
+GRANT SELECT, INSERT ON game_round_attempts TO service_role;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -286,13 +286,15 @@ Each round records `title_claimed_by`, `artist_claimed_by` (uuid refs to the tea
 
 ### `game_round_attempts`
 
-One row per `award_attempt` call: `(round_id, game_code, team_id, outcome, points_delta, created_at)`. `outcome` is one of `'title' | 'artist' | 'title_artist' | 'wrong'`. Insert-only; cascade-deletes with the round. Used to reconstruct per-buzz round detail (e.g. for a future "round breakdown" UI).
+One row per `award_attempt` call: `(round_id, game_code, team_id, outcome, points_delta, created_at)`. `outcome` is one of `'title' | 'artist' | 'title_artist' | 'wrong'`. Insert-only; cascade-deletes with the round. Used to reconstruct per-buzz round detail (e.g. for a future "round breakdown" or streaks UI).
+
+**Access (mig 037):** analytics-only. The app never reads this table, so it is **operator-only** — RLS enabled with no policy + no anon `GRANT` (same posture as `game_secrets` / `game_history*`) — and it is **not** in the `supabase_realtime` publication. Migration 016 originally published it (`REPLICA IDENTITY FULL`) and left it without RLS; mig 037 removed it from the publication (it had zero subscribers, so every scored buzz was WAL-decoded and broadcast for nothing) and locked it down. `award_attempt` still inserts rows because it runs SECURITY DEFINER as the table owner, bypassing RLS/GRANTs. A future streaks feature re-adds it to the publication deliberately.
 
 The 014 migration dropped `source_points` and `timeout_penalty` columns. The 016 migration retired the one-shot `award_points` model in favour of multi-buzz `award_attempt` + explicit `end_round`.
 
 ## 5. Row-Level Security (summary)
 
-Two principals: `anon` (browser) and `service_role` (FastAPI). All tables have RLS enabled; `anon` gets SELECT-only on the catalog and live-game tables; mutations are exclusively via service_role or via the `buzz_in` RPC (the only function `anon` is granted EXECUTE on). The durable history tables (`game_history*`, mig 033) are the exception: RLS on with **no `anon` policy at all**, so they are operator-only (read via the service role / Supabase SQL editor).
+Two principals: `anon` (browser) and `service_role` (FastAPI). All tables have RLS enabled; `anon` gets SELECT-only on the catalog and live-game tables; mutations are exclusively via service_role or via the `buzz_in` RPC (the only function `anon` is granted EXECUTE on). The exceptions are the durable history tables (`game_history*`, mig 033), the secret table (`game_secrets`, mig 034), and the per-buzz analytics log (`game_round_attempts`, mig 037): each has RLS on with **no `anon` policy at all**, so they are operator-only (read via the service role / Supabase SQL editor).
 
 Full policy DDL and threat model: see **`security-rls.md`**.
 
@@ -338,7 +340,10 @@ db/migrations/
 ├── 017_free_guess_flag.sql   -- per-round free-guess flag; waives -3 after first correct
 │   … 018–032: manager-token RPCs, browser-direct RPC migration, soundtrack/decade filters, etc.
 ├── 033_game_history.sql      -- durable game-history archive: game_history*, archive_game(); end_game + cleanup sweep into it
-└── 034_game_secrets.sql      -- move manager_token off active_games into anon-invisible game_secrets (D-1 leak fix)
+├── 034_game_secrets.sql      -- move manager_token off active_games into anon-invisible game_secrets (D-1 leak fix)
+├── 035_buzz_in_drop_round_update.sql   -- drop the dead game_rounds.buzzed_team_id mirror-write from buzz_in
+├── 036_award_attempt_collapse_writes.sql -- collapse award_attempt's per-round writes into one UPDATE...RETURNING
+└── 037_lock_down_game_round_attempts.sql -- remove game_round_attempts from the Realtime publication + enable RLS
 ```
 
 All migrations are written to be idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. Re-running them is safe.

--- a/docs/planning/03-features.md
+++ b/docs/planning/03-features.md
@@ -24,7 +24,7 @@ Tiers below are the recommended build order once Phases 1–4 (perf + resilience
 
 ## Tier 3 — Medium impact, involves the DB / additive migration
 
-- **X-Streaks · Team streak "on fire" badge.** `[M, medium]` `game_round_attempts` already records every buzz outcome per team but the frontend never subscribes it. Add it as a 4th `postgres_changes` stream, derive consecutive-correct streaks, show a flame badge on the display. (Note: this re-introduces a subscriber for `game_round_attempts` — do it deliberately *after* I-AttemptsPub, re-adding the table to the publication as part of this feature.)
+- **X-Streaks · Team streak "on fire" badge.** `[M, medium]` `game_round_attempts` already records every buzz outcome per team but the frontend never subscribes it. Add it as a 4th `postgres_changes` stream, derive consecutive-correct streaks, show a flame badge on the display. (Note: this re-introduces a subscriber for `game_round_attempts` — do it deliberately *after* I-AttemptsPub. Migration 037 removed the table from the `supabase_realtime` publication and RLS-locked it (analytics-only, zero subscribers); this feature must re-add it to the publication **and** grant/loosen anon read via a new migration, as a deliberate part of the work.)
 - **X-GenreSpotlight · Per-round genre spotlight (+ optional roulette).** `[M, medium]` `select_next_song` already picks a random genre then song but discards which genre. Add the chosen genre name/slug to the `RETURNS TABLE` (purely additive `CREATE OR REPLACE`, PostgREST routing unchanged) so the display can announce "This round: 80s Rock." Roulette mode is a fun UI layer on top.
 
 ## Tier 4 — Strategic — OUT OF SCOPE for now (resolved 2026-07-04)

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -40,12 +40,13 @@ Two distinct shared secrets gate FastAPI endpoints. Both checked with `secrets.c
 | `active_games`  | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
 | `game_teams`    | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
 | `game_rounds`   | ✅ (any row by `game_code`) | ❌ | ❌ | ❌ |
+| `game_round_attempts` *(mig 037)* | ❌ (analytics-only) | ❌ | ❌ | ❌ |
 | `game_secrets` *(mig 034)*        | ❌ (**host credential**) | ❌ | ❌ | ❌ |
 | `game_history` *(mig 033)*        | ❌ (operator-only) | ❌ | ❌ | ❌ |
 | `game_history_teams` *(mig 033)*  | ❌ (operator-only) | ❌ | ❌ | ❌ |
 | `game_history_songs` *(mig 033)*  | ❌ (operator-only) | ❌ | ❌ | ❌ |
 
-`service_role` bypasses all RLS. The tables `anon` cannot read are `game_secrets` (mig 034) and the durable `game_history*` tables (mig 033): each has RLS enabled with no read policy and no anon `GRANT`. **`game_secrets` holds the per-game `manager_token`** — it was moved off `active_games` (mig 034) precisely because `active_games` is anon-readable **and** in the `supabase_realtime` publication, so a token stored there was fanned out to every subscribed player over the WebSocket and returned by the anon `select *` hydrate. `game_secrets` is also deliberately **not** in the Realtime publication. The host-facing "export songs" feature reads the live ephemeral tables in the host's own session, not these.
+`service_role` bypasses all RLS. The tables `anon` cannot read are `game_secrets` (mig 034), the durable `game_history*` tables (mig 033), and `game_round_attempts` (mig 037 — the per-buzz analytics log; the app never reads it and it's not in the Realtime publication, so it's locked to operators/service-role): each has RLS enabled with no read policy and no anon `GRANT`. **`game_secrets` holds the per-game `manager_token`** — it was moved off `active_games` (mig 034) precisely because `active_games` is anon-readable **and** in the `supabase_realtime` publication, so a token stored there was fanned out to every subscribed player over the WebSocket and returned by the anon `select *` hydrate. `game_secrets` is also deliberately **not** in the Realtime publication. The host-facing "export songs" feature reads the live ephemeral tables in the host's own session, not these.
 
 | RPC function | anon EXECUTE | service_role EXECUTE |
 |---|---|---|
@@ -89,6 +90,11 @@ CREATE POLICY "anon_read_game_rounds"  ON game_rounds  FOR SELECT TO anon USING 
 ALTER TABLE game_history       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE game_history_teams ENABLE ROW LEVEL SECURITY;
 ALTER TABLE game_history_songs ENABLE ROW LEVEL SECURITY;
+
+-- Per-buzz analytics log (mig 016): same operator-only posture as of mig 037.
+-- RLS on with no policy; award_attempt inserts rows as the table owner (SECURITY
+-- DEFINER), so the deny-all policy never blocks the game.
+ALTER TABLE game_round_attempts ENABLE ROW LEVEL SECURITY;
 ```
 
 No `INSERT`, `UPDATE`, or `DELETE` policies are created for `anon` → all writes are denied by default. No policy at all is created for the `game_history*` tables → anon reads are denied too.
@@ -117,12 +123,17 @@ GRANT SELECT, INSERT, UPDATE, DELETE
   ON game_history, game_history_teams, game_history_songs
   TO service_role;
 
+-- Per-buzz analytics log (mig 037): service_role read/insert only.
+GRANT SELECT, INSERT ON game_round_attempts TO service_role;
+
 -- Defense in depth: hosted Supabase auto-grants base privileges on every new
 -- public table to anon/authenticated. RLS-with-no-policy already denies anon
 -- every row, but we ALSO revoke the base privilege so anon gets a hard
 -- permission-denied rather than an RLS-empty result -- the privacy boundary
--- doesn't rest on RLS alone. No-op on a bare-Postgres stack.
-REVOKE ALL ON game_history, game_history_teams, game_history_songs
+-- doesn't rest on RLS alone. No-op on a bare-Postgres stack. game_round_attempts
+-- (mig 037) is added here: mig 016 created it with NO RLS, so on hosted Supabase
+-- anon could read/write it directly until this revoke landed.
+REVOKE ALL ON game_history, game_history_teams, game_history_songs, game_round_attempts
   FROM anon, authenticated;
 ```
 
@@ -158,6 +169,8 @@ For Sound Clash, `anon` can SELECT any game row → anon receives every game's e
 - Events contain no sensitive data (just team names and scores).
 
 If we ever add per-user scoping, RLS policies become more restrictive and Realtime auto-respects them.
+
+**Publication membership.** Only the three tables the frontend actually subscribes to — `active_games`, `game_teams`, `game_rounds` — are in the `supabase_realtime` publication. `game_secrets` (mig 034) and `game_round_attempts` (mig 037) are deliberately **out** of it: the former is a secret, the latter is an analytics log with no subscriber, so publishing it only burned Realtime quota (a full row WAL-decoded and broadcast on every scored buzz, for nobody). A future streaks feature would re-add `game_round_attempts` to the publication as part of that work.
 
 ## 4. Threat Model
 

--- a/tests/db/test_rls_anon.py
+++ b/tests/db/test_rls_anon.py
@@ -30,6 +30,73 @@ HISTORY_TABLES = (
 )
 
 
+async def _seed_attempt_row(db: asyncpg.Connection) -> None:
+    """Insert one game_round_attempts row via service_role, so the update/delete
+    denial tests have a row to (fail to) touch."""
+    game_code = await create_test_game(db)
+    team_id = await create_test_team(db, game_code)
+    song_id = await create_test_song(db)
+    round_id = await db.fetchval(
+        "INSERT INTO game_rounds (game_code, round_number, song_id) "
+        "VALUES ($1, 1, $2) RETURNING id",
+        game_code,
+        song_id,
+    )
+    await db.execute(
+        "INSERT INTO game_round_attempts (round_id, game_code, team_id, outcome, points_delta) "
+        "VALUES ($1, $2, $3, 'wrong', -3)",
+        round_id,
+        game_code,
+        team_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_anon_cannot_read_attempts(anon_conn: asyncpg.Connection) -> None:
+    """game_round_attempts is analytics-only: removed from the Realtime publication
+    (mig 037) and RLS-locked with no anon grant, so anon SELECT is denied outright
+    -- in contrast to the ephemeral game tables it can read freely. The
+    award_attempt RPC still inserts rows as the table owner (SECURITY DEFINER)."""
+    with pytest.raises(
+        (asyncpg.InsufficientPrivilegeError, asyncpg.exceptions.InsufficientPrivilegeError)
+    ):
+        await anon_conn.execute("SELECT * FROM game_round_attempts")
+
+
+@pytest.mark.asyncio
+async def test_anon_cannot_insert_attempts(anon_conn: asyncpg.Connection) -> None:
+    with pytest.raises(
+        (asyncpg.InsufficientPrivilegeError, asyncpg.exceptions.InsufficientPrivilegeError)
+    ):
+        await anon_conn.execute(
+            "INSERT INTO game_round_attempts "
+            "(round_id, game_code, team_id, outcome, points_delta) "
+            "VALUES (gen_random_uuid(), 'ZZZZZZ', gen_random_uuid(), 'wrong', -3)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_anon_cannot_update_attempts(
+    db: asyncpg.Connection, anon_conn: asyncpg.Connection
+) -> None:
+    await _seed_attempt_row(db)
+    with pytest.raises(
+        (asyncpg.InsufficientPrivilegeError, asyncpg.exceptions.InsufficientPrivilegeError)
+    ):
+        await anon_conn.execute("UPDATE game_round_attempts SET points_delta = 0")
+
+
+@pytest.mark.asyncio
+async def test_anon_cannot_delete_attempts(
+    db: asyncpg.Connection, anon_conn: asyncpg.Connection
+) -> None:
+    await _seed_attempt_row(db)
+    with pytest.raises(
+        (asyncpg.InsufficientPrivilegeError, asyncpg.exceptions.InsufficientPrivilegeError)
+    ):
+        await anon_conn.execute("DELETE FROM game_round_attempts")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("table", HISTORY_TABLES)
 async def test_anon_cannot_read_history(


### PR DESCRIPTION
## Summary

Phase 3 · T3.3 (`I-AttemptsPub` + `T-AttemptsRLS`). Migration 037 does two things to `game_round_attempts` (the per-buzz analytics log, mig 016):

1. **Removes it from the `supabase_realtime` publication.** Mig 016 published it with `REPLICA IDENTITY FULL`, but nothing subscribes to it — `useGameChannel` subscribes only to `active_games` / `game_teams` / `game_rounds`. So Supabase WAL-decoded and broadcast a full attempts row on **every scored buzz** for zero consumers: pure Realtime-quota + WAL waste. A future streaks feature re-adds it to the publication deliberately (noted in `03-features.md`).
2. **Enables RLS + revokes anon/authenticated**, closing a latent gap: mig 016 created the table with **no RLS**, and hosted Supabase's bootstrap auto-grants base privileges on every new public table to `anon`. So on prod, anon could read the table directly (verified on a Supabase-flavored stack: it was published, RLS off, and `has_table_privilege('anon', …, 'SELECT') = true`). It holds no secrets (analytics only) and the app never reads it — low impact — but this applies the same operator-only posture as `game_secrets` (mig 034) / `game_history*` (mig 033). `award_attempt` still inserts rows because it runs SECURITY DEFINER as the table owner, bypassing RLS/GRANTs.

Docs: `security-rls.md` (RLS matrix + DDL + grants + a new "Publication membership" note), `data-model.md` (`game_round_attempts` access note + RLS summary + migration ordering), `03-features.md` (X-Streaks re-add note).

No CHANGELOG entry: internal Realtime economy + defense-in-depth on an analytics table the app never surfaces; no user-visible behavior change.

## Test plan

- **Local Supabase stack (real anon auto-grant):** applied 037 twice (idempotent); after: `game_round_attempts` **not** in the publication (0), RLS **on**, `has_table_privilege('anon', …, 'SELECT') = false`, and the 3 subscribed tables still published (3). The 4 new anon-denial tests pass here — anon gets a hard permission-denied on select/insert/update/delete (stronger than the core tables, which rely on RLS row-filtering).
- **testcontainers (CI parity):** `tests/db/test_rls_anon.py` 26/26 green, including 4 new `game_round_attempts` denial tests.
- `tests/db/test_migrations_idempotent.py` green (full 001→037 chain applied twice).
- Sanity: confirmed anon `DELETE FROM songs` on the live stack affects **0 rows** and the row survives — i.e. core-table writes are RLS-blocked, no actual anon-write vulnerability. (The pre-existing `test_anon_cannot_update/delete[core-table]` assertions fail only against real Supabase because they expect a hard permission-denied rather than RLS's 0-rows — the documented harness quirk in `.claude/rules/lessons-learned.md` (2026-05-25); those tables are untouched by this PR.)
- `run-e2e` label: Playwright multi-context runs a full game against a `supabase start` stack with 037 applied, confirming the publication change doesn't disturb live subscriptions.
