### PR TITLE
Phase 3 · T3.4: trim backstop resync to 60s + teardown-on-gone

### DIFF
--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -7,7 +7,7 @@ vi.mock("../lib/supabase", async () => {
 });
 
 import type { ActiveGame, GameRound, Team } from "../lib/types";
-import { gameReducer, useGameChannel } from "./useGameChannel";
+import { gameReducer, RESYNC_INTERVAL_MS, useGameChannel } from "./useGameChannel";
 import {
   channelMock,
   fireGame,
@@ -529,6 +529,40 @@ describe("useGameChannel - subscription", () => {
     await waitFor(() => expect(result.current.status).toBe("gone"));
   });
 
+  it("tears down the resync interval + channel once the game is gone", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const game = makeActiveGame();
+      setHydrate({ game, teams: [], rounds: [] });
+      renderHook(() => useGameChannel("ABCDEF"));
+      await act(async () => {
+        await fireSubscribed();
+      });
+      const callsBeforeGone = supabaseMock.from.mock.calls.length;
+      supabaseMock.removeChannel.mockClear();
+
+      // Game row deleted -> status gone -> the live plumbing is torn down.
+      act(() => {
+        fireGame(
+          makePayload<ActiveGame>("active_games", "DELETE", {
+            old: { game_code: "ABCDEF" },
+          }),
+        );
+      });
+      expect(supabaseMock.removeChannel).toHaveBeenCalled();
+
+      // Advancing well past the backstop interval must NOT trigger any further
+      // hydrate: the interval was cleared on teardown, so an overnight display
+      // on an ended game stops polling instead of hitting the DB forever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RESYNC_INTERVAL_MS * 2 + 1000);
+      });
+      expect(supabaseMock.from.mock.calls.length).toBe(callsBeforeGone);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("flips to reconnecting on CHANNEL_ERROR", async () => {
     const { result } = renderHook(() => useGameChannel("ABCDEF"));
     await act(async () => {
@@ -596,10 +630,10 @@ describe("useGameChannel - subscription", () => {
         await fireSubscribed();
       });
       const callsAfterInit = supabaseMock.from.mock.calls.length;
-      // Tick past one resync interval (20s); the inner setInterval callback
-      // should fire and run hydrate() once.
+      // Tick past one resync interval; the inner setInterval callback should
+      // fire and run hydrate() once.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(20_500);
+        await vi.advanceTimersByTimeAsync(RESYNC_INTERVAL_MS + 500);
       });
       // Each hydrate hits the three ephemeral tables.
       expect(supabaseMock.from.mock.calls.length).toBe(callsAfterInit + 3);

--- a/frontend/src/hooks/useGameChannel.ts
+++ b/frontend/src/hooks/useGameChannel.ts
@@ -17,12 +17,17 @@ export type ChannelStatus = "idle" | "connecting" | "subscribed" | "reconnecting
 // drops a postgres_changes event (flaky networks, a missed heartbeat that
 // silently re-joins, the free tier under load) — and a missed "a team buzzed"
 // event would strand the manager with greyed-out scoring buttons until the
-// next state change. So every 20 seconds we re-hydrate from the tables; the
+// next state change. So on a cadence we re-hydrate from the tables; the
 // reducer's HYDRATE skips the dispatch when nothing material changed, so a
-// quiet round costs ~3 REST queries per 20s with zero re-renders. Migrations
-// 009/010 fixed the original Realtime-event-loss bugs, so the resync is now a
-// true safety net, not the primary sync path.
-const RESYNC_INTERVAL_MS = 20_000;
+// quiet round costs ~3 REST queries per tick with zero re-renders.
+//
+// Migrations 009/010 fixed the original Realtime-event-loss bugs, so the resync
+// is a true safety net, not the primary sync path. It was 20s; at 60s it does
+// ~3× fewer backstop queries per visible client (a 6-team game drops from
+// ~1.2 to ~0.4 q/s) while still catching a genuinely dropped event within a
+// minute — comfortably faster than a human notices a stuck button. Exported so
+// the test can advance fake timers by exactly one interval.
+export const RESYNC_INTERVAL_MS = 60_000;
 
 // Explicit column list for the active_games hydrate — every field the reducer
 // reads, and nothing else. Deliberately NOT `select("*")`: the per-game
@@ -184,6 +189,12 @@ export function useGameChannel(gameCode: string): {
     if (!gameCode) return;
     let cancelled = false;
     let hydrated = false;
+    // Set once the game is permanently gone (row deleted / missing). Stops the
+    // backstop interval and tears the channel down so a display left open all
+    // night on an ended game doesn't keep polling + holding a subscription
+    // forever. Distinct from `cancelled` (which is unmount) — the component
+    // stays mounted showing the "ended" screen, we just stop the live plumbing.
+    let goneTornDown = false;
     // Realtime events that arrive between SUBSCRIBED and HYDRATE land on
     // state===null and are dropped by the reducer's null guards. Queue them
     // here and replay after HYDRATE; gameReducer is idempotent so replay is safe.
@@ -226,7 +237,10 @@ export function useGameChannel(gameCode: string): {
             }
           }
           dispatchOrQueue({ type: "GAME_CHANGE", payload: typed });
-          if (typed.eventType === "DELETE") setStatus("gone");
+          if (typed.eventType === "DELETE") {
+            setStatus("gone");
+            teardownLive();
+          }
         },
       )
       .on(
@@ -296,12 +310,24 @@ export function useGameChannel(gameCode: string): {
         resyncId = null;
       }
     }
+    // The game is permanently gone: stop the backstop and drop the Realtime
+    // channel so we don't poll + hold a subscription for a game that no longer
+    // exists (an overnight display on an ended game was doing exactly that).
+    // Idempotent; the effect cleanup also removes the channel (harmless twice).
+    function teardownLive(): void {
+      if (goneTornDown) return;
+      goneTornDown = true;
+      stopResync();
+      void supabase.removeChannel(
+        channel as unknown as Parameters<typeof supabase.removeChannel>[0],
+      );
+    }
     // Pause the backstop on background tabs (display in another window, a
     // player who switched to another app). When the tab becomes visible
     // again we hydrate once immediately then resume the interval — so the
     // user never sees a stale snapshot when they return.
     function onVisibilityChange(): void {
-      if (cancelled) return;
+      if (cancelled || goneTornDown) return;
       if (document.hidden) {
         stopResync();
       } else {
@@ -341,6 +367,7 @@ export function useGameChannel(gameCode: string): {
             if (authoritative) {
               setStatus("gone");
               dispatch({ type: "GAME_DELETED" });
+              teardownLive();
             }
           } else {
             dispatch({


### PR DESCRIPTION
## Summary

Phase 3 · T3.4 (`I-Resync`). Two economy fixes to `useGameChannel`'s Realtime backstop:

1. **Lengthen the backstop resync from 20s → 60s.** The interval re-hydrates the three ephemeral tables to catch a dropped `postgres_changes` event. Migrations 009/010 fixed the original event-loss bugs, so it's a true safety net, not the primary sync path — 20s was needlessly aggressive. At 60s each visible client does ~3× fewer backstop queries (a 6-team game drops from ~1.2 to ~0.4 q/s across manager + display + teams), while still catching a genuinely dropped event within a minute — far faster than a human notices a stuck button. HYDRATE returns the same state reference when nothing changed, so quiet ticks still cost zero re-renders.
2. **Tear down the interval + channel once the game is `gone`.** Previously a display left open overnight on an ended/deleted game kept firing the backstop `SELECT`s and holding a Realtime subscription forever. Now, when the game row is deleted (or an authoritative hydrate finds it missing), we stop the interval and `removeChannel` — the component stays mounted showing the "ended" screen, but the live plumbing stops. The visibility-resume path is guarded so a backgrounded-then-foregrounded gone game doesn't revive it.

No user-visible behavior change (no CHANGELOG): the game syncs identically; this cuts idle query volume and stops orphaned polling.

## Test plan

- `frontend` full suite green (368 tests): `npm run format:check && npm run lint && npm run typecheck && npm run test:run`.
- Updated the backstop test to advance fake timers by the exported `RESYNC_INTERVAL_MS` (no longer a hardcoded 20s).
- New test `tears down the resync interval + channel once the game is gone`: after an `active_games` DELETE, `removeChannel` is called and advancing fake timers well past the interval triggers **no** further hydrate.
