### PR TITLE
Phase 3 · T3.5: keep-warm immediate + visibility-aware (keep hook as documented fallback)

### DIFF
--- a/docs/free-tier-budget.md
+++ b/docs/free-tier-budget.md
@@ -100,6 +100,16 @@ Free, no quotas relevant to this project.
 | Cron jobs | 50 | Use 1 |
 | Min interval | 1 minute | We use 14 min |
 
+This 24/7 cron is the **primary** Render keepalive. The frontend `useKeepBackendWarm`
+hook (manager console only, while a game is `waiting`/`playing`) is a deliberate
+**visibility-aware fallback** on top of it (T-KeepWarm decision, Phase 3): it pings
+`/health` immediately on mount, on `visibilitychange → visible`, and every 10 min.
+The mount + on-visible pings cover the two cases the cron cannot: a host who
+deep-links straight into `/manager/game/<code>`, and a phone whose background timers
+were frozen while asleep and returns to a possibly-cold dyno right at Bonus/End.
+`/health` is unlimited + unauthenticated (§6), so the handful of extra GETs per game
+is free; if the cron is ever paused/misconfigured this is the safety net.
+
 ### 2.8 Domain (paid; not free)
 
 `soundclash.org` registration ~$10–15 / yr. The only non-free cost.

--- a/frontend/src/hooks/useKeepBackendWarm.test.ts
+++ b/frontend/src/hooks/useKeepBackendWarm.test.ts
@@ -10,59 +10,83 @@ import { KEEP_WARM_INTERVAL_MS, useKeepBackendWarm } from "./useKeepBackendWarm"
 
 const getHealthMock = vi.mocked(getHealth);
 
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => hidden });
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   getHealthMock.mockClear();
+  setHidden(false);
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  setHidden(false);
 });
 
 describe("useKeepBackendWarm", () => {
-  it("pings /health once per interval while active (no immediate ping)", () => {
+  it("pings /health immediately on mount, then once per interval, while active", () => {
     renderHook(() => useKeepBackendWarm(true));
-    expect(getHealthMock).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
+    // Immediate warm on mount (no waiting up to 10 min for the first tick).
     expect(getHealthMock).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS);
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
     expect(getHealthMock).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS);
+    expect(getHealthMock).toHaveBeenCalledTimes(3);
   });
 
   it("never pings while inactive", () => {
     renderHook(() => useKeepBackendWarm(false));
     vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 3);
+    document.dispatchEvent(new Event("visibilitychange"));
     expect(getHealthMock).not.toHaveBeenCalled();
   });
 
-  it("stops pinging after unmount", () => {
-    const { unmount } = renderHook(() => useKeepBackendWarm(true));
-    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
+  it("re-warms when the tab returns to the foreground", () => {
+    renderHook(() => useKeepBackendWarm(true));
+    expect(getHealthMock).toHaveBeenCalledTimes(1); // mount ping
+
+    // Tab hidden: visibilitychange must NOT ping.
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
     expect(getHealthMock).toHaveBeenCalledTimes(1);
+
+    // Tab visible again: fires an extra warm (mobile froze the interval while
+    // backgrounded, so this is the ping that actually matters).
+    setHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(getHealthMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops pinging (interval + visibility) after unmount", () => {
+    const { unmount } = renderHook(() => useKeepBackendWarm(true));
+    expect(getHealthMock).toHaveBeenCalledTimes(1); // mount
 
     unmount();
     vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 2);
-    expect(getHealthMock).toHaveBeenCalledTimes(1);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(getHealthMock).toHaveBeenCalledTimes(1); // nothing after unmount
   });
 
   it("stops pinging once it flips from active to inactive", () => {
     const { rerender } = renderHook(({ active }) => useKeepBackendWarm(active), {
       initialProps: { active: true },
     });
-    vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100);
-    expect(getHealthMock).toHaveBeenCalledTimes(1);
+    expect(getHealthMock).toHaveBeenCalledTimes(1); // mount ping (active)
 
     rerender({ active: false });
     vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS * 2);
+    document.dispatchEvent(new Event("visibilitychange"));
     expect(getHealthMock).toHaveBeenCalledTimes(1);
   });
 
   it("a rejected health ping does not throw", () => {
     getHealthMock.mockReturnValueOnce(Promise.reject(new Error("cold")));
-    renderHook(() => useKeepBackendWarm(true));
-    expect(() => vi.advanceTimersByTime(KEEP_WARM_INTERVAL_MS + 100)).not.toThrow();
+    expect(() => renderHook(() => useKeepBackendWarm(true))).not.toThrow();
+    // The immediate mount ping was the rejected one; swallowed by .catch.
     expect(getHealthMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useKeepBackendWarm.ts
+++ b/frontend/src/hooks/useKeepBackendWarm.ts
@@ -5,23 +5,47 @@ import { getHealth } from "../lib/api";
 // active game every hot-path action (buzz, score, next round) goes straight to
 // Supabase, so the FastAPI backend sees no traffic and goes cold mid-game --
 // and then the host's next REST call (Bonus / End game / Kick) or a late team's
-// join stalls 2-30s on cold start. HomePage already pre-warms on entry, but
-// that wears off once a long game has been running on direct-RPC traffic alone.
+// join stalls 2-30s on cold start.
 //
 // While the manager console is mounted and a game is in progress we ping
-// /health on an interval, keeping the container warm for exactly as long as a
-// game is being run (no 24/7 always-on cost — it conserves Render's free
-// monthly hours, which a cron pinger would burn). Errors are ignored: a failed
-// ping just means the next real call hits the same cold start it would have
-// hit anyway, so this is never worse than not pinging.
+// /health: immediately on mount, again whenever the tab returns to the
+// foreground, and on a 10-min interval. Errors are ignored: a failed ping just
+// means the next real call hits the same cold start it would have hit anyway,
+// so this is never worse than not pinging.
+//
+// T-KeepWarm decision (Phase 3): an external cron (cron-job.org, every 14 min --
+// see docs/free-tier-budget.md §2.7) already pings /health 24/7, so this hook is
+// *redundant* for the plain cold-start-after-idle case. We deliberately KEEP it,
+// as a cheap, visibility-aware belt-and-suspenders fallback:
+//   * the immediate mount ping warms Render for a host who deep-linked straight
+//     to /manager/game/<code> without passing through HomePage's prewarm;
+//   * the visibilitychange ping is the one the 24/7 cron cannot substitute for --
+//     mobile browsers FREEZE background timers, so a host whose phone slept for a
+//     few minutes returns to a possibly-cold dyno right when they reach for
+//     Bonus/End; re-warming inside the "tab visible again" gesture hides that.
+// Cost is a handful of extra /health GETs per game (unlimited + unauthenticated;
+// budget §6). If the cron is ever paused/misconfigured this is the safety net.
 export const KEEP_WARM_INTERVAL_MS = 10 * 60 * 1000; // 10 min, comfortably under Render's ~15 min idle
 
 export function useKeepBackendWarm(active: boolean): void {
   useEffect(() => {
     if (!active) return undefined;
-    const id = window.setInterval(() => {
+    const ping = (): void => {
       void getHealth().catch(() => undefined);
-    }, KEEP_WARM_INTERVAL_MS);
-    return () => window.clearInterval(id);
+    };
+    // Warm immediately when the game becomes active rather than waiting up to
+    // 10 min for the first interval tick.
+    ping();
+    // Re-warm the moment the tab returns to the foreground (mobile freezes
+    // background intervals, so the tick that should have fired never did).
+    const onVisible = (): void => {
+      if (!document.hidden) ping();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    const id = window.setInterval(ping, KEEP_WARM_INTERVAL_MS);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, [active]);
 }

--- a/frontend/src/pages/ManagerConsolePage.test.tsx
+++ b/frontend/src/pages/ManagerConsolePage.test.tsx
@@ -22,6 +22,9 @@ vi.mock("../lib/api", () => ({
   },
   awardBonus: vi.fn(),
   endGame: vi.fn(),
+  // useKeepBackendWarm pings this immediately on mount (T3.5); mock it so the
+  // console's keep-warm ping is a no-op in tests.
+  getHealth: vi.fn(() => Promise.resolve({ status: "ok", version: "test", supabase: "ok" })),
 }));
 
 vi.mock("../hooks/useManagerActions", () => ({


### PR DESCRIPTION
## Summary

Phase 3 · T3.5 (`I-Warm` + the `T-KeepWarm` decision). `useKeepBackendWarm` now pings `/health`:

- **immediately on mount** (when the game is `waiting`/`playing`) — a host who deep-links straight to `/manager/game/<code>` no longer waits up to 10 min for the first interval tick to warm Render;
- **on `visibilitychange → visible`** — mobile browsers freeze background timers, so a host whose phone slept for a few minutes returns to a possibly-cold dyno right when they reach for Bonus/End; re-warming inside the "tab visible again" moment hides that cold start;
- **on the existing 10-min interval** (unchanged).

**T-KeepWarm decision (kept, documented):** an external cron (cron-job.org, every 14 min) already pings `/health` 24/7, so this hook is redundant for the plain cold-start-after-idle case. We deliberately **keep** it as a cheap, visibility-aware belt-and-suspenders fallback — the mount + on-visible pings cover the two cases the cron cannot (deep-link entry; frozen mobile background timers), and if the cron is ever paused/misconfigured this is the safety net. `/health` is unlimited + unauthenticated, so the handful of extra GETs per game is free. Documented in the hook and in `free-tier-budget.md §2.7`.

No CHANGELOG entry: reliability tweak on top of the existing 24/7 keepalive; no user-visible behavior change or new capability.

## Test plan

- `frontend` full suite green (369 tests): `npm run format:check && npm run lint && npm run typecheck && npm run test:run`.
- `useKeepBackendWarm` tests rewritten for the new behavior: immediate mount ping, interval ping, `visibilitychange → visible` ping (and no ping while hidden), teardown on unmount + on active→inactive, rejected ping doesn't throw.
- Fixed `ManagerConsolePage.test.tsx`'s `../lib/api` mock to include `getHealth` — previously the ping only fired inside the 10-min interval (never advanced in tests); now it fires on mount, so the mock needed the export.
