### PR TITLE
Phase 3 · T2.7: memoize BuzzButton to isolate it from unrelated re-renders

### DIFF
--- a/frontend/src/components/BuzzButton.test.tsx
+++ b/frontend/src/components/BuzzButton.test.tsx
@@ -4,6 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 import { BuzzButton } from "./BuzzButton";
 
 describe("BuzzButton", () => {
+  it("is wrapped in React.memo so unrelated parent re-renders skip it (I-TeamRender)", () => {
+    // TeamGameplayPage re-renders on every ROUND_CHANGE; the buzzer's props are
+    // primitives + a stabilized onBuzz, so memo's shallow compare short-circuits
+    // a re-render of the latency-critical button. Guard against someone
+    // unwrapping the memo.
+    expect((BuzzButton as unknown as { $$typeof?: symbol }).$$typeof).toBe(
+      Symbol.for("react.memo"),
+    );
+  });
+
   it("renders the label and subtitle", () => {
     render(
       <BuzzButton

--- a/frontend/src/components/BuzzButton.tsx
+++ b/frontend/src/components/BuzzButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
+import { memo, useEffect, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
 import styles from "./BuzzButton.module.css";
 
 export type BuzzTone = "idle" | "locked-other" | "winner" | "waiting" | "pending";
@@ -12,7 +12,12 @@ interface Props {
   onBuzz: () => void;
 }
 
-export function BuzzButton({
+// Memoized (I-TeamRender): TeamGameplayPage re-renders on every ROUND_CHANGE
+// (title/artist claims, free_guess toggles) that doesn't affect the buzzer.
+// All props here are primitives except onBuzz, which the page stabilizes with
+// useCallback, so React.memo's shallow compare skips a re-render of the
+// latency-critical BUZZ button on those unrelated round updates.
+export const BuzzButton = memo(function BuzzButton({
   disabled,
   isBuzzing,
   label = "BUZZ",
@@ -94,4 +99,4 @@ export function BuzzButton({
       ) : null}
     </button>
   );
-}
+});

--- a/frontend/src/pages/TeamGameplayPage.tsx
+++ b/frontend/src/pages/TeamGameplayPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BuzzButton, type BuzzTone } from "../components/BuzzButton";
 import { EndScreen } from "../components/EndScreen";
@@ -63,6 +63,15 @@ export function TeamGameplayPage() {
       navigate("/", { replace: true });
     }
   }, [hydratedOnce, stored, state, status, gameCode, navigate]);
+
+  // Stable handler so the memoized BuzzButton (I-TeamRender) isn't re-rendered
+  // by a new inline arrow on every parent render. buzzer.buzz is itself a
+  // useCallback, so this only changes when the buzz identity legitimately does
+  // (round number / lock / playing state) — not on unrelated ROUND_CHANGEs.
+  // (Hoisted to a local: depending on `buzzer` directly would churn every
+  // render — useBuzzer returns a fresh object — and defeat the memo.)
+  const buzzAction = buzzer.buzz;
+  const handleBuzz = useCallback(() => void buzzAction(), [buzzAction]);
 
   if (!stored) return null;
 
@@ -149,7 +158,7 @@ export function TeamGameplayPage() {
           label={buzz.label}
           subtitle={buzz.subtitle}
           tone={buzz.tone}
-          onBuzz={() => void buzzer.buzz()}
+          onBuzz={handleBuzz}
         />
       </div>
 


### PR DESCRIPTION
## Summary

Phase 3 · T2.7 (`I-TeamRender`, carried from Phase 2 — unblocked now that `I-Buzz1UPDATE` shipped in #166). Isolates the latency-critical BUZZ button from unrelated re-renders.

`TeamGameplayPage` re-renders on every `ROUND_CHANGE` — title/artist claims, `free_guess` toggles — none of which affect the buzzer. Previously each of those re-rendered `BuzzButton` too. Two small changes fix that:

- **`BuzzButton` is wrapped in `React.memo`.** All its props are primitives (`disabled` / `isBuzzing` / `label` / `subtitle` / `tone`) except `onBuzz`, so memo's shallow compare short-circuits a re-render when nothing the button shows has changed.
- **`onBuzz` is stabilized** in `TeamGameplayPage` via `useCallback` over the hook's already-stable `buzzer.buzz` (hoisted to a local so the dep is the stable callback, not the fresh hook-result object). Without this, a new inline arrow each render would defeat the memo.

Now #166 has removed the per-buzz `game_rounds` no-op `ROUND_CHANGE`, and this keeps the remaining legitimate round updates from touching the buzzer's render path.

No user-visible behavior change (no CHANGELOG): the button behaves identically; it just re-renders less.

## Test plan

- `frontend` full suite green (370 tests): `npm run format:check && npm run lint && npm run typecheck && npm run test:run`.
- New test: `BuzzButton` is a `React.memo` component (`$$typeof === Symbol.for("react.memo")`) — guards against someone unwrapping the memo.
- Existing `BuzzButton` interaction tests (click / keyboard / pointer / disabled) and `TeamGameplayPage` tests unchanged and green.
