### PR TITLE
Docs: prune shipped T4.0 items; drop redundant Skip button from T4.1

### DIFF
--- a/docs/planning/01-fixes.md
+++ b/docs/planning/01-fixes.md
@@ -5,15 +5,13 @@ Ranked P0 (fix now / production risk) → P1 (real user-facing bug) → P2 (edge
 Legend for the perf tag on latency-adjacent items: `buzz-latency` (moves the <200ms number), `load` (time-to-playable), `smoothness` (perceived responsiveness).
 
 > **Resolved items removed 2026-07-05** (shipped in Phases 1–3; detail in git history / `CHANGELOG.md`): F-P0-1 (manager_token leak → `game_secrets`, mig 034), F-P0-2 (catalog DR backup), F-P0-4 (deploy-before-migrate outage), F-P1-8 (busy flag dropped clicks), F-P2-2 (Continue pending flag), F-P2-3 (keep-warm immediate ping). IDs are intentionally not reused.
+> **Resolved 2026-07-07** (Phase 4): F-P0-3 (deploy-during-game blank screen → `vite:preloadError` budget-guarded auto-reload + app-level `ErrorBoundary`; runbook §1.2; PR #185).
 
 ---
 
 ## P0 — Production risk
 
-### F-P0-3 · Deploy-during-game blanks the screen `[bug, P0 — hits live players on every deploy]` — ✅ RESOLVED (Phase 4 T4.0, PR #185)
-- **Evidence:** `_redirects` = `/* /index.html 200`; a stale content-hashed chunk URL returns `index.html` as `200 text/html`; `vite:preloadError` has zero handlers and there is no ErrorBoundary (`App.tsx`); routes are `React.lazy` (`App.tsx`). Confirmed live: old `/assets/index-*.js` returns 200 HTML.
-- **Failure:** a player who loaded the app before a deploy, then navigates (join → `/team/:code`), triggers a failed dynamic import → blank white screen mid-party. Every Cloudflare Pages deploy is a live-game landmine.
-- **Fix (shipped):** `frontend/src/lib/preloadError.ts` handles `vite:preloadError` → auto-reloads, guarded by a `sessionStorage` reload BUDGET (one auto-reload per incident, reset after a 5-min window). The budget is loop-proof regardless of reload-cycle timing, and when the reload can't recover (broken deploy / offline) or `sessionStorage` is unavailable it stops auto-reloading and defers to the app-level `frontend/src/components/ErrorBoundary.tsx` manual-reload CTA. Tests: `preloadError.test.ts` + `ErrorBoundary.test.tsx` (T-DeployTest). Runbook §1.2 updated: **deploying during a live game is now safe.**
+_None open._ (F-P0-3 shipped 2026-07-07 — Phase 4 T4.0, PR #185.)
 
 ---
 

--- a/docs/planning/04-tech-debt.md
+++ b/docs/planning/04-tech-debt.md
@@ -26,7 +26,6 @@ Steady autonomous cleanup that makes the app easier to keep production-perfect. 
 - **T-RLSCI · Isolated CI job for the RLS suite.** `[S]` Run `test_rls_anon.py` + `test_rls_function_grants.py` as their own fresh-container job so the security matrix has a deterministic green/red signal instead of being folded into a 200-test run where its flake is ignored. **CI change → flag per repo rules.**
 - **T-ScoringTest · Bind toasts to scoring constants in a test.** `[S]` No test asserts the "+10"/"−3" toast strings derive from `TITLE_POINTS`/`WRONG_BUZZ_PENALTY` (the test hardcodes "+10" independently). One test importing the constants catches drift — pairs with T-Scoring.
 - **T-CascadeTest · Pin the Realtime cascade-delete UX.** `[S]` No test exercises the `game_teams`-before-`active_games` delete ordering that routes players to Home instead of the expiry screen (F-P1-2). A reducer/e2e case locks in the intended "ended/expired" UX.
-- **T-DeployTest · deploy-during-game / preloadError test.** `[S]` ✅ (PR #185) — done at the vitest layer (the right layer for this deterministic single-client behavior): `preloadError.test.ts` dispatches `vite:preloadError` and asserts auto-reload + budget record, per-incident cap → defer, later-deploy budget reset, storage-unavailable → defer, and idempotent install; `ErrorBoundary.test.tsx` asserts a thrown child → reload CTA → hard reload (+ our specific diagnostic log).
 
 ## D. CI & bundle discipline
 

--- a/docs/planning/phases/phase-4-resilience.md
+++ b/docs/planning/phases/phase-4-resilience.md
@@ -17,16 +17,12 @@
 
 ## Tasks
 
-### T4.0 · Deploy-safe chunk loading (do first) `[S]` — F-P0-3 (orphaned P0) ✅ (PR #185)
-- [x] `window.addEventListener('vite:preloadError', …)` → `location.reload()`, guarded by a `sessionStorage` budget against reload loops (a stale content-hashed chunk 200s as `index.html` after a Cloudflare deploy → failed dynamic import → blank white screen mid-party; routes are `React.lazy`, so join → `/team/:code` is the classic trigger). → `frontend/src/lib/preloadError.ts` (bounded reload count per incident, reset after a 5-min window — loop-proof regardless of reload-cycle timing; and when `sessionStorage` is unavailable it does NOT auto-reload, deferring to the ErrorBoundary CTA, since a budget that can't survive the reload can't guarantee loop-freedom).
-- [x] Add an app-level `ErrorBoundary` (App has none) with a "reload" CTA as the backstop. → `frontend/src/components/ErrorBoundary.tsx`, wraps the whole tree in `App.tsx`.
-- [x] Test (T-DeployTest): simulate a failed dynamic import → reload. → `preloadError.test.ts` (dispatch `vite:preloadError` → reload + record budget, per-incident cap → defer, later-deploy budget reset, storage-unavailable → defer, idempotent install) + `ErrorBoundary.test.tsx` (throw → CTA → hard reload; asserts our specific diagnostic log). This removes the "never deploy during a game" operational caveat entirely — **highest-value single fix for a live party**.
+### T4.0 · Deploy-safe chunk loading — F-P0-3 ✅ SHIPPED (PR #185, 2026-07-07)
+Vite `vite:preloadError` → budget-guarded auto-reload (`frontend/src/lib/preloadError.ts`) + app-level `ErrorBoundary` backstop (`frontend/src/components/ErrorBoundary.tsx`, wraps `App.tsx`). Removes the "never deploy during a live game" caveat (runbook §1.2). Tests in `preloadError.test.ts` + `ErrorBoundary.test.tsx`.
 
-### T4.1 · Dead-video handling + Skip `[S–M]` — F-P1-4, `I-Skip`, X-Skip
-> Note: the persistent inline "Video unavailable" state is already shipped (`YouTubePlayer.tsx`); what remains is the one-tap **Skip song** button + the errored-`youtube_id` blocklist.
-- [ ] Persistent inline "Video unavailable" state on the manager when the live player errors (don't rely on the auto-dismiss toast).
-- [ ] One-tap **Skip song** button → `select_next_song`, not counting the dead song against anything meaningful.
-- [ ] Blocklist the errored `youtube_id` for the game so peek/select can't re-pick it (client-side exclude set passed to peek; or a small server-side exclusion).
+### T4.1 · Dead-video handling — F-P1-4 — ✅ effectively already covered (no new button)
+> Decided 2026-07-07: **do not add a Skip button.** The host already skips a dead video with the existing **Next round** button, and the live/prebuffer error already shows a persistent "Video unavailable" state + a "click Next round" toast (`YouTubePlayer.tsx` / `ManagerConsolePage.tsx:189,359`). A dead song shown in a round is marked *played*, and `select_next_song` / `peek_next_song` both exclude already-played songs (`rpc-functions.md:368`), so it can't be re-picked; the catalog also dedups `youtube_id`. The originally-planned `youtube_id` blocklist is therefore redundant in practice.
+- [ ] (optional, low value) Only if a real re-pick is ever observed: add the errored `youtube_id` to the peek/select client-side exclude set (covers the narrow not-yet-played-duplicate case). Skip unless it proves needed.
 
 ### T4.2 · Recover a paused song after host phone lock `[S–M]` — `I-Resume`
 - [ ] On `visibilitychange → visible` with `game.status==='playing'` and no buzz, auto-resume playback; or add a plain play/pause toggle on the manager.


### PR DESCRIPTION
## Summary
Housekeeping after F-P0-3/T4.0 shipped (PR #185):
- Prune the completed items from the planning docs — F-P0-3 (now `_None open._` under P0, recorded in the resolved note), T-DeployTest (`04-tech-debt.md`), and collapse the finished T4.0 checklist to a one-line shipped marker.
- Reshape **T4.1**: drop the planned **Skip song** button (redundant — the existing **Next round** button already moves past a dead video and shows a persistent "Video unavailable" state) and note the `youtube_id` blocklist is also redundant in practice (`select_next_song`/`peek_next_song` exclude already-played songs; the catalog dedups `youtube_id`).

## Test plan
Docs-only; no code changed. CI runs for gate consistency.