### PR TITLE
E2E: fit all scoring paths inside the 7-song CI pool and make the coverage guard round-aware

### DIFF
--- a/tests/e2e/ten_teams_thirty_rounds.spec.ts
+++ b/tests/e2e/ten_teams_thirty_rounds.spec.ts
@@ -23,7 +23,11 @@
 // run; against the tiny CI seed the game is capped at the available pool (same
 // approach as four_teams_twenty_rounds / soundtrack_playthrough) so it never
 // hits `no_more_songs`. When the pool caps the run short of a scenario's round,
-// that scenario is skipped and logged (no silent truncation).
+// that scenario is skipped and logged (no silent truncation), and the coverage
+// guard at the end only requires the paths whose scheduled round actually ran.
+// Rounds 1-7 cover all seven round-consuming paths (+ the round-2 bonus
+// overlay) so even the 7-song CI seed exercises every scoring path; the
+// kick-seeding round and the volume rounds come after.
 //
 // Robustness: the manager console serialises every scoring/advance action behind
 // a `busy` flag and each handler early-returns while it's set, so a click fired
@@ -55,7 +59,7 @@ import { countSongsInGenreSlugs } from "./fixtures/supabase-admin";
 const TARGET_ROUNDS = 30;
 const TEAM_COUNT = 10;
 const BONUS_TEAM = "Team08"; // receives the +4 host bonus
-const KICK_TEAM = "Team10"; // scored in R6, then kicked after R8
+const KICK_TEAM = "Team10"; // scored in R8, then kicked after R8
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
@@ -284,11 +288,14 @@ test("10 teams, up to 30 rounds: every scoring path, live scores, podium & archi
       case 5:
         return { type: "wrong", a: "Team05", b: "Team06" };
       case 6:
-        return { type: "song", a: KICK_TEAM }; // give the sacrificial team a score
+        // noscore sits inside rounds 1-7 so the capped CI pool still covers it.
+        return { type: "noscore", a: "Team07" };
       case 7:
         return { type: "race" };
       case 8:
-        return { type: "noscore", a: "Team07" };
+        // Give the sacrificial team a score just before the R8 kick overlay;
+        // only matters when TOTAL > 8, so it lives outside the 1-7 core.
+        return { type: "song", a: KICK_TEAM };
       default: {
         // Volume rounds 9..TOTAL: even -> feed the leader (+15), odd -> cycle a
         // list that repeats every path (incl. split/wrong/race) on other teams.
@@ -394,7 +401,7 @@ test("10 teams, up to 30 rounds: every scoring path, live scores, podium & archi
     }
 
     // --- Kick overlay: after round 8 advances (no active buzz), remove the
-    //     sacrificial team that scored in R6. Standings for everyone else must
+    //     sacrificial team that scored in R8. Standings for everyone else must
     //     be untouched. ---
     if (r === 8 && TOTAL > 8) {
       paths.add("kick-midgame");
@@ -501,18 +508,22 @@ test("10 teams, up to 30 rounds: every scoring path, live scores, podium & archi
   expect(ghsRows.length).toBe(TOTAL);
   expect(new Set(ghsRows.map((r) => r.round_number)).size).toBe(TOTAL);
 
-  // ---- Coverage guard: every scoring path we scheduled actually ran ----
-  const wantPaths = [
-    "song+10",
-    "artist+5",
-    "both+15",
-    "multibuzz-split",
-    "wrong-then-win",
-    "continue-noscore",
-    "concurrent-race",
-    "bonus+4",
+  // ---- Coverage guard: every scoring path whose scheduled round actually ran ----
+  // The pool can cap TOTAL below a path's round (skipped + logged above); a
+  // skipped path must not fail the guard. Each entry is [path, first round
+  // that schedules it]; kick-midgame already keys off TOTAL below.
+  const wantPaths: Array<[string, number]> = [
+    ["song+10", 1],
+    ["artist+5", 2],
+    ["bonus+4", 2],
+    ["both+15", 3],
+    ["multibuzz-split", 4],
+    ["wrong-then-win", 5],
+    ["continue-noscore", 6],
+    ["concurrent-race", 7],
   ];
-  for (const p of wantPaths) {
+  for (const [p, firstRound] of wantPaths) {
+    if (TOTAL < firstRound) continue;
     expect(paths.has(p), `scoring path '${p}' should have been exercised`).toBe(true);
   }
   if (TOTAL > 8) expect(paths.has("kick-midgame")).toBe(true);


### PR DESCRIPTION
## Summary

Fixes the deterministic e2e failure that has had the labeled/`main` Playwright runs red since the 10-team spec landed: the CI seed's Rock+Pop pool is 7 songs, so `ten_teams_thirty_rounds` caps at `TOTAL = 7` rounds — but `noscore` was scheduled at round 8 and the end-of-test coverage guard unconditionally required `continue-noscore`, failing every CI run (`scoring path 'continue-noscore' should have been exercised`, 3/3 attempts, also on `main` runs from Jul 7).

Two changes, both in the spec:

- **Rounds 6 and 8 swapped in `planFor`.** Round 6 previously duplicated the `song` path just to give the sacrificial kick-team a score — but the kick overlay only runs when `TOTAL > 8`, so that seeding never matters on the capped CI pool. `noscore` now sits at round 6 and the kick-team scoring at round 8, so rounds 1–7 cover all seven round-consuming paths (plus the round-2 bonus overlay) and the 7-song CI seed exercises **every** scoring path.
- **The coverage guard is now round-aware** ([path, first-scheduled-round] pairs; a path whose round didn't run is not required), matching the spec's own documented intent ("that scenario is skipped and logged (no silent truncation)") and degrading gracefully if the seed pool ever shrinks further. `kick-midgame` already keyed off `TOTAL > 8`; unchanged.

Net effect: CI e2e goes from deterministically red to green **with more coverage than before** (`continue-noscore` had never actually run in CI).

## Test plan

- `npx playwright test ten_teams_thirty_rounds.spec.ts --list` — spec transpiles, 8 tests listed.
- `run-e2e` label on this PR: the full Playwright suite against the CI ephemeral stack, where the pool is 7 — the previously failing test must now pass with all eight paths exercised.
