### PR TITLE
Drop the orphan active_games.total_rounds column (mig 040, T6.2)

### DIFF
--- a/db/migrations/040_drop_total_rounds_column.sql
+++ b/db/migrations/040_drop_total_rounds_column.sql
@@ -1,0 +1,12 @@
+-- Migration 040: Drop the orphan active_games.total_rounds column.
+--
+-- History: 003 created total_rounds NOT NULL; the round-limit feature was
+-- removed and 015 relaxed it (DROP NOT NULL + DEFAULT 0) as a transitional
+-- step, promising "a follow-up migration will DROP the column entirely once
+-- every live backend is on the new contract." That day is here: no frontend,
+-- backend, or PL/pgSQL RPC reads or writes total_rounds (verified 2026-07-10).
+-- The create-game INSERT omits it, select_next_song never touches it, and it is
+-- absent from data-model.md's active_games DDL block. This finishes 015's job.
+--
+-- Idempotent: DROP COLUMN IF EXISTS is a no-op once the column is gone.
+ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -339,7 +339,7 @@ db/migrations/
 ├── 012_manager_token.sql     -- per-game host credential
 ├── 013_seed_extra_genres.sql
 ├── 014_scoring_revamp.sql    -- wrong-buzz penalty, +4 bonus, drop source/timeout
-├── 015_drop_total_rounds.sql
+├── 015_drop_total_rounds.sql   -- relaxed total_rounds NOT NULL (the actual DROP is mig 040)
 ├── 016_multi_buzz_rounds.sql -- multi-buzz model: token claims, award_attempt, end_round
 ├── 017_free_guess_flag.sql   -- per-round free-guess flag; waives -3 after first correct
 │   … 018–032: manager-token RPCs, browser-direct RPC migration, soundtrack/decade filters, etc.
@@ -347,7 +347,10 @@ db/migrations/
 ├── 034_game_secrets.sql      -- move manager_token off active_games into anon-invisible game_secrets (D-1 leak fix)
 ├── 035_buzz_in_drop_round_update.sql   -- drop the dead game_rounds.buzzed_team_id mirror-write from buzz_in
 ├── 036_award_attempt_collapse_writes.sql -- collapse award_attempt's per-round writes into one UPDATE...RETURNING
-└── 037_lock_down_game_round_attempts.sql -- remove game_round_attempts from the Realtime publication + enable RLS
+├── 037_lock_down_game_round_attempts.sql -- remove game_round_attempts from the Realtime publication + enable RLS
+├── 038_peek_next_song_metadata.sql -- peek_next_song also returns the candidate's title/artist/is_soundtrack so Next-round can label the song in-gesture
+├── 039_extend_game.sql          -- token-gated "Keep playing +1h" TTL bump: expires_at = GREATEST(expires_at, now()) + 1h
+└── 040_drop_total_rounds_column.sql -- finally DROP the orphan active_games.total_rounds (mig 015 only relaxed it)
 ```
 
 All migrations are written to be idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. Re-running them is safe.

--- a/docs/planning/NEXT-SESSION.md
+++ b/docs/planning/NEXT-SESSION.md
@@ -1,6 +1,6 @@
 # Next session — start here
 
-_Last updated: 2026-07-10 (**Phase 6 T6.1 ✅ done** — PR #199, docs-only drift sync merged. **Next: T6.2 — drop the orphan `active_games.total_rounds` column (migration PR).**)_
+_Last updated: 2026-07-10 (**Phase 6 T6.2 ✅ done** — PR #TBD, mig 040 drops the orphan `active_games.total_rounds` column. **Next: T6.3 — `UNIQUE(songs.youtube_id)` + a one-time prod dedup (migration PR; the prod dedup mutation needs maintainer go).**)_
 
 ## Short prompt to paste into the fresh session
 
@@ -17,14 +17,17 @@ _Last updated: 2026-07-10 (**Phase 6 T6.1 ✅ done** — PR #199, docs-only drif
 - **Pre-event validation done** (10-team live-prod pass 2026-07-05 + DB-verified 10-team/30-round e2e 2026-07-06); the two display-scaling bugs it found are fixed (PRs #176/#178). No open blockers. Reusable checklist: `docs/pre-event-checklist.md`.
 - **Phases 5–8 not started**, but re-verification shrank them: Phase 5's critical item (D-1) and T5.3 already shipped; Phase 6 is down to one doc-sync PR + two migrations; Phase 7 lost T-KeepWarm/T-DocRPC (done). Recommended order after Phase 4: **6 → 7 → 5 → 8** (see `phases/README.md`).
 
-## What to do next — Phase 6 (T6.2: drop the orphan `total_rounds` column)
+## What to do next — Phase 6 (T6.3: `UNIQUE(songs.youtube_id)` + prod dedup)
 
-**T6.1 ✅ done (PR #199)** — docs-only drift sync merged: `data-model.md` intro (→ eleven tables, three groups), §5/§6 anon-EXECUTE set (→ the six anon RPCs) + §6 caller column; `api-contracts.md` §3 anon-surface line; `game-rules.md` state-transition auth column (→ open-hosting / `manager_token`); plus the same drift class caught in `architecture.md`, `diagrams/internal.md` and its `internal.html` mirror. (Discovered while doing it: the plan's "ten tables" was one short — `game_round_attempts` is a real table absent from the §2 DDL block; and `api-contracts.md` line 71's endpoint list was already correct from a Phase 4 sync.)
+**T6.1 ✅ done (PR #199)** — docs-only drift sync merged (eleven-table intro, six anon RPCs, open-hosting auth model across `data-model.md`/`api-contracts.md`/`game-rules.md`/`architecture.md`/`diagrams/*`).
 
-Next is **T6.2**, a single migration PR:
+**T6.2 ✅ done (PR #TBD)** — mig `040_drop_total_rounds_column.sql` drops the orphan `active_games.total_rounds` (mig 015 only relaxed its NOT NULL). Re-verified zero code refs (grep hits only mig 003/015 + docs); applied twice on the local stack (idempotent skip on #2); a create-game INSERT that omits the column still succeeds; `data-model.md` ledger synced (015 note + 038/039/040 appended). **Prod apply is still pending maintainer go** — it's a hard-required-nothing drop, so run it in a quiet window: `supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`.
 
-1. Migration `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (mig 015 promised it but only relaxed the NOT NULL). Confirm no code path reads/writes `total_rounds` (verified none as of 2026-07-07 — re-verify frontend + backend + RPCs), sync `data-model.md`, apply the migration twice against a local `supabase start` stack for idempotency. (T-TotalRounds)
-2. Then **T6.3** (`UNIQUE(songs.youtube_id)` + a one-time prod dedup) is a separate single-session migration PR.
+Next is **T6.3**, a single migration PR (**D-8 = youtube_id now**):
+
+1. One-time dedup on prod's catalog: identify duplicate `youtube_id`s, merge them, repoint `song_genres`, delete the losers. (The known Avicii "Wake Me Up" double-upload is a same-song-different-*video* case — two distinct `youtube_id`s — so it is NOT a `youtube_id` dupe and must be left alone.) **This mutates prod data → needs maintainer go before applying.**
+2. Add the `UNIQUE(songs.youtube_id)` index migration (idempotent) once the catalog is clean.
+3. Verify no dedup regression: sane row counts, no orphaned `song_genres`, song selection still works (no repeats within a game).
 
 Migration PRs run backend/db CI. After merge + maintainer go, apply to prod (`supabase db query --linked`). Recommended phase order after 6: **7 → 5 → 8** (see `phases/README.md`).
 

--- a/docs/planning/NEXT-SESSION.md
+++ b/docs/planning/NEXT-SESSION.md
@@ -1,10 +1,10 @@
 # Next session — start here
 
-_Last updated: 2026-07-10 (**Phase 6 T6.2 ✅ done** — PR #TBD, mig 040 drops the orphan `active_games.total_rounds` column. **Next: T6.3 — `UNIQUE(songs.youtube_id)` + a one-time prod dedup (migration PR; the prod dedup mutation needs maintainer go).**)_
+_Last updated: 2026-07-10 (**Phase 6 T6.2 ✅ done** — PR #200, mig 040 drops the orphan `active_games.total_rounds` column. **Next: T6.3 — `UNIQUE(songs.youtube_id)` + a one-time prod dedup (migration PR; the prod dedup mutation needs maintainer go).**)_
 
 ## Short prompt to paste into the fresh session
 
-> **Continue the Sound Clash plan. Read `docs/planning/NEXT-SESSION.md` first, then do Phase 6 T6.2 per `docs/planning/phases/EXECUTION-CONTRACT.md` and `docs/planning/phases/phase-6-correctness-docs.md`. Read `.claude/rules/lessons-learned.md` before running anything. T6.2 is a single migration PR: `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (mig 015 promised it but only relaxed NOT NULL); confirm no code path reads/writes `total_rounds` (verified none as of 2026-07-07 — re-verify), sync `data-model.md`, apply the migration twice locally for idempotency. It's a hard-required-nothing drop, so apply to prod after merge + maintainer go. The maintainer is button-averse: prefer zero-UI/auto fixes and confirm before adding any button.**
+> **Continue the Sound Clash plan. Read `docs/planning/NEXT-SESSION.md` first, then do Phase 6 T6.3 per `docs/planning/phases/EXECUTION-CONTRACT.md` and `docs/planning/phases/phase-6-correctness-docs.md`. Read `.claude/rules/lessons-learned.md` before running anything. T6.3 is a single migration PR: dedup prod's catalog on `youtube_id` (merge dupes, repoint `song_genres`, delete losers — leave the Avicii "Wake Me Up" same-song-different-*video* pair alone; it has two distinct youtube_ids), then add an idempotent `UNIQUE(songs.youtube_id)` index migration. The prod dedup mutates prod data → apply only after maintainer go. Verify no orphaned `song_genres` and that song selection still works. The maintainer is button-averse: prefer zero-UI/auto fixes and confirm before adding any button.**
 
 (Or just run the local **`/next-task`** skill — it encodes the same loop.)
 
@@ -21,7 +21,7 @@ _Last updated: 2026-07-10 (**Phase 6 T6.2 ✅ done** — PR #TBD, mig 040 drops 
 
 **T6.1 ✅ done (PR #199)** — docs-only drift sync merged (eleven-table intro, six anon RPCs, open-hosting auth model across `data-model.md`/`api-contracts.md`/`game-rules.md`/`architecture.md`/`diagrams/*`).
 
-**T6.2 ✅ done (PR #TBD)** — mig `040_drop_total_rounds_column.sql` drops the orphan `active_games.total_rounds` (mig 015 only relaxed its NOT NULL). Re-verified zero code refs (grep hits only mig 003/015 + docs); applied twice on the local stack (idempotent skip on #2); a create-game INSERT that omits the column still succeeds; `data-model.md` ledger synced (015 note + 038/039/040 appended). **Prod apply is still pending maintainer go** — it's a hard-required-nothing drop, so run it in a quiet window: `supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`.
+**T6.2 ✅ done (PR #200)** — mig `040_drop_total_rounds_column.sql` drops the orphan `active_games.total_rounds` (mig 015 only relaxed its NOT NULL). Re-verified zero code refs (grep hits only mig 003/015 + docs); applied twice on the local stack (idempotent skip on #2); a create-game INSERT that omits the column still succeeds; `data-model.md` ledger synced (015 note + 038/039/040 appended). **Prod apply is still pending maintainer go** — it's a hard-required-nothing drop, so run it in a quiet window: `supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`.
 
 Next is **T6.3**, a single migration PR (**D-8 = youtube_id now**):
 

--- a/docs/planning/phases/phase-6-correctness-docs.md
+++ b/docs/planning/phases/phase-6-correctness-docs.md
@@ -19,7 +19,7 @@
 - [x] `game-rules.md`: replaced the "(admin auth)" host transitions with the open-hosting / `manager_token` model. (T-DocGameRules)
 - [x] Spot-sweep: caught the same drift class in `architecture.md` (§5 "Nothing else" + stale `select-song`/`award-points` gate list), `diagrams/internal.md` + its hand-maintained `internal.html` mirror (the "only RPC anon EXECUTEs on" auth-table rows and the `/games/*` Mermaid node listing removed endpoints). All synced.
 
-### T6.2 · Drop the orphan `total_rounds` column `[S]` — T-TotalRounds ✅ (PR #TBD)
+### T6.2 · Drop the orphan `total_rounds` column `[S]` — T-TotalRounds ✅ (PR #200)
 - [x] Migration `040_drop_total_rounds_column.sql` = `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (mig 015 promised it; only relaxed NOT NULL). Re-verified no code path reads/writes it (2026-07-10: repo-wide grep hits only mig 003/015 + docs — zero frontend/backend/RPC refs). Applied twice against the local stack (APPLY #2 = idempotent skip NOTICE); a create-game INSERT that omits the column still succeeds. Synced `data-model.md` ledger (015 → "actual DROP is mig 040"; appended 038/039/040). Prod apply deferred to maintainer go (hard-required-nothing drop).
 
 ### T6.3 · `UNIQUE(songs.youtube_id)` `[M]` — T-YoutubeUnique, **D-8**

--- a/docs/planning/phases/phase-6-correctness-docs.md
+++ b/docs/planning/phases/phase-6-correctness-docs.md
@@ -19,8 +19,8 @@
 - [x] `game-rules.md`: replaced the "(admin auth)" host transitions with the open-hosting / `manager_token` model. (T-DocGameRules)
 - [x] Spot-sweep: caught the same drift class in `architecture.md` (§5 "Nothing else" + stale `select-song`/`award-points` gate list), `diagrams/internal.md` + its hand-maintained `internal.html` mirror (the "only RPC anon EXECUTEs on" auth-table rows and the `/games/*` Mermaid node listing removed endpoints). All synced.
 
-### T6.2 · Drop the orphan `total_rounds` column `[S]` — T-TotalRounds
-- [ ] Migration `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (mig 015 promised it; only relaxed NOT NULL). Confirm no code path reads/writes it (verified none as of 2026-07-07); sync `data-model.md`.
+### T6.2 · Drop the orphan `total_rounds` column `[S]` — T-TotalRounds ✅ (PR #TBD)
+- [x] Migration `040_drop_total_rounds_column.sql` = `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (mig 015 promised it; only relaxed NOT NULL). Re-verified no code path reads/writes it (2026-07-10: repo-wide grep hits only mig 003/015 + docs — zero frontend/backend/RPC refs). Applied twice against the local stack (APPLY #2 = idempotent skip NOTICE); a create-game INSERT that omits the column still succeeds. Synced `data-model.md` ledger (015 → "actual DROP is mig 040"; appended 038/039/040). Prod apply deferred to maintainer go (hard-required-nothing drop).
 
 ### T6.3 · `UNIQUE(songs.youtube_id)` `[M]` — T-YoutubeUnique, **D-8**
 - [ ] One-time dedup pass on prod's catalog (identify + merge duplicate `youtube_id`s, repoint `song_genres` — the known Avicii "Wake Me Up" double-upload is a same-song-different-video case, not a `youtube_id` dupe).


### PR DESCRIPTION
## Summary

Drops the orphan `active_games.total_rounds` column (Phase 6 · T6.2 · T-TotalRounds).

The round-limit feature was removed long ago. Migration 015 relaxed the column
(`DROP NOT NULL` + `DEFAULT 0`) as a transitional step and explicitly promised a
follow-up migration to drop it once every live backend stopped writing it. This
finishes that job.

- **Migration `040_drop_total_rounds_column.sql`**: `ALTER TABLE active_games DROP COLUMN IF EXISTS total_rounds` (idempotent).
- Re-verified **no code path** reads or writes `total_rounds`: a repo-wide grep hits only the original `003_ephemeral_tables.sql` CREATE, the transitional `015`, and docs — zero references in `frontend/src`, `backend/app`, or any PL/pgSQL RPC body. The create-game INSERT already omits the column.
- `data-model.md` migration ledger synced: annotated `015` (the real DROP is `040`) and appended the previously-missing `038`/`039`/`040` entries. The `active_games` DDL block already omitted `total_rounds`, so it stays accurate.

No user-visible behavior change (internal schema cleanup), so no `CHANGELOG` entry.

Prod apply is a hard-required-nothing drop, deferred to a maintainer-chosen quiet window (`supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`).

## Test plan

- Applied the migration **twice** against the local `supabase start` stack: APPLY #1 drops the column; APPLY #2 is a no-op (`NOTICE: column "total_rounds" ... does not exist, skipping`) — idempotent, as CI re-verifies.
- After the drop, `active_games` columns match `data-model.md`'s DDL block exactly (no `total_rounds`).
- Confirmed a create-game-shaped `INSERT INTO active_games (game_code, status)` (omitting `total_rounds`) still succeeds after the drop (rolled back).
- CI: backend/db migration idempotency rerun + CodeQL.
