### PR TITLE
Make migration 015 re-runnable after 040 drops total_rounds

### DIFF
--- a/db/migrations/015_drop_total_rounds.sql
+++ b/db/migrations/015_drop_total_rounds.sql
@@ -3,10 +3,24 @@
 -- The column is no longer used by application code. Old backend code still
 -- INSERTs total_rounds explicitly; new backend code omits it. To keep both
 -- shapes working during the rollout, drop the NOT NULL constraint and add a
--- default. A follow-up migration will DROP the column entirely once every
--- live backend is on the new contract.
+-- default. Migration 040 later DROPs the column entirely.
 --
--- Idempotent: ALTER COLUMN ... DROP NOT NULL is a no-op on an already-nullable
--- column, and SET DEFAULT just overwrites whatever default was there.
-ALTER TABLE active_games ALTER COLUMN total_rounds DROP NOT NULL;
-ALTER TABLE active_games ALTER COLUMN total_rounds SET DEFAULT 0;
+-- Idempotent AND re-runnable after 040: guarded with IF EXISTS so replaying the
+-- full migration set once 040 has dropped total_rounds is a clean no-op. (CI
+-- applies every migration twice to verify idempotency; without the guard the
+-- second pass fails here with "column total_rounds does not exist" because
+-- migration 003's CREATE TABLE IF NOT EXISTS won't re-add a column to the
+-- already-existing table.) On a DB that still has the column the two ALTERs run
+-- as before -- DROP NOT NULL is a no-op on an already-nullable column and SET
+-- DEFAULT just overwrites whatever default was there.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'active_games' AND column_name = 'total_rounds'
+  ) THEN
+    ALTER TABLE active_games ALTER COLUMN total_rounds DROP NOT NULL;
+    ALTER TABLE active_games ALTER COLUMN total_rounds SET DEFAULT 0;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Fixes a migration re-runnability regression introduced by mig 040 (PR #200, T6.2).

Migration `040_drop_total_rounds_column.sql` drops `active_games.total_rounds`. But migration **015** later runs `ALTER TABLE active_games ALTER COLUMN total_rounds DROP NOT NULL / SET DEFAULT 0`. On a **second pass over the full migration set** (CI applies migrations twice to verify idempotency; `003` is `CREATE TABLE IF NOT EXISTS`, so it won't re-add the column to the already-existing table), migration 015 fails:

```
Migration 015_drop_total_rounds.sql failed: column "total_rounds" of relation "active_games" does not exist
```

This slipped past #200 because the migration-only PR ran **only CodeQL** — `backend.yml` is path-filtered to `backend/**` / `tests/**`, so it doesn't fire on `db/migrations/**`, and the full-sequence idempotency check (the buzz-race stress job's `tests/db/conftest.py::_read_migrations`) is label-gated. The failure surfaced on the next PR that carried the `run-stress` label.

**Fix:** guard 015's two `ALTER COLUMN` statements in a `DO $$ … IF EXISTS … END $$` block so replaying the set after 040 has dropped the column is a clean no-op. On a DB that still has the column (fresh single-pass install, or prod before 040), the two ALTERs run exactly as before.

Not a runtime/user-visible change (no prod behavior shift; prod still has the column and applies migrations forward-only), so no `CHANGELOG` entry. Prod is unaffected — it never re-runs the set.

## Test plan

- Reproduced locally: on a DB where 040 already dropped the column, re-running the old 015 fails with the exact CI error.
- With the fix, applied 015 **twice** against that same DB (column absent) — both are clean `DO` no-ops.
- Present-branch check: added `total_rounds NOT NULL DEFAULT 7` in a transaction, ran the guarded block → column becomes `is_nullable=YES, default=0` (relaxed as before), rolled back.
- `run-stress` + `run-e2e` labels added so CI replays the **full** migration set twice (the job that caught the regression) and confirms it now passes end-to-end.
