### PR TITLE
T7.5: proper RLS fixture (dedicated LOGIN role) + expiry-warning reducer test

### DIFF
--- a/docs/planning/NEXT-SESSION.md
+++ b/docs/planning/NEXT-SESSION.md
@@ -1,6 +1,6 @@
 # Next session — start here
 
-_Last updated: 2026-07-10 (**afternoon /next-task session** — merged **T6.2 (#200)**, **T7.4 (#201)**, **T7.3 T-RpcError+T-Deps (#202)**, and **fixed a mig-015 idempotency regression the stress gate caught (#203)**. **⚠️ Two maintainer actions pending** — see the box below. **Next autonomous work: Phase 7 (T7.5 or T7.2)** — T6.3 is blocked on maintainer prod access.)_
+_Last updated: 2026-07-10 (**T7.5 shipped** — proper RLS fixture fix (`anon_conn` now a dedicated non-superuser `LOGIN` role, kills the `test_rls_anon` in-suite flake) + expiry-warning reducer test; PR open, awaiting green CI + merge. Earlier the same day: merged **T6.2 (#200)**, **T7.4 (#201)**, **T7.3 T-RpcError+T-Deps (#202)**, **mig-015 idempotency fix (#203)**. **⚠️ Two maintainer actions pending** — see the box below. **Next autonomous work: T7.2** — T6.3 is blocked on maintainer prod access.)_
 
 > ### ⚠️ Maintainer actions pending (can't be done autonomously)
 > 1. **Apply mig 040 to prod** (T6.2 — deferred, hard-required-nothing column drop). Quiet window: `supabase link --project-ref jvfddxuaqcsrguibkymp && supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`, then `bash ./tests/smoke/post_deploy.sh https://api.soundclash.org`. Prod is safe either way — mig 015 is now guarded so the drop can't break a replay.
@@ -30,11 +30,12 @@ _Last updated: 2026-07-10 (**afternoon /next-task session** — merged **T6.2 (#
 
 ## What to do next
 
-**T6.3 is blocked on maintainer prod access** (the read-only dupe query is denied by the auto-mode classifier without the maintainer present). So the next **autonomous** task is a Phase 7 item; recommended order:
+**T6.3 is blocked on maintainer prod access** (the read-only dupe query is denied by the auto-mode classifier without the maintainer present). **T7.5 is done** (RLS fixture fix + expiry reducer test — PR open, test-only, no runtime/schema change). So the next **autonomous** task is a Phase 7 item; recommended order:
 
-1. **T7.5** `[M]` — proper RLS fixture fix (`tests/db/conftest.py:124`: dedicated non-superuser `LOGIN` role + `current_user` assertion instead of `SET ROLE anon`) to kill the recurring `test_rls_anon` flake; plus a reducer/e2e test for the T4.8 expiry warning. **Backend/db — run pytest with `DATABASE_URL=""` so it uses a throwaway testcontainer, never the shared local stack** (lessons-learned).
-2. **T7.2** `[M]` — decompose the god components (`ManagerConsolePage` → `useSongPrebuffer`+`useScoring`; `AdminSongsPage` → `SongTable`/`SongEditForm`/`useAdminSongs`), guarded by their existing ~48-case tests.
-3. **T7.1** `[M, D-7]` — scoring single-source-of-truth in the DB. Own PR **behind the buzz-race gate** (`award_attempt` change) — careful.
+1. **T7.2** `[M]` — decompose the god components (`ManagerConsolePage` → `useSongPrebuffer`+`useScoring`; `AdminSongsPage` → `SongTable`/`SongEditForm`/`useAdminSongs`), guarded by their existing ~48-case tests.
+2. **T7.1** `[M, D-7]` — scoring single-source-of-truth in the DB. Own PR **behind the buzz-race gate** (`award_attempt` change) — careful.
+
+_(T7.5 ✅ — `anon_conn` now connects as a dedicated non-superuser `LOGIN` role (`anon_login_test`, granted membership in `anon`) via its own DSN with `session_user`/`rolsuper`/`rolbypassrls` assertions, replacing `SET ROLE anon`; full `tests/db` suite green in-suite with no `test_rls_anon` contamination. Plus a `useGameChannel` reducer test that a `GAME_CHANGE` UPDATE bumping `expires_at` — the Realtime event `extend_game` triggers — flows into state; the rest of the T4.8 expiry flow was already fully covered.)_
 
 **T6.3 (when the maintainer is present)** — one migration PR (**D-8 = youtube_id now**): (a) read-only prod query for duplicate `youtube_id`s; (b) dedup — merge dupes, repoint `song_genres`, delete losers (leave the Avicii "Wake Me Up" same-song-different-*video* pair — two distinct youtube_ids — alone); (c) idempotent `UNIQUE(songs.youtube_id)` migration; (d) verify no orphaned `song_genres`, song selection still works. Consider making it one migration that dedups **then** adds the constraint so it applies atomically to prod. Label it `run-stress` + `run-e2e`.
 

--- a/docs/planning/phases/phase-7-tech-debt.md
+++ b/docs/planning/phases/phase-7-tech-debt.md
@@ -36,8 +36,8 @@
 - [ ] Un-ignore `frontend/package-lock.json` after re-verifying the npm-10 runner bug is gone (deploy reproducibility). **Verify before flipping.**
 
 ### T7.5 · Test hardening `[M]` — T-RLSFix, T-CascadeTest
-- [ ] Proper RLS fixture fix: dedicated non-superuser `LOGIN` role + `current_user` assertion (`tests/db/conftest.py:124` still uses `SET ROLE anon`). The table-coverage extension already shipped.
-- [ ] e2e/reducer tests for: expiry warning (T4.8). (Cascade-delete ordering shipped with T4.4/PR #192, failed-hydrate with T4.3/PR #190, `preloadError` deploy-path tests with T4.0.)
+- [x] Proper RLS fixture fix: `anon_conn` now connects **as a dedicated non-superuser `LOGIN` role** (`anon_login_test`, provisioned once in `_migrated` setup, granted membership in `anon`) via its own DSN, instead of `SET ROLE anon` on the superuser connection; the fixture asserts `session_user`/`current_user` is that role and `rolsuper`/`rolbypassrls` are false. Kills the recurring in-suite `test_rls_anon` flake. (T7.5 — done 2026-07-10.)
+- [x] Reducer test for the expiry warning (T4.8): `useGameChannel.test.ts` now asserts a `GAME_CHANGE` UPDATE bumping `expires_at` (the Realtime event `extend_game` triggers) flows into reducer state. The rest of the T4.8 flow was already covered end-to-end (`ExpiryCountdown.test.tsx`, `ManagerConsolePage.test.tsx` "Keep playing…", `useManagerActions.test.ts::extendGameDirect`, `test_extend_game.py`), so no duplication was added. (Cascade-delete ordering shipped with T4.4/PR #192, failed-hydrate with T4.3/PR #190, `preloadError` deploy-path tests with T4.0.)
 
 ### T7.6 · CI discipline `[S — flag CI changes]`
 - [ ] `T-RLSCI`: isolated CI job for the RLS suite (deterministic green/red).

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -64,6 +64,8 @@ Numbers are targets at end of Phase 6. Don't game them; let the test count emerg
 
 Spin up Postgres via `testcontainers-postgres`. Apply all migrations from `db/migrations/`. Run tests against the fresh DB.
 
+The RLS tests (`test_rls_anon.py`, `test_rls_function_grants.py`) authenticate through the `anon_conn` fixture, which connects **as a dedicated non-superuser `LOGIN` role** provisioned once in setup and granted membership in `anon` (its own DSN), rather than doing `SET ROLE anon` on the superuser connection. The fixture asserts `session_user`/`current_user` is that role and that it is not a superuser and does not bypass RLS — so the denial assertions genuinely exercise anon-level privileges. This replaced the old `SET ROLE` approach, which leaked role state across reused containers and caused a recurring in-suite flake.
+
 | File | What it tests | Priority |
 |---|---|---|
 | `test_buzz_in_race.py` | 10 concurrent buzz_in calls → exactly 1 winner. **Loops 100×** in stress mode. | P0 |

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -280,6 +280,28 @@ describe("gameReducer", () => {
     expect(next?.currentRound?.id).toBe("r1");
   });
 
+  it("GAME_CHANGE UPDATE carries a bumped expires_at into state (extend_game path)", () => {
+    // After the manager's "Keep playing +1h" fires extend_game, the only thing
+    // that moves the expiry warning back out of the window is the Realtime
+    // UPDATE on active_games with the new expires_at. Assert that update flows
+    // through the reducer so the ExpiryCountdown re-reads a later deadline.
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game: makeActiveGame({ status: "playing", expires_at: "2026-05-05T12:10:00.000Z" }),
+      teams: [],
+      rounds: [],
+    });
+    const bumped = makeActiveGame({
+      status: "playing",
+      expires_at: "2026-05-05T13:10:00.000Z",
+    });
+    const next = gameReducer(start, {
+      type: "GAME_CHANGE",
+      payload: makePayload("active_games", "UPDATE", { new: bumped }),
+    });
+    expect(next?.game.expires_at).toBe("2026-05-05T13:10:00.000Z");
+  });
+
   it("GAME_CHANGE DELETE returns null", () => {
     const start = gameReducer(null, {
       type: "HYDRATE",

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import asyncpg
 import pytest
@@ -28,6 +29,19 @@ import pytest_asyncio
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+
+# A dedicated LOGIN role the RLS tests connect *as* directly (its own DSN),
+# instead of doing `SET ROLE anon` on the superuser connection. `SET ROLE` on a
+# superuser session leaks superuser/role state across the reused testcontainer
+# and was the root cause of the recurring `test_rls_anon` flake (spurious "DID
+# NOT RAISE InsufficientPrivilegeError" when the file ran after the rest of the
+# suite). Postgres's `anon` role is NOLOGIN (see migration 006), so it can't be
+# connected to directly; this role is LOGIN + INHERIT and is GRANTed membership
+# in `anon`, so every policy/GRANT targeting `anon` applies to it -- while it is
+# genuinely NOT a superuser and does NOT bypass RLS. Test-only: created in the
+# `_migrated` setup fixture, never in a migration file (so it never reaches prod).
+ANON_LOGIN_ROLE = "anon_login_test"
+ANON_LOGIN_PASSWORD = "anon_login_test_pw"  # noqa: S105 - throwaway local test role
 
 # Truncated between tests so each function starts clean. Durable tables
 # (songs/genres/song_genres) are included so tests populate exactly what they need.
@@ -75,9 +89,24 @@ def database_url() -> Iterator[str]:
         container.stop()
 
 
+def _anon_login_dsn(migrated_url: str) -> str:
+    """Derive the anon-login DSN from the migrated (superuser) DSN.
+
+    Same host/port/dbname/query; only the user+password change to the dedicated
+    non-superuser login role. Keeps the tests pointed at the identical database
+    the migrations were applied to, just with anon's effective privileges.
+    """
+    parts = urlsplit(migrated_url)
+    host = parts.hostname or "localhost"
+    netloc = f"{quote(ANON_LOGIN_ROLE)}:{quote(ANON_LOGIN_PASSWORD)}@{host}"
+    if parts.port is not None:
+        netloc += f":{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def _migrated(database_url: str) -> AsyncIterator[str]:
-    """Apply every migration once per session.
+    """Apply every migration once per session, then provision the anon-login role.
 
     `loop_scope="session"` is required because pytest-asyncio defaults to a
     function-scoped event loop; without this, the session-scoped fixture
@@ -90,6 +119,25 @@ async def _migrated(database_url: str) -> AsyncIterator[str]:
                 await conn.execute(sql)
             except Exception as e:
                 raise RuntimeError(f"Migration {name} failed: {e}") from e
+        # Provision the dedicated non-superuser LOGIN role the RLS tests connect
+        # as (see ANON_LOGIN_ROLE). Idempotent: created only if missing, then its
+        # attributes + `anon` membership are re-asserted so a reused container
+        # (external $DATABASE_URL / testcontainer reuse) converges to the same
+        # state. NOSUPERUSER + NOBYPASSRLS + INHERIT make it a true anon stand-in.
+        # The interpolated values are hardcoded module constants, not user input.
+        provision_role_sql = f"""
+            DO $$
+            BEGIN
+              IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{ANON_LOGIN_ROLE}') THEN
+                CREATE ROLE {ANON_LOGIN_ROLE} LOGIN PASSWORD '{ANON_LOGIN_PASSWORD}';
+              END IF;
+            END $$;
+            ALTER ROLE {ANON_LOGIN_ROLE}
+              LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT
+              PASSWORD '{ANON_LOGIN_PASSWORD}';
+            GRANT anon TO {ANON_LOGIN_ROLE};
+            """  # noqa: S608 - constants, not user input
+        await conn.execute(provision_role_sql)
     finally:
         await conn.close()
     yield database_url
@@ -114,14 +162,37 @@ async def db(_migrated: str) -> AsyncIterator[asyncpg.Connection]:
 
 @pytest_asyncio.fixture
 async def anon_conn(db: asyncpg.Connection, _migrated: str) -> AsyncIterator[asyncpg.Connection]:
-    """A fresh connection with `SET ROLE anon`, for RLS tests.
+    """A fresh connection authenticated *as* the dedicated non-superuser login
+    role (ANON_LOGIN_ROLE), for RLS tests.
+
+    This connects with the login role's own DSN rather than doing `SET ROLE anon`
+    on a superuser connection -- the latter leaked superuser/role state across
+    the reused testcontainer and caused the recurring `test_rls_anon` flake. The
+    login role inherits `anon`'s privileges via role membership, so RLS policies
+    and GRANTs that target `anon` apply, while it is genuinely not a superuser and
+    does not bypass RLS.
 
     The `db` fixture is requested only to ensure truncation happens first; the
     anon connection itself is separate.
     """
-    conn = await asyncpg.connect(_migrated)
+    conn = await asyncpg.connect(_anon_login_dsn(_migrated))
     try:
-        await conn.execute("SET ROLE anon")
+        # Prove we're really testing anon-level privileges: a non-superuser
+        # login role, not superuser-with-SET-ROLE. If this ever regressed to a
+        # superuser session the RLS denial assertions would silently pass for
+        # the wrong reason (superuser bypasses every check).
+        ident = await conn.fetchrow(
+            "SELECT session_user, current_user, "
+            "(SELECT rolsuper FROM pg_roles WHERE rolname = current_user) AS is_super, "
+            "(SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) AS bypass_rls"
+        )
+        assert ident is not None
+        assert ident["session_user"] == ANON_LOGIN_ROLE, (
+            f"anon_conn must authenticate as {ANON_LOGIN_ROLE}, got {ident['session_user']}"
+        )
+        assert ident["current_user"] == ANON_LOGIN_ROLE
+        assert ident["is_super"] is False, "anon_conn must NOT be a superuser"
+        assert ident["bypass_rls"] is False, "anon_conn must NOT bypass RLS"
         yield conn
     finally:
         await conn.close()


### PR DESCRIPTION
## Summary

Phase 7, task **T7.5** (Test hardening). **Test-only — no runtime, schema, or prod-migration change.**

**Part A — proper RLS fixture fix (T-RLSFix).** `tests/db/conftest.py`'s `anon_conn` fixture no longer does `SET ROLE anon` on the superuser connection — that leaked superuser/role state across the reused testcontainer and caused the recurring `test_rls_anon.py` flake (12 spurious "DID NOT RAISE InsufficientPrivilegeError" failures when the file ran after the rest of the suite). Instead:

- A dedicated non-superuser `LOGIN` role (`anon_login_test`, `NOSUPERUSER NOBYPASSRLS INHERIT`) is provisioned once in the `_migrated` setup fixture and granted membership in `anon`, so every RLS policy / GRANT targeting `anon` applies to it via inheritance. It is created only in test setup, never in a migration file, so it never reaches prod.
- `anon_conn` now connects **as that role directly** (its own DSN, derived from the migrated DSN by swapping only user + password on the same host/port/dbname).
- The fixture asserts `session_user`/`current_user` is the login role and that `rolsuper`/`rolbypassrls` are both false — proving the denial assertions genuinely exercise anon-level privileges rather than superuser-with-`SET ROLE`.

**Part B — expiry-warning reducer test (T4.8).** The T4.8 expiry warning was already covered end-to-end (`ExpiryCountdown.test.tsx`, `ManagerConsolePage.test.tsx` "Keep playing…", `useManagerActions.test.ts::extendGameDirect`, `test_extend_game.py`, `expiration.spec.ts` for the sweep path). The one genuine gap was a reducer-level assertion, added here: a `GAME_CHANGE` UPDATE bumping `expires_at` — the Realtime event `extend_game` triggers — flows into `useGameChannel` state so the countdown re-reads the later deadline. No existing assertions were duplicated.

Docs: `docs/testing-strategy.md` §4.1 updated with a note about the new RLS fixture approach. Phase file boxes ticked; `NEXT-SESSION.md` refreshed (next autonomous task = T7.2).

## Test plan

- **Part A (backend/db, testcontainer via `DATABASE_URL=""`):**
  - RLS files in isolation: `pytest tests/db/test_rls_anon.py tests/db/test_rls_function_grants.py` → **52 passed**.
  - Full `tests/db` suite (proves no cross-contamination — `test_rls_anon` passes in-suite): **171 passed, 1 skipped**.
  - Full backend+db suite as CI runs it (from `backend/`, no path args): **289 passed, 1 skipped** (the one skip is `test_pg_cron_registered`, expected on a bare testcontainer). CI uses testcontainers too (no external `DATABASE_URL`), matching this path exactly.
  - `ruff check` + `ruff format --check` clean on the changed file; `mypy app` clean.
- **Part B (frontend):** `npm run format:check && npm run lint && npm run typecheck && npm run test:run` all green — **43 files, 451 tests** (the new `useGameChannel` reducer test included).
