### PR TITLE
Decompose the god components: ManagerConsolePage + AdminSongsPage (T7.2)

### DIFF
--- a/docs/planning/NEXT-SESSION.md
+++ b/docs/planning/NEXT-SESSION.md
@@ -1,6 +1,6 @@
 # Next session — start here
 
-_Last updated: 2026-07-10 (**afternoon /next-task session** — merged **T6.2 (#200)**, **T7.4 (#201)**, **T7.3 T-RpcError+T-Deps (#202)**, and **fixed a mig-015 idempotency regression the stress gate caught (#203)**. **⚠️ Two maintainer actions pending** — see the box below. **Next autonomous work: Phase 7 (T7.5 or T7.2)** — T6.3 is blocked on maintainer prod access.)_
+_Last updated: 2026-07-10 (**T7.5 shipped** — proper RLS fixture fix (`anon_conn` now a dedicated non-superuser `LOGIN` role, kills the `test_rls_anon` in-suite flake) + expiry-warning reducer test; PR open, awaiting green CI + merge. Earlier the same day: merged **T6.2 (#200)**, **T7.4 (#201)**, **T7.3 T-RpcError+T-Deps (#202)**, **mig-015 idempotency fix (#203)**. **⚠️ Two maintainer actions pending** — see the box below. **Next autonomous work: T7.2** — T6.3 is blocked on maintainer prod access.)_
 
 > ### ⚠️ Maintainer actions pending (can't be done autonomously)
 > 1. **Apply mig 040 to prod** (T6.2 — deferred, hard-required-nothing column drop). Quiet window: `supabase link --project-ref jvfddxuaqcsrguibkymp && supabase db query --linked -f db/migrations/040_drop_total_rounds_column.sql`, then `bash ./tests/smoke/post_deploy.sh https://api.soundclash.org`. Prod is safe either way — mig 015 is now guarded so the drop can't break a replay.
@@ -30,11 +30,12 @@ _Last updated: 2026-07-10 (**afternoon /next-task session** — merged **T6.2 (#
 
 ## What to do next
 
-**T6.3 is blocked on maintainer prod access** (the read-only dupe query is denied by the auto-mode classifier without the maintainer present). So the next **autonomous** task is a Phase 7 item; recommended order:
+**T6.3 is blocked on maintainer prod access** (the read-only dupe query is denied by the auto-mode classifier without the maintainer present). **T7.5 is done** (RLS fixture fix + expiry reducer test — PR open, test-only, no runtime/schema change). So the next **autonomous** task is a Phase 7 item; recommended order:
 
-1. **T7.5** `[M]` — proper RLS fixture fix (`tests/db/conftest.py:124`: dedicated non-superuser `LOGIN` role + `current_user` assertion instead of `SET ROLE anon`) to kill the recurring `test_rls_anon` flake; plus a reducer/e2e test for the T4.8 expiry warning. **Backend/db — run pytest with `DATABASE_URL=""` so it uses a throwaway testcontainer, never the shared local stack** (lessons-learned).
-2. **T7.2** `[M]` — decompose the god components (`ManagerConsolePage` → `useSongPrebuffer`+`useScoring`; `AdminSongsPage` → `SongTable`/`SongEditForm`/`useAdminSongs`), guarded by their existing ~48-case tests.
-3. **T7.1** `[M, D-7]` — scoring single-source-of-truth in the DB. Own PR **behind the buzz-race gate** (`award_attempt` change) — careful.
+1. **T7.2** `[M]` — decompose the god components (`ManagerConsolePage` → `useSongPrebuffer`+`useScoring`; `AdminSongsPage` → `SongTable`/`SongEditForm`/`useAdminSongs`), guarded by their existing ~48-case tests.
+2. **T7.1** `[M, D-7]` — scoring single-source-of-truth in the DB. Own PR **behind the buzz-race gate** (`award_attempt` change) — careful.
+
+_(T7.5 ✅ — `anon_conn` now connects as a dedicated non-superuser `LOGIN` role (`anon_login_test`, granted membership in `anon`) via its own DSN with `session_user`/`rolsuper`/`rolbypassrls` assertions, replacing `SET ROLE anon`; full `tests/db` suite green in-suite with no `test_rls_anon` contamination. Plus a `useGameChannel` reducer test that a `GAME_CHANGE` UPDATE bumping `expires_at` — the Realtime event `extend_game` triggers — flows into state; the rest of the T4.8 expiry flow was already fully covered.)_
 
 **T6.3 (when the maintainer is present)** — one migration PR (**D-8 = youtube_id now**): (a) read-only prod query for duplicate `youtube_id`s; (b) dedup — merge dupes, repoint `song_genres`, delete losers (leave the Avicii "Wake Me Up" same-song-different-*video* pair — two distinct youtube_ids — alone); (c) idempotent `UNIQUE(songs.youtube_id)` migration; (d) verify no orphaned `song_genres`, song selection still works. Consider making it one migration that dedups **then** adds the constraint so it applies atomically to prod. Label it `run-stress` + `run-e2e`.
 

--- a/docs/planning/phases/phase-7-tech-debt.md
+++ b/docs/planning/phases/phase-7-tech-debt.md
@@ -22,8 +22,8 @@
 - [ ] Behind the buzz-race + full-game gate; own PR.
 
 ### T7.2 · Decompose the god components `[M]` — T-Manager, T-Admin
-- [ ] Extract `useSongPrebuffer` + `useScoring` from `ManagerConsolePage`; leave it as layout+wiring. Existing ~48-case test guards it.
-- [ ] Extract `SongTable`/`SongEditForm`/`useAdminSongs` from `AdminSongsPage`; fix the page-index clamp cleanly.
+- [x] Extract `useSongPrebuffer` + `useScoring` from `ManagerConsolePage`; leave it as layout+wiring. Existing ~48-case test guards it. (Pure refactor; all 64 `ManagerConsolePage.test.tsx` cases stayed green unchanged. Also split out `useManagerToken` so the intentional in-render ref access is contained to one small hook — needed because the new `react-hooks/refs` rule now analyzes the slimmed-down page.)
+- [x] Extract `SongTable`/`SongEditForm`/`useAdminSongs` from `AdminSongsPage`; fix the page-index clamp cleanly. (Clamp effect snaps `page` back to `totalPages` when a delete/filter shrinks the result set; new discriminating test in `AdminSongsPage.test.tsx`.)
 
 ### T7.3 · Small quality cleanups `[S]`
 - ~~`T-SongFetch`~~ ✅ shipped 2026-07-09 with Phase 4 T4.7 (PR #194) as `fetchSongById()` in `lib/songMetadata.ts` — it carries the F-P1-7 retry, so it outgrew `lib/soundtrack.ts`.

--- a/docs/planning/phases/phase-7-tech-debt.md
+++ b/docs/planning/phases/phase-7-tech-debt.md
@@ -36,8 +36,8 @@
 - [ ] Un-ignore `frontend/package-lock.json` after re-verifying the npm-10 runner bug is gone (deploy reproducibility). **Verify before flipping.**
 
 ### T7.5 · Test hardening `[M]` — T-RLSFix, T-CascadeTest
-- [ ] Proper RLS fixture fix: dedicated non-superuser `LOGIN` role + `current_user` assertion (`tests/db/conftest.py:124` still uses `SET ROLE anon`). The table-coverage extension already shipped.
-- [ ] e2e/reducer tests for: expiry warning (T4.8). (Cascade-delete ordering shipped with T4.4/PR #192, failed-hydrate with T4.3/PR #190, `preloadError` deploy-path tests with T4.0.)
+- [x] Proper RLS fixture fix: `anon_conn` now connects **as a dedicated non-superuser `LOGIN` role** (`anon_login_test`, provisioned once in `_migrated` setup, granted membership in `anon`) via its own DSN, instead of `SET ROLE anon` on the superuser connection; the fixture asserts `session_user`/`current_user` is that role and `rolsuper`/`rolbypassrls` are false. Kills the recurring in-suite `test_rls_anon` flake. (T7.5 — done 2026-07-10.)
+- [x] Reducer test for the expiry warning (T4.8): `useGameChannel.test.ts` now asserts a `GAME_CHANGE` UPDATE bumping `expires_at` (the Realtime event `extend_game` triggers) flows into reducer state. The rest of the T4.8 flow was already covered end-to-end (`ExpiryCountdown.test.tsx`, `ManagerConsolePage.test.tsx` "Keep playing…", `useManagerActions.test.ts::extendGameDirect`, `test_extend_game.py`), so no duplication was added. (Cascade-delete ordering shipped with T4.4/PR #192, failed-hydrate with T4.3/PR #190, `preloadError` deploy-path tests with T4.0.)
 
 ### T7.6 · CI discipline `[S — flag CI changes]`
 - [ ] `T-RLSCI`: isolated CI job for the RLS suite (deterministic green/red).

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -64,6 +64,8 @@ Numbers are targets at end of Phase 6. Don't game them; let the test count emerg
 
 Spin up Postgres via `testcontainers-postgres`. Apply all migrations from `db/migrations/`. Run tests against the fresh DB.
 
+The RLS tests (`test_rls_anon.py`, `test_rls_function_grants.py`) authenticate through the `anon_conn` fixture, which connects **as a dedicated non-superuser `LOGIN` role** provisioned once in setup and granted membership in `anon` (its own DSN), rather than doing `SET ROLE anon` on the superuser connection. The fixture asserts `session_user`/`current_user` is that role and that it is not a superuser and does not bypass RLS — so the denial assertions genuinely exercise anon-level privileges. This replaced the old `SET ROLE` approach, which leaked role state across reused containers and caused a recurring in-suite flake.
+
 | File | What it tests | Priority |
 |---|---|---|
 | `test_buzz_in_race.py` | 10 concurrent buzz_in calls → exactly 1 winner. **Loops 100×** in stress mode. | P0 |

--- a/frontend/src/components/SongEditForm.tsx
+++ b/frontend/src/components/SongEditForm.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState, type FormEvent } from "react";
+import type { Genre, Song, SongWritePayload } from "../lib/types";
+import styles from "../pages/AdminSongsPage.module.css";
+
+// Extracted from AdminSongsPage (T7.2, was the inline `SongForm`). The
+// create/edit song form: local field state, client-side validation, and the
+// genre multi-select. Pure move — the FormState shape, the validation rules,
+// and the payload mapping are unchanged.
+
+const YT_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+interface FormState {
+  title: string;
+  artist: string;
+  youtube_id: string;
+  start_time: string;
+  release_year: string;
+  genre_ids: Set<string>;
+}
+
+const EMPTY_FORM: FormState = {
+  title: "",
+  artist: "",
+  youtube_id: "",
+  start_time: "0",
+  release_year: "",
+  genre_ids: new Set(),
+};
+
+// Build the initial field state for the edit target, or the empty form when
+// creating. Kept internal so the page passes the raw `song` and this component
+// owns the Song → form-fields mapping (the page never touches FormState).
+function initialForm(song: Song | undefined): FormState {
+  if (!song) return EMPTY_FORM;
+  return {
+    title: song.title,
+    artist: song.artist,
+    youtube_id: song.youtube_id,
+    start_time: String(song.start_time),
+    release_year: song.release_year != null ? String(song.release_year) : "",
+    genre_ids: new Set((song.genres ?? []).map((g) => g.id)),
+  };
+}
+
+function formToPayload(form: FormState): SongWritePayload {
+  return {
+    title: form.title.trim(),
+    artist: form.artist.trim(),
+    youtube_id: form.youtube_id.trim(),
+    start_time: Number(form.start_time),
+    release_year: form.release_year.trim() === "" ? null : Number(form.release_year),
+    genre_ids: Array.from(form.genre_ids),
+  };
+}
+
+function formIsValid(form: FormState): boolean {
+  if (form.title.trim().length === 0 || form.title.trim().length > 200) return false;
+  if (form.artist.trim().length === 0 || form.artist.trim().length > 200) return false;
+  if (!YT_ID_PATTERN.test(form.youtube_id.trim())) return false;
+  const start = Number(form.start_time);
+  if (!Number.isInteger(start) || start < 0) return false;
+  const year = form.release_year.trim();
+  if (year !== "") {
+    const y = Number(year);
+    if (!Number.isInteger(y) || y < 1900 || y > 2100) return false;
+  }
+  if (form.genre_ids.size === 0) return false;
+  return true;
+}
+
+interface SongEditFormProps {
+  genres: Genre[];
+  // The song being edited, or undefined when creating a new one. The form seeds
+  // its fields from this once on mount; the parent remounts it (via a keyed
+  // element) when the target changes, so it isn't re-read after mount.
+  song: Song | undefined;
+  submitLabel: string;
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (payload: SongWritePayload) => void;
+}
+
+export function SongEditForm({
+  genres,
+  song,
+  submitLabel,
+  busy,
+  onCancel,
+  onSubmit,
+}: SongEditFormProps) {
+  const [form, setForm] = useState<FormState>(() => initialForm(song));
+
+  const valid = useMemo(() => formIsValid(form), [form]);
+
+  function toggleGenre(id: string) {
+    setForm((prev) => {
+      const next = new Set(prev.genre_ids);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { ...prev, genre_ids: next };
+    });
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!valid || busy) return;
+    onSubmit(formToPayload(form));
+  }
+
+  return (
+    <form className={styles.formPanel} onSubmit={handleSubmit}>
+      <h2>{submitLabel}</h2>
+      <p className="muted">
+        Tagging a song with the Soundtracks or Israeli Soundtracks genre makes it a +15 “name the
+        film/show” round. For those, put the film/show name in <strong>Artist</strong> (that’s the
+        answer revealed on screen); <strong>Title</strong> is the song/clip name, shown only as a
+        hint. Set Title equal to the film name when there’s no distinct song.
+      </p>
+      <div className={styles.formGrid}>
+        <label className={styles.field}>
+          <span>Title</span>
+          <input
+            type="text"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            maxLength={200}
+            aria-label="Title"
+          />
+        </label>
+        <label className={styles.field}>
+          <span>Artist</span>
+          <input
+            type="text"
+            value={form.artist}
+            onChange={(e) => setForm({ ...form, artist: e.target.value })}
+            maxLength={200}
+            aria-label="Artist"
+          />
+        </label>
+        <label className={styles.field}>
+          <span>YouTube ID (11 chars)</span>
+          <input
+            type="text"
+            value={form.youtube_id}
+            onChange={(e) => setForm({ ...form, youtube_id: e.target.value })}
+            maxLength={11}
+            spellCheck={false}
+            aria-label="YouTube ID"
+          />
+        </label>
+        <label className={styles.field}>
+          <span>Start time (seconds)</span>
+          <input
+            type="number"
+            min={0}
+            value={form.start_time}
+            onChange={(e) => setForm({ ...form, start_time: e.target.value })}
+            aria-label="Start time"
+          />
+        </label>
+        <label className={styles.field}>
+          <span>Release year (optional)</span>
+          <input
+            type="number"
+            min={1900}
+            max={2100}
+            placeholder="e.g. 1985"
+            value={form.release_year}
+            onChange={(e) => setForm({ ...form, release_year: e.target.value })}
+            aria-label="Release year"
+          />
+        </label>
+        <div className={`${styles.field} ${styles.fieldFull}`}>
+          <span>Genres ({form.genre_ids.size} selected)</span>
+          <div className={styles.genres}>
+            {genres.map((g) => {
+              const sel = form.genre_ids.has(g.id);
+              return (
+                <label
+                  key={g.id}
+                  className={`${styles.genreChip} ${sel ? styles.genreSelected : ""}`}
+                >
+                  <input type="checkbox" checked={sel} onChange={() => toggleGenre(g.id)} />
+                  {g.name}
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <div className={styles.formActions}>
+        <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+        <button type="submit" className="btn btn-primary" disabled={!valid || busy}>
+          {busy ? "Saving…" : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/SongTable.tsx
+++ b/frontend/src/components/SongTable.tsx
@@ -1,0 +1,124 @@
+import { Skeleton } from "./Skeleton";
+import type { Song } from "../lib/types";
+import styles from "../pages/AdminSongsPage.module.css";
+
+// Extracted from AdminSongsPage (T7.2). The catalog table: header, the
+// stale-while-revalidate dimming, the first-load skeleton rows, the empty
+// state, and the per-row Edit/Delete actions. Pure presentation — all state and
+// the API handlers live in useAdminSongs; this component only renders `songs`
+// and raises `onEdit` / `onDelete`.
+
+interface SongTableProps {
+  songs: Song[];
+  loading: boolean;
+  busy: boolean;
+  onEdit: (song: Song) => void;
+  onDelete: (id: string) => void;
+}
+
+export function SongTable({ songs, loading, busy, onEdit, onDelete }: SongTableProps) {
+  return (
+    <div className={styles.tableWrap} aria-busy={loading}>
+      {/* Stale-while-revalidate: on a filter/page change we keep the current
+          rows on screen (dimmed) while refetching, instead of blanking the
+          whole table back to skeletons. Skeletons show only on the very first
+          load, when there are no rows to keep. */}
+      <table className={`${styles.table} ${loading && songs.length > 0 ? styles.tableStale : ""}`}>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Artist</th>
+            <th>YouTube ID</th>
+            <th>Start</th>
+            <th>Year</th>
+            <th>Genres</th>
+            <th aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {loading && songs.length === 0 ? (
+            Array.from({ length: 5 }).map((_, i) => (
+              <tr key={`s-${i}`}>
+                <td>
+                  <Skeleton width="80%" height={16} />
+                </td>
+                <td>
+                  <Skeleton width="60%" height={16} />
+                </td>
+                <td>
+                  <Skeleton width="100px" height={16} />
+                </td>
+                <td>
+                  <Skeleton width="40px" height={16} />
+                </td>
+                <td>
+                  <Skeleton width="40px" height={16} />
+                </td>
+                <td>
+                  <Skeleton width="120px" height={16} />
+                </td>
+                <td />
+              </tr>
+            ))
+          ) : songs.length === 0 ? (
+            <tr>
+              <td colSpan={7} className={styles.empty}>
+                No songs found.
+              </td>
+            </tr>
+          ) : (
+            songs.map((s) => {
+              const genreNames = (s.genres ?? []).map((g) => g.name);
+              return (
+                <tr key={s.id}>
+                  <td>{s.title}</td>
+                  <td>{s.artist}</td>
+                  <td className={styles.ytId}>{s.youtube_id}</td>
+                  <td className={styles.startTime}>
+                    {s.start_time > 0 ? `${s.start_time}s` : "—"}
+                  </td>
+                  <td className={styles.startTime}>
+                    {s.release_year != null ? s.release_year : "—"}
+                  </td>
+                  <td>
+                    <div className={styles.genreList}>
+                      {genreNames.length === 0 ? (
+                        <span className={styles.startTime}>—</span>
+                      ) : (
+                        genreNames.map((name) => (
+                          <span key={name} className={styles.genreTag}>
+                            {name}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </td>
+                  <td>
+                    <div className={styles.rowActions}>
+                      <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={() => onEdit(s)}
+                        disabled={busy}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-danger"
+                        onClick={() => onDelete(s.id)}
+                        disabled={busy}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAdminSongs.ts
+++ b/frontend/src/hooks/useAdminSongs.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
+import { useToast } from "../context/useToast";
+import {
+  ApiError,
+  bulkImportSongs,
+  createSong,
+  deleteSong,
+  listGenres,
+  listSongs,
+  updateSong,
+} from "../lib/api";
+import type { Genre, Song, SongWritePayload } from "../lib/types";
+
+// Extracted from AdminSongsPage's SongsConsole during the T7.2 decomposition.
+// Owns the catalog data + filter/pagination state, the load/refetch effects,
+// and the create/edit/delete/import handlers. Behaviour is a pure move from the
+// component, plus one bug fix: the page index is now clamped into range so a
+// delete or filter that shrinks the result set can't strand the operator on a
+// page past the last one (see the clamp effect below).
+
+const PER_PAGE = 50;
+const SEARCH_DEBOUNCE_MS = 250;
+
+export type Mode = { kind: "list" } | { kind: "create" } | { kind: "edit"; song: Song };
+
+export interface AdminSongs {
+  songs: Song[];
+  total: number;
+  totalPages: number;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  searchInput: string;
+  setSearchInput: (value: string) => void;
+  genreFilter: string;
+  setGenreFilter: (value: string) => void;
+  genres: Genre[];
+  mode: Mode;
+  setMode: React.Dispatch<React.SetStateAction<Mode>>;
+  deleteId: string | null;
+  setDeleteId: React.Dispatch<React.SetStateAction<string | null>>;
+  loading: boolean;
+  busy: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  startEdit: (song: Song) => void;
+  handleSubmitForm: (payload: SongWritePayload) => Promise<void>;
+  handleConfirmDelete: () => Promise<void>;
+  handleFile: (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
+}
+
+interface UseAdminSongsOptions {
+  pw: string;
+  onAuthFail: () => void;
+}
+
+export function useAdminSongs({ pw, onAuthFail }: UseAdminSongsOptions): AdminSongs {
+  const { toast } = useToast();
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [genreFilter, setGenreFilterState] = useState("");
+  const [genres, setGenres] = useState<Genre[]>([]);
+  const [mode, setMode] = useState<Mode>({ kind: "list" });
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const deleteInFlightRef = useRef(false);
+
+  const reportError = useCallback(
+    (err: unknown, fallback: string) => {
+      if (err instanceof ApiError && err.status === 401) {
+        onAuthFail();
+        return;
+      }
+      toast(err instanceof Error ? err.message : fallback, { variant: "error" });
+    },
+    [onAuthFail, toast],
+  );
+
+  // Load genres once.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await listGenres();
+        if (!cancelled) setGenres(list);
+      } catch (err) {
+        if (!cancelled) reportError(err, "Failed to load genres");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reportError]);
+
+  // Debounce search input → search.
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [searchInput]);
+
+  // Refetch when filter inputs change.
+  const fetchSongs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await listSongs(
+        {
+          page,
+          per_page: PER_PAGE,
+          search: search || undefined,
+          genre: genreFilter || undefined,
+        },
+        pw,
+      );
+      setSongs(res.items);
+      setTotal(res.total);
+    } catch (err) {
+      reportError(err, "Failed to load songs");
+    } finally {
+      setLoading(false);
+    }
+  }, [genreFilter, page, pw, reportError, search]);
+
+  useEffect(() => {
+    void fetchSongs();
+  }, [fetchSongs]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
+
+  // Clamp the page index into range. A delete or a filter that shrinks the
+  // result set can leave `page` pointing past the last page (e.g. deleting the
+  // only row on page 3 of 3 → totalPages drops to 2 but page stays 3), which
+  // strands the operator on an empty "Page 3 of 2". Snapping back to the last
+  // real page triggers a refetch on a page that actually has rows. Guard on
+  // total > 0 so an empty result (totalPages floored at 1) doesn't fight a
+  // pending page-1 reset.
+  useEffect(() => {
+    if (total > 0 && page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, total, totalPages]);
+
+  // Changing the genre filter resets to page 1 (same as the debounced search),
+  // so the operator never lands on a page index that the new filter's smaller
+  // result set doesn't have.
+  const setGenreFilter = useCallback((value: string) => {
+    setGenreFilterState(value);
+    setPage(1);
+  }, []);
+
+  const startEdit = useCallback((song: Song) => {
+    setMode({ kind: "edit", song });
+  }, []);
+
+  async function handleSubmitForm(payload: SongWritePayload) {
+    setBusy(true);
+    try {
+      if (mode.kind === "create") {
+        await createSong(payload, pw);
+        toast("Song created", { variant: "success" });
+      } else if (mode.kind === "edit") {
+        await updateSong(mode.song.id, payload, pw);
+        toast("Song updated", { variant: "success" });
+      }
+      setMode({ kind: "list" });
+      await fetchSongs();
+    } catch (err) {
+      reportError(err, "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (deleteId === null || deleteInFlightRef.current) return;
+    deleteInFlightRef.current = true;
+    setBusy(true);
+    try {
+      await deleteSong(deleteId, pw);
+      toast("Song deleted", { variant: "success" });
+      setDeleteId(null);
+      await fetchSongs();
+    } catch (err) {
+      reportError(err, "Delete failed");
+    } finally {
+      setBusy(false);
+      deleteInFlightRef.current = false;
+    }
+  }
+
+  async function handleFile(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setBusy(true);
+    try {
+      const summary = await bulkImportSongs(file, pw);
+      toast(
+        `Imported ${summary.inserted} new + ${summary.updated} updated (${summary.total} total)`,
+        { variant: "success" },
+      );
+      await fetchSongs();
+    } catch (err) {
+      reportError(err, "Import failed");
+    } finally {
+      setBusy(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  return {
+    songs,
+    total,
+    totalPages,
+    page,
+    setPage,
+    searchInput,
+    setSearchInput,
+    genreFilter,
+    setGenreFilter,
+    genres,
+    mode,
+    setMode,
+    deleteId,
+    setDeleteId,
+    loading,
+    busy,
+    fileInputRef,
+    startEdit,
+    handleSubmitForm,
+    handleConfirmDelete,
+    handleFile,
+  };
+}

--- a/frontend/src/hooks/useGameChannel.test.ts
+++ b/frontend/src/hooks/useGameChannel.test.ts
@@ -280,6 +280,28 @@ describe("gameReducer", () => {
     expect(next?.currentRound?.id).toBe("r1");
   });
 
+  it("GAME_CHANGE UPDATE carries a bumped expires_at into state (extend_game path)", () => {
+    // After the manager's "Keep playing +1h" fires extend_game, the only thing
+    // that moves the expiry warning back out of the window is the Realtime
+    // UPDATE on active_games with the new expires_at. Assert that update flows
+    // through the reducer so the ExpiryCountdown re-reads a later deadline.
+    const start = gameReducer(null, {
+      type: "HYDRATE",
+      game: makeActiveGame({ status: "playing", expires_at: "2026-05-05T12:10:00.000Z" }),
+      teams: [],
+      rounds: [],
+    });
+    const bumped = makeActiveGame({
+      status: "playing",
+      expires_at: "2026-05-05T13:10:00.000Z",
+    });
+    const next = gameReducer(start, {
+      type: "GAME_CHANGE",
+      payload: makePayload("active_games", "UPDATE", { new: bumped }),
+    });
+    expect(next?.game.expires_at).toBe("2026-05-05T13:10:00.000Z");
+  });
+
   it("GAME_CHANGE DELETE returns null", () => {
     const start = gameReducer(null, {
       type: "HYDRATE",

--- a/frontend/src/hooks/useManagerToken.ts
+++ b/frontend/src/hooks/useManagerToken.ts
@@ -1,0 +1,48 @@
+import { useMemo, useRef } from "react";
+import { getManagerToken, parseRecoveryHash, setManagerToken } from "../lib/managerToken";
+
+// Resolve the per-game manager token for the console (T4.10 backup-host-link
+// adoption). Extracted verbatim from ManagerConsolePage during the T7.2
+// decomposition so the intentional in-render ref access stays contained in one
+// small, well-named hook instead of tainting the page's whole render.
+//
+// A backup-host-link URL — /manager/game/<code>#mt=<token> — re-authenticates a
+// host whose localStorage is gone (new device, cleared browser). Resolution
+// order:
+//   1. A token already stored for this game wins unconditionally — recovery is
+//      for tokenless devices. The room knows the game code, so if the hash won
+//      instead, any guest could craft a well-formed #mt= link that silently
+//      clobbers the host's working credential (one-click lockout).
+//   2. Otherwise a well-formed fragment is adopted: persisted for future visits
+//      and mirrored in a ref so the credential survives the hash scrub the page
+//      runs next, even where localStorage writes are blocked (private mode) —
+//      persistence is best-effort, the live session is not.
+//   3. Otherwise fall back to that ref (an adoption earlier in this mount);
+//      keyed by game code so a console-to-console navigation can't reuse it.
+// Reading storage and the idempotent write inside the memo keep the very first
+// render authenticated (no "not the host" flash); both are safe under
+// StrictMode's double-invoke.
+export function useManagerToken(gameCode: string, hash: string): string | null {
+  const adoptedTokenRef = useRef<{ gameCode: string; token: string } | null>(null);
+  // The memo intentionally reads/writes the ref during render to keep the very
+  // first paint authenticated (no "not the host" flash) and to survive the
+  // page's hash-scrub navigation even where localStorage writes are blocked.
+  // The write is idempotent, so it's safe under StrictMode's double-invoke.
+  // react-hooks/refs forbids in-render ref access categorically; this is the
+  // documented exception, contained to this one small hook so it doesn't taint
+  // the console's render.
+  // eslint-disable-next-line react-hooks/refs -- first-paint no-flash guard; survives the hash scrub
+  return useMemo(() => {
+    const stored = getManagerToken(gameCode);
+    if (stored) return stored;
+    const adopted = parseRecoveryHash(hash);
+    if (adopted) {
+      // eslint-disable-next-line react-hooks/refs -- see above; idempotent in-render mirror write
+      adoptedTokenRef.current = { gameCode, token: adopted };
+      setManagerToken(gameCode, adopted);
+      return adopted;
+    }
+    // eslint-disable-next-line react-hooks/refs -- see above; in-render read is the no-flash guard
+    return adoptedTokenRef.current?.gameCode === gameCode ? adoptedTokenRef.current.token : null;
+  }, [gameCode, hash]);
+}

--- a/frontend/src/hooks/useScoring.ts
+++ b/frontend/src/hooks/useScoring.ts
@@ -1,0 +1,625 @@
+import { useEffect, useRef, useState } from "react";
+import { useToast } from "../context/useToast";
+import { ApiError, awardBonus, endGame } from "../lib/api";
+import {
+  awardAttemptDirect,
+  extendGameDirect,
+  releaseBuzzLockDirect,
+  RpcError,
+} from "./useManagerActions";
+import { selectNextSongDirect } from "./useSelectNextSong";
+import { clearManagerToken } from "../lib/managerToken";
+import { failScore, log, markScoreStart } from "../lib/telemetry";
+import { fetchSongById } from "../lib/songMetadata";
+import type { GameState, Song } from "../lib/types";
+import type { SongPrebuffer } from "./useSongPrebuffer";
+
+// Extracted from ManagerConsolePage (T7.2). Owns the manager scoring + round
+// actions: the direct-RPC calls (award_attempt / release_buzz_lock /
+// select_next_song / extend_game) and the FastAPI-routed ones (bonus / end),
+// the optimistic-toast-then-await ordering, the per-action in-flight guards, and
+// the pending-flag handoffs that bridge the RPC → Realtime gap. Behaviour is a
+// pure move — the same RPCs with the same args, the same toast timing, the same
+// busy/pending gating. handleNextRound drives the double-buffer swap via the
+// SongPrebuffer surface passed in, so the two hooks compose exactly as the
+// single component did.
+
+interface PlayerReadyHandle {
+  ready: boolean;
+  enqueueSong: (song: { youtube_id: string; start_time: number }) => void;
+}
+
+export interface Scoring {
+  currentSong: Song | null;
+  busy: boolean;
+  endConfirmOpen: boolean;
+  setEndConfirmOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  bonusOpen: boolean;
+  setBonusOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  pendingTitle: string | null;
+  pendingArtist: string | null;
+  pendingWrong: string | null;
+  pendingContinue: string | null;
+  pendingExtendFor: string | null;
+  handleCorrectTitle: () => Promise<void>;
+  handleCorrectArtist: () => Promise<void>;
+  handleCorrectSoundtrack: () => Promise<void>;
+  handleContinueRound: () => Promise<void>;
+  handleWrong: () => Promise<void>;
+  handleNextRound: () => Promise<void>;
+  handleExtendGame: () => Promise<void>;
+  handleBonus: (teamId: string, teamName: string) => Promise<void>;
+  performEnd: () => Promise<void>;
+}
+
+export function useScoring(
+  gameCode: string,
+  managerToken: string | null,
+  state: GameState | null,
+  player: PlayerReadyHandle,
+  prebuffer: SongPrebuffer,
+): Scoring {
+  const { toast } = useToast();
+  const {
+    activePlayer,
+    standbyPlayer,
+    activeKeyRef,
+    setActiveKey,
+    preloadRef,
+    preloadEpochRef,
+    optimisticSongIdRef,
+    songStartRef,
+    playerARef,
+    playerBRef,
+    loadSongIntoPlayer,
+    armSongStartTimeout,
+    beginSongStart,
+  } = prebuffer;
+
+  const [currentSong, setCurrentSong] = useState<Song | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [endConfirmOpen, setEndConfirmOpen] = useState(false);
+  const [bonusOpen, setBonusOpen] = useState(false);
+
+  // Optimistic "we just clicked this" markers for the per-round action buttons,
+  // each holding the round id the click happened on. They bridge the ~50-
+  // 100ms gap between the RPC returning and the Realtime UPDATE on game_rounds
+  // (title_claimed_by / artist_claimed_by) or active_games (buzzed_team_id)
+  // arriving -- keeping the button disabled across that gap so it doesn't flash
+  // enabled in the window. The flag is naturally self-clearing on round change
+  // (stale id won't equal the new round.id) and gets reset by the effects
+  // below for tidiness. Cleared in each handler's catch on failure so a
+  // transient RPC error doesn't leave the button permanently disabled.
+  // pendingContinue mirrors pendingWrong: Continue releases the buzz lock, so
+  // it stays disabled until the Realtime UPDATE clears buzzed_team_id.
+  const [pendingTitle, setPendingTitle] = useState<string | null>(null);
+  const [pendingArtist, setPendingArtist] = useState<string | null>(null);
+  const [pendingWrong, setPendingWrong] = useState<string | null>(null);
+  const [pendingContinue, setPendingContinue] = useState<string | null>(null);
+  // Extend-game handoff, same shape as the flags above but keyed on the
+  // expires_at value the click happened on: the banner's button stays disabled
+  // until the Realtime UPDATE lands with the bumped value (at which point the
+  // flag is stale and inert). Cleared on failure so the host can retry.
+  const [pendingExtendFor, setPendingExtendFor] = useState<string | null>(null);
+
+  // Synchronous in-flight locks, one PER ACTION. These are the sole guard
+  // against a same-action double-fire now that the shared `busy` gate is off
+  // the hot handlers (removing it is what stops a *distinct* second click --
+  // e.g. Correct Song then quickly Wrong -- from being silently dropped inside
+  // the first action's window; see F-P1-8 / F-P2-2). useState can't do this
+  // job: `busy` is captured in the closure at render time, so two clicks in
+  // one React tick both read the stale value; useRef.current mutates
+  // synchronously, so the second same-action click sees `true` and bails.
+  // Matters most for handleNextRound, where a duplicate fire would insert an
+  // orphan game_rounds row (the other actions are idempotent via the SQL
+  // function's already-claimed / no-buzz-to-score branches).
+  const titleInFlightRef = useRef(false);
+  const artistInFlightRef = useRef(false);
+  const wrongInFlightRef = useRef(false);
+  const continueInFlightRef = useRef(false);
+  const nextRoundInFlightRef = useRef(false);
+  const extendInFlightRef = useRef(false);
+
+  // When we get the buzz lock signal, pause playback on the live player.
+  useEffect(() => {
+    if (state?.game.buzzed_team_id != null) {
+      // activePlayer() reads activeKeyRef synchronously, so it always pauses
+      // whichever player is live regardless of swaps.
+      activePlayer()?.pause();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state?.game.buzzed_team_id]);
+
+  // Reset the per-click pending flags whenever the round changes. The
+  // disabled checks already compare against `round?.id` so stale flags
+  // are inert, but clearing them keeps state tidy and avoids confusion
+  // when debugging.
+  const currentRoundId = state?.currentRound?.id ?? null;
+  useEffect(() => {
+    setPendingTitle(null);
+    setPendingArtist(null);
+    setPendingWrong(null);
+    setPendingContinue(null);
+    // The round advanced (or reset): any optimistic Next-round prediction has
+    // now either landed or is moot, so drop the suppression id.
+    optimisticSongIdRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentRoundId]);
+
+  // Wrong and Continue both release the buzz lock, so a follow-up buzz in the
+  // same round must re-enable their buttons. `pendingWrong` / `pendingContinue`
+  // only bridge the gap between the RPC returning and the Realtime UPDATE on
+  // buzzed_team_id; once that UPDATE has landed (lock cleared) the flags have
+  // done their job and must drop or the next buzz's click stays blocked.
+  useEffect(() => {
+    if (state?.game.buzzed_team_id == null) {
+      setPendingWrong(null);
+      setPendingContinue(null);
+    }
+  }, [state?.game.buzzed_team_id]);
+
+  // After a manager-tab refresh mid-round, currentSong is null but the round
+  // row still has a song_id. Resolve it and push it into the player so the
+  // host doesn't have to abandon the round and click Next round. Must stay
+  // loadVideoById (not cueVideoById): on the happy path the Realtime INSERT
+  // for the new round arrives before selectSong's HTTP response, so this
+  // effect races with handleNextRound's loadVideoById. Calling cue while load
+  // is in flight (or vice-versa) puts YT.Player into an inconsistent state and
+  // surfaces as the "Video unavailable" onError overlay.
+  const currentRoundSongId = state?.currentRound?.song_id ?? null;
+  const playerReady = player.ready;
+  useEffect(() => {
+    if (!currentRoundSongId) return;
+    if (currentSong && currentSong.id === currentRoundSongId) return;
+    // I-NextMeta: currentSong is the optimistically-committed next song, ahead of
+    // the round that hasn't advanced yet — NOT a stale leftover. Don't refetch
+    // the old round's song (which would also reload it over the promoted player);
+    // the round will catch up momentarily and the RPC reconciles the metadata.
+    if (currentSong && currentSong.id === optimisticSongIdRef.current) return;
+    let cancelled = false;
+    // fetchSongById retries transient failures with bounded backoff (F-P1-7)
+    // so one blip doesn't leave the post-refresh player empty for the round.
+    void fetchSongById(currentRoundSongId, () => cancelled).then((song) => {
+      if (cancelled || !song) return;
+      setCurrentSong(song);
+      if (playerReady) {
+        activePlayer()?.loadVideoById(song.youtube_id, song.start_time);
+      } else {
+        player.enqueueSong({ youtube_id: song.youtube_id, start_time: song.start_time });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // `player` is a stable hook handle; we only need to re-run when the
+    // current round's song changes or the player flips to ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentRoundSongId, currentSong?.id, playerReady]);
+
+  function reportError(err: unknown) {
+    if (err instanceof ApiError) {
+      const reason =
+        err.details && typeof err.details === "object" && err.details !== null
+          ? (err.details as { reason?: unknown }).reason
+          : undefined;
+      if (err.status === 409 && reason === "no_more_songs") {
+        toast(
+          "All songs in your selected genres have been played. End the game or start a new one with more genres.",
+          { variant: "error" },
+        );
+        return;
+      }
+    }
+    if (err instanceof RpcError) {
+      // PL/pgSQL RAISE EXCEPTION '<code>' lands as message = '<code>'.
+      // 'no_buzz_to_score' / 'title_already_claimed' just mean the click was
+      // a no-op (Realtime already cleared the lock or claimed the token);
+      // don't spook the host with an error toast.
+      if (
+        err.message === "no_buzz_to_score" ||
+        err.message === "title_already_claimed" ||
+        err.message === "artist_already_claimed"
+      ) {
+        return;
+      }
+      // 'no_more_songs' is the friendly user-facing error from select_next_song
+      // when the selected-genres pool is exhausted. Mirror the ApiError text
+      // above so the manager sees the same wording regardless of which path
+      // surfaced it.
+      if (err.message === "no_more_songs") {
+        toast(
+          "All songs in your selected genres have been played. End the game or start a new one with more genres.",
+          { variant: "error" },
+        );
+        return;
+      }
+      log("error", "manager_rpc_failed", { message: err.message });
+      toast(err.message, { variant: "error" });
+      return;
+    }
+    log("error", "manager_action_failed", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    toast(err instanceof Error ? err.message : "Request failed", { variant: "error" });
+  }
+
+  // Apply an attempt via the direct browser -> Supabase RPC. Migration 021
+  // moved the manager-token gate into the PL/pgSQL function, so we bypass
+  // FastAPI/Render here and cut ~300ms of cross-continent hops off the
+  // critical path. The score commit and the Realtime fan-out happen in the
+  // same DB transaction; the UI then redraws when game_teams / game_rounds
+  // UPDATE events arrive.
+  async function applyAttempt(
+    roundId: string,
+    flags: { title_correct: boolean; artist_correct: boolean; wrong_buzz: boolean },
+  ): Promise<void> {
+    if (!managerToken) return;
+    await awardAttemptDirect(gameCode, managerToken, roundId, flags);
+  }
+
+  // Helper for the optimistic toast on the three scoring buttons. Fired
+  // before the RPC so the click feels instant; the Realtime UPDATE on
+  // game_teams.score is still the source of truth for the displayed score.
+  function buzzedTeamName(): string | null {
+    if (!state) return null;
+    const tid = state.game.buzzed_team_id;
+    if (!tid) return null;
+    return state.teams.get(tid)?.name ?? null;
+  }
+
+  async function handleCorrectTitle() {
+    if (titleInFlightRef.current) return;
+    if (!state?.currentRound || !managerToken) return;
+    if (!state.game.buzzed_team_id) return;
+    titleInFlightRef.current = true;
+    const roundId = state.currentRound.id;
+    const teamName = buzzedTeamName();
+    if (teamName) toast(`+10 to ${teamName}`, { variant: "success" });
+    // Pending flag flips the disabled prop synchronously on click and stays
+    // set until the Realtime UPDATE on game_rounds.title_claimed_by lands
+    // (after which the semantic gate takes over) -- no enable/disable
+    // flicker in the gap.
+    setPendingTitle(roundId);
+    markScoreStart(gameCode, roundId, "title");
+    try {
+      await applyAttempt(roundId, {
+        title_correct: true,
+        artist_correct: false,
+        wrong_buzz: false,
+      });
+    } catch (err) {
+      failScore(roundId, "title");
+      setPendingTitle(null);
+      reportError(err);
+    } finally {
+      titleInFlightRef.current = false;
+    }
+  }
+
+  async function handleCorrectArtist() {
+    if (artistInFlightRef.current) return;
+    if (!state?.currentRound || !managerToken) return;
+    if (!state.game.buzzed_team_id) return;
+    artistInFlightRef.current = true;
+    const roundId = state.currentRound.id;
+    const teamName = buzzedTeamName();
+    if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
+    setPendingArtist(roundId);
+    markScoreStart(gameCode, roundId, "artist");
+    try {
+      await applyAttempt(roundId, {
+        title_correct: false,
+        artist_correct: true,
+        wrong_buzz: false,
+      });
+    } catch (err) {
+      failScore(roundId, "artist");
+      setPendingArtist(null);
+      reportError(err);
+    } finally {
+      artistInFlightRef.current = false;
+    }
+  }
+
+  // Soundtrack rounds (current song has is_soundtrack=true) use a single
+  // "Correct +15" button instead of the title/artist split. The team's job is
+  // to name the work (film / TV / game / musical), not the song title; awarding
+  // both flags at once sums to 15 points via the existing award_attempt
+  // function -- no SQL change needed. Both tokens claim together; nothing more
+  // can be scored on this round, so we let it sit in the fully-scored state
+  // (lock held, player paused) and wait for the manager's "Next round" click,
+  // mirroring how a regular round behaves once both title + artist are claimed.
+  async function handleCorrectSoundtrack() {
+    if (titleInFlightRef.current || artistInFlightRef.current) return;
+    if (!state?.currentRound || !managerToken) return;
+    if (!state.game.buzzed_team_id) return;
+    titleInFlightRef.current = true;
+    artistInFlightRef.current = true;
+    const roundId = state.currentRound.id;
+    const teamName = buzzedTeamName();
+    if (teamName) toast(`+15 to ${teamName}`, { variant: "success" });
+    setPendingTitle(roundId);
+    setPendingArtist(roundId);
+    markScoreStart(gameCode, roundId, "soundtrack");
+    try {
+      await applyAttempt(roundId, {
+        title_correct: true,
+        artist_correct: true,
+        wrong_buzz: false,
+      });
+    } catch (err) {
+      failScore(roundId, "soundtrack");
+      setPendingTitle(null);
+      setPendingArtist(null);
+      reportError(err);
+    } finally {
+      titleInFlightRef.current = false;
+      artistInFlightRef.current = false;
+    }
+  }
+
+  async function handleContinueRound() {
+    if (continueInFlightRef.current) return;
+    if (!managerToken) return;
+    continueInFlightRef.current = true;
+    // Optimistic toast fires before the RPC so the click feels instant; the
+    // Realtime UPDATE on active_games.buzzed_team_id is still the source of
+    // truth for re-arming the buzzers.
+    toast("Round continued", { variant: "info" });
+    // Keep Continue disabled until the lock actually clears via Realtime, the
+    // same handoff pendingWrong uses -- no enable/disable flash in the gap.
+    setPendingContinue(state?.currentRound?.id ?? null);
+    try {
+      await releaseBuzzLockDirect(gameCode, managerToken);
+      activePlayer()?.play();
+    } catch (err) {
+      setPendingContinue(null);
+      reportError(err);
+    } finally {
+      continueInFlightRef.current = false;
+    }
+  }
+
+  // Wrong is a one-click verdict: it fires award_attempt with wrong_buzz=true,
+  // re-arms the buzzers, and resumes the song (no separate "Continue round"
+  // press needed). Per game-rules.md §4 the -3 is waived only when the round's
+  // one-shot free-guess flag is armed (`free_guess_active`), which the SQL
+  // arms after a correct attempt and consumes on the very next attempt. We
+  // mirror that exact flag here so the optimistic toast matches the score the
+  // server will commit -- reading "any token claimed" instead would wrongly
+  // suppress the -3 toast for every later wrong in a round that had a correct.
+  // Playback resume is held until the RPC commits so a failed Wrong leaves the
+  // song paused with the lock still held -- the manager can simply retry.
+  async function handleWrong() {
+    if (wrongInFlightRef.current) return;
+    if (!state?.currentRound || !managerToken) return;
+    if (!state.game.buzzed_team_id) return;
+    wrongInFlightRef.current = true;
+    const roundId = state.currentRound.id;
+    const teamName = buzzedTeamName();
+    const freeGuess = state.currentRound.free_guess_active;
+    if (teamName && !freeGuess) toast(`-3 to ${teamName}`, { variant: "info" });
+    setPendingWrong(roundId);
+    try {
+      await applyAttempt(roundId, {
+        title_correct: false,
+        artist_correct: false,
+        wrong_buzz: true,
+      });
+      activePlayer()?.play();
+    } catch (err) {
+      setPendingWrong(null);
+      reportError(err);
+    } finally {
+      wrongInFlightRef.current = false;
+    }
+  }
+
+  async function handleNextRound() {
+    if (nextRoundInFlightRef.current) return;
+    if (!managerToken) return;
+    nextRoundInFlightRef.current = true;
+    // Bump the preload epoch so any in-flight peek is discarded rather than
+    // buffering into a player we're about to repurpose.
+    preloadEpochRef.current += 1;
+    // Open the song-start span at the click instant (before the toast) so it
+    // captures click → RPC → load → audio actually playing.
+    const songStart = beginSongStart();
+    // Optimistic toast confirms the click immediately.
+    toast("Loading next round...", { variant: "info" });
+    // Snapshot + clear the prebuffered song now so a late preload can't reuse it.
+    const preloaded = preloadRef.current;
+    preloadRef.current = null;
+    // Pre-swap snapshot for the rollback in the catch below: which player was
+    // live and which song card was up before the optimistic in-gesture swap.
+    const prevKey = activeKeyRef.current;
+    const prevSong = currentSong;
+
+    // FAST PATH — start the prebuffered song *synchronously inside this tap*,
+    // BEFORE awaiting the RPC. Mobile browsers only allow unmuted playback that
+    // begins within a user gesture; resuming after `await select_next_song`
+    // counts as blocked autoplay, which is exactly the reported bug (round 1 /
+    // Next round stayed silent until a stray buzz + Continue finally unlocked
+    // it). We pass preloaded.song_id to the RPC below, so the video we begin
+    // playing here is guaranteed to be the one the round records — it's safe to
+    // start it before the round is committed server-side. commitPrebuffered
+    // resumes an already-downloaded (muted) buffer, so the unmute+play lands in
+    // the gesture and the room hears it immediately.
+    let committedPreloaded = false;
+    if (preloaded) {
+      songStart.loadIssued();
+      armSongStartTimeout();
+      const promoted = standbyPlayer();
+      const demoted = activePlayer();
+      promoted?.commitPrebuffered(preloaded.start_time);
+      demoted?.stop();
+      const nextKey = activeKeyRef.current === "A" ? "B" : "A";
+      activeKeyRef.current = nextKey;
+      setActiveKey(nextKey);
+      committedPreloaded = true;
+      // I-NextMeta: the prebuffered audio is already playing, so render the new
+      // song's card in-gesture from the peeked metadata (mig 038) instead of
+      // leaving the PREVIOUS title up until select_next_song resolves ~150ms
+      // later. Record the id first so the song-resolver effect treats this as an
+      // optimistic lead (not staleness) and doesn't reload the old song. The
+      // RPC's authoritative row reconciles the card below (same values).
+      optimisticSongIdRef.current = preloaded.song_id;
+      setCurrentSong({
+        id: preloaded.song_id,
+        title: preloaded.title,
+        artist: preloaded.artist,
+        youtube_id: preloaded.youtube_id,
+        start_time: preloaded.start_time,
+        is_soundtrack: preloaded.is_soundtrack,
+      });
+    }
+
+    try {
+      if (committedPreloaded && preloaded) {
+        // Confirm/record the round for the exact song we already started.
+        const result = await selectNextSongDirect(gameCode, managerToken, preloaded.song_id);
+        songStart.rpcDone({
+          roundNumber: result.round_number,
+          songId: result.song.id,
+          youtubeId: result.song.youtube_id,
+          preloaded: true,
+        });
+        setCurrentSong(result.song);
+        if (result.song.id !== preloaded.song_id) {
+          // Defensive: the RPC picked something other than what we prebuffered
+          // and already began playing (should not happen with an explicit
+          // song_id). Cold-load the real song onto the now-live player.
+          await loadSongIntoPlayer(result.song);
+        }
+      } else {
+        // Slow path (first round without a warmed buffer, preload missed, or
+        // pool was empty at peek time): random pick + cold load on the live
+        // player. On mobile this load lands after the await, so it can't reliably
+        // autoplay — but the waiting-screen prebuffer normally routes round 1
+        // through the fast path above, leaving this as a rare fallback.
+        const result = await selectNextSongDirect(gameCode, managerToken);
+        songStart.rpcDone({
+          roundNumber: result.round_number,
+          songId: result.song.id,
+          youtubeId: result.song.youtube_id,
+          preloaded: false,
+        });
+        setCurrentSong(result.song);
+        await loadSongIntoPlayer(result.song);
+      }
+    } catch (err) {
+      songStart.fail("select_next_song_failed");
+      songStartRef.current = null;
+      optimisticSongIdRef.current = null;
+      // The round failed to advance server-side, so the optimistic in-gesture
+      // swap (which has to happen before the await for mobile autoplay) must
+      // not stand. Roll all of it back: silence the promoted player, restore
+      // the pre-click active player + song card, and reload the still-current
+      // round's song so the room isn't left in silence (best-effort on strict
+      // mobile autoplay — this load lands outside the gesture). The peeked
+      // song goes back into the standby buffer: the round never advanced, so
+      // it is still exactly what select_next_song would record, and a retry
+      // click keeps the in-gesture fast path.
+      if (committedPreloaded && preloaded) {
+        activePlayer()?.stop();
+        activeKeyRef.current = prevKey;
+        setActiveKey(prevKey);
+        setCurrentSong(prevSong);
+        if (prevSong) activePlayer()?.loadVideoById(prevSong.youtube_id, prevSong.start_time);
+        preloadRef.current = preloaded;
+        standbyPlayer()?.prebuffer(preloaded.youtube_id, preloaded.start_time);
+      }
+      reportError(err);
+    } finally {
+      nextRoundInFlightRef.current = false;
+    }
+  }
+
+  // The expiry banner's "Keep playing +1h" -> extend_game direct RPC (mig
+  // 039), pushing active_games.expires_at out an hour. The Realtime UPDATE on
+  // expires_at is what moves the banner back to the subtle hint for everyone;
+  // the toast just confirms the commit to the host who clicked.
+  async function handleExtendGame() {
+    if (extendInFlightRef.current) return;
+    if (!state || !managerToken) return;
+    extendInFlightRef.current = true;
+    setPendingExtendFor(state.game.expires_at);
+    try {
+      const newExpiresAt = await extendGameDirect(gameCode, managerToken);
+      const endsAt = new Date(newExpiresAt).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      toast(`Game extended — now ends at ${endsAt}`, { variant: "success" });
+    } catch (err) {
+      setPendingExtendFor(null);
+      reportError(err);
+    } finally {
+      extendInFlightRef.current = false;
+    }
+  }
+
+  async function handleBonus(teamId: string, teamName: string) {
+    if (busy || !managerToken) return;
+    // Close the picker and acknowledge the click immediately, but do NOT
+    // claim success yet: the bonus is the one Render-routed scoring call, so
+    // on a cold start it can hang for many seconds or fail outright, and an
+    // optimistic "+4" here let the host believe a bonus landed that the room
+    // never saw (F-P1-5). The success toast waits for the call to resolve;
+    // `busy` keeps Bonus + End game gated while it's in flight (the per-round
+    // scoring buttons stay deliberately independent of it).
+    setBonusOpen(false);
+    toast(`Sending +4 to ${teamName}...`, { variant: "info" });
+    setBusy(true);
+    try {
+      await awardBonus(gameCode, managerToken, { team_id: teamId });
+      toast(`+4 bonus to ${teamName}`, { variant: "success" });
+    } catch (err) {
+      reportError(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function performEnd() {
+    if (busy || !managerToken) return;
+    // Toast fires before the network call so the manager gets immediate
+    // feedback the click registered; if endGame() fails reportError() will
+    // surface the failure on top.
+    toast("Ending game...", { variant: "info" });
+    setBusy(true);
+    try {
+      await endGame(gameCode, managerToken);
+      playerARef.current?.stop();
+      playerBRef.current?.stop();
+      clearManagerToken(gameCode);
+    } catch (err) {
+      reportError(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return {
+    currentSong,
+    busy,
+    endConfirmOpen,
+    setEndConfirmOpen,
+    bonusOpen,
+    setBonusOpen,
+    pendingTitle,
+    pendingArtist,
+    pendingWrong,
+    pendingContinue,
+    pendingExtendFor,
+    handleCorrectTitle,
+    handleCorrectArtist,
+    handleCorrectSoundtrack,
+    handleContinueRound,
+    handleWrong,
+    handleNextRound,
+    handleExtendGame,
+    handleBonus,
+    performEnd,
+  };
+}

--- a/frontend/src/hooks/useSongPrebuffer.ts
+++ b/frontend/src/hooks/useSongPrebuffer.ts
@@ -1,0 +1,273 @@
+import { useEffect, useRef, useState } from "react";
+import type { YouTubePlayerHandle } from "../components/YouTubePlayer";
+import { useToast } from "../context/useToast";
+import { peekNextSongDirect, type PeekedSong } from "./usePeekNextSong";
+import { log, startSongStart, type SongStartHandle } from "../lib/telemetry";
+import type { GameState, Song } from "../lib/types";
+
+// Extracted from ManagerConsolePage (T7.2). Owns the double-buffer YouTube
+// player machinery: two persistent players overlaid in one box (one live +
+// audible, one silent standby that prebuffers the NEXT song), the peek +
+// prebuffer flow (`peek_next_song`, mig 029/038), and the song-start telemetry
+// span. Behaviour is a pure move — the same peeks, prebuffers, swaps, and
+// telemetry as before; nothing about the RPC semantics or ordering changed.
+//
+// The hook returns both the JSX-facing pieces (player refs, activeKey, the
+// player callbacks) AND an imperative surface the "Next round" handler needs to
+// commit/roll back a swap. useScoring's handleNextRound composes that surface,
+// so the two hooks stay coupled exactly as the single component was.
+
+export interface SongPrebuffer {
+  // JSX wiring.
+  playerARef: React.RefObject<YouTubePlayerHandle | null>;
+  playerBRef: React.RefObject<YouTubePlayerHandle | null>;
+  activeKey: "A" | "B";
+  onPlayerReady: () => void;
+  onPlayerBReady: () => void;
+  handlePlayerPlaying: (detection: "statechange" | "poll") => void;
+  handlePlayerError: (key: "A" | "B", code: number) => void;
+
+  // Imperative surface for handleNextRound + the mid-round song resolver.
+  activePlayer: () => YouTubePlayerHandle | null;
+  standbyPlayer: () => YouTubePlayerHandle | null;
+  activeKeyRef: React.MutableRefObject<"A" | "B">;
+  setActiveKey: React.Dispatch<React.SetStateAction<"A" | "B">>;
+  preloadRef: React.MutableRefObject<PeekedSong | null>;
+  preloadEpochRef: React.MutableRefObject<number>;
+  optimisticSongIdRef: React.MutableRefObject<string | null>;
+  songStartRef: React.MutableRefObject<SongStartHandle | null>;
+  loadSongIntoPlayer: (song: Song) => Promise<void>;
+  armSongStartTimeout: () => void;
+  maybePreloadNext: () => void;
+  beginSongStart: () => SongStartHandle;
+}
+
+interface PlayerReadyHandle {
+  ready: boolean;
+  setReady: () => void;
+  enqueueSong: (song: { youtube_id: string; start_time: number }) => void;
+  flushPendingSong: () => { youtube_id: string; start_time: number } | null;
+}
+
+export function useSongPrebuffer(
+  gameCode: string,
+  managerToken: string | null,
+  state: GameState | null,
+  player: PlayerReadyHandle,
+): SongPrebuffer {
+  const { toast } = useToast();
+
+  // Double-buffer: two persistent YouTube players overlaid in one box. One is
+  // the live "active" player (audible, on top); the other is the "standby" that
+  // silently prebuffers the NEXT song during the current round so that clicking
+  // Next round resumes an already-downloaded video (~tens of ms) instead of a
+  // cold YouTube load (~1.2s). They swap roles on commit. See
+  // db/migrations/029_peek_next_song.sql for the read-only picker that tells us
+  // which song to prebuffer. `activeKey` (state) drives opacity/testId; a
+  // mirror ref lets the click handlers and player callbacks read it
+  // synchronously without going stale.
+  const playerARef = useRef<YouTubePlayerHandle | null>(null);
+  const playerBRef = useRef<YouTubePlayerHandle | null>(null);
+  const [activeKey, setActiveKey] = useState<"A" | "B">("A");
+  const activeKeyRef = useRef<"A" | "B">("A");
+  const playersReadyRef = useRef<{ A: boolean; B: boolean }>({ A: false, B: false });
+  // State mirror of the standby player's readiness. playersReadyRef is a ref
+  // (read synchronously by the click handlers), but the waiting-screen preload
+  // effect needs a re-render trigger when the standby finishes constructing, so
+  // we also track it as state. Flipped in onPlayerBReady.
+  const [standbyConstructed, setStandbyConstructed] = useState(false);
+  const activePlayer = (): YouTubePlayerHandle | null =>
+    activeKeyRef.current === "A" ? playerARef.current : playerBRef.current;
+  const standbyPlayer = (): YouTubePlayerHandle | null =>
+    activeKeyRef.current === "A" ? playerBRef.current : playerARef.current;
+  const standbyReady = (): boolean =>
+    activeKeyRef.current === "A" ? playersReadyRef.current.B : playersReadyRef.current.A;
+
+  // The song currently prebuffered into the standby player (or null). Set after
+  // a successful peek+prebuffer; consumed (and cleared) when Next round commits
+  // it. `preloadInFlightRef` dedupes concurrent peeks; `preloadEpochRef` is
+  // bumped on every Next round / swap so a peek that resolves after the host has
+  // already moved on is discarded instead of buffering into the wrong player.
+  const preloadRef = useRef<PeekedSong | null>(null);
+  const preloadInFlightRef = useRef(false);
+  const preloadEpochRef = useRef(0);
+  // I-NextMeta: on the Next-round fast path we optimistically render the peeked
+  // song's metadata BEFORE the round advances server-side. That makes
+  // `currentSong.id` briefly lead `currentRound.song_id`; this ref holds the
+  // optimistically-committed id so the mid-round song-resolver effect below
+  // doesn't mistake the lead for staleness and refetch (and reload) the PREVIOUS
+  // song over the freshly-promoted player. Cleared when the round catches up or
+  // the commit fails.
+  const optimisticSongIdRef = useRef<string | null>(null);
+  // Song-start measurement: the handle is opened on a "Next round" click and
+  // resolved when the player reaches PLAYING (or the timeout fires). It crosses
+  // the click handler → loadVideoById → YouTubePlayer.onPlaying boundary, so it
+  // lives in a ref rather than state.
+  const songStartRef = useRef<SongStartHandle | null>(null);
+  const songStartTimeoutRef = useRef<number | null>(null);
+
+  // Warm up the FIRST song during the pre-game "waiting" screen. Mobile
+  // browsers block unmuted playback that resumes after an `await`, so if the
+  // first video isn't loaded until after select_next_song returns, round 1
+  // stays silent until the host taps something a second time. Prebuffering the
+  // first song here lets the "Start game" tap commit an already-buffered
+  // (muted-then-unmuted) video synchronously inside the gesture — the same
+  // in-gesture path every later round already uses. Best-effort: maybePreloadNext
+  // is fully guarded and a miss just falls back to the post-await cold load.
+  const waitingStatus = state?.game.status;
+  useEffect(() => {
+    if (waitingStatus === "waiting") maybePreloadNext();
+    // maybePreloadNext is a hoisted closure over the current render; we only
+    // need to (re)try when the game enters waiting or the standby player
+    // finishes constructing (standbyConstructed).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [waitingStatus, standbyConstructed]);
+
+  // Prebuffer the next song into the standby player so the upcoming Next round
+  // resumes an already-downloaded video. During play it's triggered once the
+  // current round's song is actually PLAYING (so it never contends with the
+  // current song's critical first-play); during the pre-game "waiting" screen
+  // it's triggered by an effect once the standby player is ready, so the very
+  // first "Start game" also commits an already-buffered video in-gesture (see
+  // the waiting-prebuffer effect + handleNextRound for why that matters on
+  // mobile). Read-only `peek_next_song` tells us which song select_next_song
+  // would pick; on the click we commit that exact id. Best-effort throughout:
+  // a peek/prebuffer failure must never disturb the round.
+  function maybePreloadNext() {
+    if (!managerToken) return;
+    const gameStatus = state?.game.status;
+    if (gameStatus !== "playing" && gameStatus !== "waiting") return;
+    // During play, only prebuffer once a round is live so peek excludes the
+    // current song. During waiting there is no round yet — that's expected, and
+    // the first song is the thing we want to warm up.
+    if (gameStatus === "playing" && !state?.currentRound?.id) return;
+    if (preloadRef.current !== null || preloadInFlightRef.current) return;
+    if (!standbyReady()) return;
+    preloadInFlightRef.current = true;
+    const epoch = preloadEpochRef.current;
+    void (async () => {
+      try {
+        const peeked = await peekNextSongDirect(gameCode, managerToken);
+        // A Next round / swap happened while we were peeking: discard so we
+        // don't mute or overwrite what is now the live player.
+        if (epoch !== preloadEpochRef.current) return;
+        if (!peeked) return; // pool exhausted -> nothing to prebuffer
+        preloadRef.current = peeked;
+        standbyPlayer()?.prebuffer(peeked.youtube_id, peeked.start_time);
+      } catch (err) {
+        log("warn", "preload_peek_failed", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        preloadInFlightRef.current = false;
+      }
+    })();
+  }
+
+  // Bound the song-start span so a video that never reaches PLAYING (autoplay
+  // blocked, dead embed) is recorded as a timeout outlier rather than left open.
+  function armSongStartTimeout() {
+    if (songStartTimeoutRef.current !== null) window.clearTimeout(songStartTimeoutRef.current);
+    songStartTimeoutRef.current = window.setTimeout(() => {
+      songStartRef.current?.playing("timeout");
+      songStartRef.current = null;
+      songStartTimeoutRef.current = null;
+    }, 8000);
+  }
+
+  // Open the song-start span at the "Next round" click instant, storing the
+  // handle in the ref that spans the click → load → playing boundary. Returned
+  // so the caller can also drive rpcDone/fail on the same handle.
+  function beginSongStart(): SongStartHandle {
+    const songStart = startSongStart({ game_code: gameCode });
+    songStartRef.current = songStart;
+    return songStart;
+  }
+
+  async function loadSongIntoPlayer(song: Song) {
+    if (player.ready) {
+      songStartRef.current?.loadIssued();
+      armSongStartTimeout();
+      activePlayer()?.loadVideoById(song.youtube_id, song.start_time);
+    } else {
+      // Player not ready yet (first song): the load is deferred to
+      // onPlayerReady, which issues loadVideoById and marks loadIssued there.
+      player.enqueueSong({ youtube_id: song.youtube_id, start_time: song.start_time });
+    }
+  }
+
+  // Resolve the open song-start span when the live player actually starts
+  // playing, then prebuffer the next song into the standby (now that the
+  // current song is up, there's idle time and no contention with its start).
+  function handlePlayerPlaying(detection: "statechange" | "poll") {
+    if (songStartTimeoutRef.current !== null) {
+      window.clearTimeout(songStartTimeoutRef.current);
+      songStartTimeoutRef.current = null;
+    }
+    songStartRef.current?.playing(detection);
+    songStartRef.current = null;
+    maybePreloadNext();
+  }
+
+  // A YouTube error on the standby/preload buffer must not alarm the host (the
+  // live song is fine); just abandon the preload so Next round falls back to a
+  // fresh random pick. An error on the live player surfaces as before.
+  function handlePlayerError(key: "A" | "B", code: number) {
+    if (key === activeKeyRef.current) {
+      log("warn", "yt_player_error", { code: String(code) });
+      toast("Video unavailable — click Next round to pick a different song.", {
+        variant: "error",
+      });
+    } else {
+      log("warn", "yt_preload_error", { code: String(code) });
+      preloadRef.current = null;
+    }
+  }
+
+  // onReady for the initially-active player (A). Drives the reactive ready gate
+  // (Start button) and flushes any deferred first song into the live player.
+  function onPlayerReady() {
+    playersReadyRef.current.A = true;
+    player.setReady();
+    const queued = player.flushPendingSong();
+    if (queued) {
+      // This is the deferred first-song load; mark loadIssued here so the
+      // song-start span's load_to_playing child measures from the real load.
+      songStartRef.current?.loadIssued();
+      armSongStartTimeout();
+      activePlayer()?.loadVideoById(queued.youtube_id, queued.start_time);
+    }
+  }
+
+  // onReady for the standby player (B). It only ever plays after a swap, so it
+  // doesn't gate the Start button or flush the first song — it just records
+  // readiness so we don't prebuffer into a player that hasn't constructed yet.
+  // The state flip wakes the waiting-prebuffer effect so the first song warms
+  // up as soon as both the standby is ready and the game is in "waiting".
+  function onPlayerBReady() {
+    playersReadyRef.current.B = true;
+    setStandbyConstructed(true);
+  }
+
+  return {
+    playerARef,
+    playerBRef,
+    activeKey,
+    onPlayerReady,
+    onPlayerBReady,
+    handlePlayerPlaying,
+    handlePlayerError,
+    activePlayer,
+    standbyPlayer,
+    activeKeyRef,
+    setActiveKey,
+    preloadRef,
+    preloadEpochRef,
+    optimisticSongIdRef,
+    songStartRef,
+    loadSongIntoPlayer,
+    armSongStartTimeout,
+    maybePreloadNext,
+    beginSongStart,
+  };
+}

--- a/frontend/src/pages/AdminSongsPage.test.tsx
+++ b/frontend/src/pages/AdminSongsPage.test.tsx
@@ -237,6 +237,69 @@ describe("AdminSongsPage: list", () => {
       expect(listSongs).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }), "letmein");
     });
   });
+
+  it("clamps the page index back into range when the result set shrinks (delete on the last page)", async () => {
+    // Pure fake timers for full determinism: nothing (including the one-shot
+    // search debounce that also calls setPage(1)) advances unless we explicitly
+    // flush it, so the debounce can't race the clamp under a loaded suite run.
+    vi.useFakeTimers();
+    const flush = async () => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+    };
+    try {
+      // Three pages (110 songs); advance to page 3 (the last one).
+      vi.mocked(listSongs).mockResolvedValue({
+        items: [SONG_A],
+        page: 3,
+        per_page: 50,
+        total: 110,
+      });
+      renderPage();
+      fireEvent.change(screen.getByLabelText(/admin password/i), { target: { value: "letmein" } });
+      fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+      // Drain the initial load AND the mount debounce's setPage(1) together, so
+      // the debounce is fully consumed before any navigation.
+      await flush();
+      expect(screen.getByText(/page 1 of 3/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+      await flush();
+      expect(screen.getByText(/page 2 of 3/i)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+      await flush();
+      expect(screen.getByText(/page 3 of 3/i)).toBeInTheDocument();
+
+      // The catalog shrinks to two pages' worth (total=90): page 3 no longer
+      // exists. Being stranded on "page 3 of 2" must not happen — the delete's
+      // refetch reveals the smaller total and the clamp snaps the index back to
+      // the last real page (2) and refetches it, so the operator sees rows.
+      vi.mocked(listSongs).mockResolvedValue({
+        items: [SONG_A],
+        page: 2,
+        per_page: 50,
+        total: 90,
+      });
+      vi.mocked(deleteSong).mockResolvedValueOnce();
+      fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]!);
+      // The confirm dialog mounts synchronously on the click (conditional render
+      // on deleteId), so no async wait is needed under the fake-timer clock.
+      const dialog = screen.getByRole("dialog");
+      fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+      // Flush the delete refetch (reveals total=90) then the clamp's page-2 refetch.
+      await flush();
+      await flush();
+
+      // Footer clamps to "page 2 of 2" (never "page 3 of 2") and a page-2 fetch
+      // is issued, landing the operator on a page that actually has rows.
+      expect(screen.getByText(/page 2 of 2/i)).toBeInTheDocument();
+      expect(screen.queryByText(/page 3 of 2/i)).not.toBeInTheDocument();
+      expect(listSongs).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }), "letmein");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("AdminSongsPage: create + edit + delete", () => {

--- a/frontend/src/pages/AdminSongsPage.tsx
+++ b/frontend/src/pages/AdminSongsPage.tsx
@@ -1,88 +1,11 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FormEvent,
-} from "react";
+import { useState, type FormEvent } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog";
-import { Skeleton } from "../components/Skeleton";
+import { SongEditForm } from "../components/SongEditForm";
+import { SongTable } from "../components/SongTable";
 import { useToast } from "../context/useToast";
-import {
-  ApiError,
-  bulkImportSongs,
-  createSong,
-  deleteSong,
-  listGenres,
-  listSongs,
-  updateSong,
-} from "../lib/api";
+import { useAdminSongs } from "../hooks/useAdminSongs";
 import { clearAdminPassword, getAdminPassword, setAdminPassword } from "../lib/adminPassword";
-import type { Genre, Song, SongWritePayload } from "../lib/types";
 import styles from "./AdminSongsPage.module.css";
-
-const PER_PAGE = 50;
-const YT_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
-const SEARCH_DEBOUNCE_MS = 250;
-
-type Mode = { kind: "list" } | { kind: "create" } | { kind: "edit"; song: Song };
-
-interface FormState {
-  title: string;
-  artist: string;
-  youtube_id: string;
-  start_time: string;
-  release_year: string;
-  genre_ids: Set<string>;
-}
-
-const EMPTY_FORM: FormState = {
-  title: "",
-  artist: "",
-  youtube_id: "",
-  start_time: "0",
-  release_year: "",
-  genre_ids: new Set(),
-};
-
-function songToForm(song: Song, genreIds: string[]): FormState {
-  return {
-    title: song.title,
-    artist: song.artist,
-    youtube_id: song.youtube_id,
-    start_time: String(song.start_time),
-    release_year: song.release_year != null ? String(song.release_year) : "",
-    genre_ids: new Set(genreIds),
-  };
-}
-
-function formToPayload(form: FormState): SongWritePayload {
-  return {
-    title: form.title.trim(),
-    artist: form.artist.trim(),
-    youtube_id: form.youtube_id.trim(),
-    start_time: Number(form.start_time),
-    release_year: form.release_year.trim() === "" ? null : Number(form.release_year),
-    genre_ids: Array.from(form.genre_ids),
-  };
-}
-
-function formIsValid(form: FormState): boolean {
-  if (form.title.trim().length === 0 || form.title.trim().length > 200) return false;
-  if (form.artist.trim().length === 0 || form.artist.trim().length > 200) return false;
-  if (!YT_ID_PATTERN.test(form.youtube_id.trim())) return false;
-  const start = Number(form.start_time);
-  if (!Number.isInteger(start) || start < 0) return false;
-  const year = form.release_year.trim();
-  if (year !== "") {
-    const y = Number(year);
-    if (!Number.isInteger(y) || y < 1900 || y > 2100) return false;
-  }
-  if (form.genre_ids.size === 0) return false;
-  return true;
-}
 
 export function AdminSongsPage() {
   const { toast } = useToast();
@@ -160,143 +83,29 @@ interface SongsConsoleProps {
 }
 
 function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
-  const { toast } = useToast();
-  const [songs, setSongs] = useState<Song[]>([]);
-  const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
-  const [searchInput, setSearchInput] = useState("");
-  const [search, setSearch] = useState("");
-  const [genreFilter, setGenreFilter] = useState("");
-  const [genres, setGenres] = useState<Genre[]>([]);
-  const [mode, setMode] = useState<Mode>({ kind: "list" });
-  const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const deleteInFlightRef = useRef(false);
-
-  const reportError = useCallback(
-    (err: unknown, fallback: string) => {
-      if (err instanceof ApiError && err.status === 401) {
-        onAuthFail();
-        return;
-      }
-      toast(err instanceof Error ? err.message : fallback, { variant: "error" });
-    },
-    [onAuthFail, toast],
-  );
-
-  // Load genres once.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const list = await listGenres();
-        if (!cancelled) setGenres(list);
-      } catch (err) {
-        if (!cancelled) reportError(err, "Failed to load genres");
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [reportError]);
-
-  // Debounce search input → search.
-  useEffect(() => {
-    const handle = window.setTimeout(() => {
-      setSearch(searchInput);
-      setPage(1);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => window.clearTimeout(handle);
-  }, [searchInput]);
-
-  // Refetch when filter inputs change.
-  const fetchSongs = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await listSongs(
-        {
-          page,
-          per_page: PER_PAGE,
-          search: search || undefined,
-          genre: genreFilter || undefined,
-        },
-        pw,
-      );
-      setSongs(res.items);
-      setTotal(res.total);
-    } catch (err) {
-      reportError(err, "Failed to load songs");
-    } finally {
-      setLoading(false);
-    }
-  }, [genreFilter, page, pw, reportError, search]);
-
-  useEffect(() => {
-    void fetchSongs();
-  }, [fetchSongs]);
-
-  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
-
-  const songToFilterEdit = useCallback((song: Song) => {
-    setMode({ kind: "edit", song });
-  }, []);
-
-  async function handleSubmitForm(payload: SongWritePayload) {
-    setBusy(true);
-    try {
-      if (mode.kind === "create") {
-        await createSong(payload, pw);
-        toast("Song created", { variant: "success" });
-      } else if (mode.kind === "edit") {
-        await updateSong(mode.song.id, payload, pw);
-        toast("Song updated", { variant: "success" });
-      }
-      setMode({ kind: "list" });
-      await fetchSongs();
-    } catch (err) {
-      reportError(err, "Save failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function handleConfirmDelete() {
-    if (deleteId === null || deleteInFlightRef.current) return;
-    deleteInFlightRef.current = true;
-    setBusy(true);
-    try {
-      await deleteSong(deleteId, pw);
-      toast("Song deleted", { variant: "success" });
-      setDeleteId(null);
-      await fetchSongs();
-    } catch (err) {
-      reportError(err, "Delete failed");
-    } finally {
-      setBusy(false);
-      deleteInFlightRef.current = false;
-    }
-  }
-
-  async function handleFile(e: ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setBusy(true);
-    try {
-      const summary = await bulkImportSongs(file, pw);
-      toast(
-        `Imported ${summary.inserted} new + ${summary.updated} updated (${summary.total} total)`,
-        { variant: "success" },
-      );
-      await fetchSongs();
-    } catch (err) {
-      reportError(err, "Import failed");
-    } finally {
-      setBusy(false);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    }
-  }
+  const {
+    songs,
+    total,
+    totalPages,
+    page,
+    setPage,
+    searchInput,
+    setSearchInput,
+    genreFilter,
+    setGenreFilter,
+    genres,
+    mode,
+    setMode,
+    deleteId,
+    setDeleteId,
+    loading,
+    busy,
+    fileInputRef,
+    startEdit,
+    handleSubmitForm,
+    handleConfirmDelete,
+    handleFile,
+  } = useAdminSongs({ pw, onAuthFail });
 
   return (
     <main className={styles.shell}>
@@ -317,10 +126,7 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
         />
         <select
           value={genreFilter}
-          onChange={(e) => {
-            setGenreFilter(e.target.value);
-            setPage(1);
-          }}
+          onChange={(e) => setGenreFilter(e.target.value)}
           aria-label="Filter by genre"
         >
           <option value="">All genres</option>
@@ -354,17 +160,10 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
       </div>
 
       {mode.kind !== "list" ? (
-        <SongForm
+        <SongEditForm
           key={mode.kind === "edit" ? mode.song.id : "create"}
           genres={genres}
-          initial={
-            mode.kind === "edit"
-              ? songToForm(
-                  mode.song,
-                  (mode.song.genres ?? []).map((g) => g.id),
-                )
-              : EMPTY_FORM
-          }
+          song={mode.kind === "edit" ? mode.song : undefined}
           submitLabel={mode.kind === "edit" ? "Save changes" : "Create song"}
           busy={busy}
           onCancel={() => setMode({ kind: "list" })}
@@ -372,110 +171,13 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
         />
       ) : null}
 
-      <div className={styles.tableWrap} aria-busy={loading}>
-        {/* Stale-while-revalidate: on a filter/page change we keep the current
-            rows on screen (dimmed) while refetching, instead of blanking the
-            whole table back to skeletons. Skeletons show only on the very first
-            load, when there are no rows to keep. */}
-        <table
-          className={`${styles.table} ${loading && songs.length > 0 ? styles.tableStale : ""}`}
-        >
-          <thead>
-            <tr>
-              <th>Title</th>
-              <th>Artist</th>
-              <th>YouTube ID</th>
-              <th>Start</th>
-              <th>Year</th>
-              <th>Genres</th>
-              <th aria-label="Actions" />
-            </tr>
-          </thead>
-          <tbody>
-            {loading && songs.length === 0 ? (
-              Array.from({ length: 5 }).map((_, i) => (
-                <tr key={`s-${i}`}>
-                  <td>
-                    <Skeleton width="80%" height={16} />
-                  </td>
-                  <td>
-                    <Skeleton width="60%" height={16} />
-                  </td>
-                  <td>
-                    <Skeleton width="100px" height={16} />
-                  </td>
-                  <td>
-                    <Skeleton width="40px" height={16} />
-                  </td>
-                  <td>
-                    <Skeleton width="40px" height={16} />
-                  </td>
-                  <td>
-                    <Skeleton width="120px" height={16} />
-                  </td>
-                  <td />
-                </tr>
-              ))
-            ) : songs.length === 0 ? (
-              <tr>
-                <td colSpan={7} className={styles.empty}>
-                  No songs found.
-                </td>
-              </tr>
-            ) : (
-              songs.map((s) => {
-                const genreNames = (s.genres ?? []).map((g) => g.name);
-                return (
-                  <tr key={s.id}>
-                    <td>{s.title}</td>
-                    <td>{s.artist}</td>
-                    <td className={styles.ytId}>{s.youtube_id}</td>
-                    <td className={styles.startTime}>
-                      {s.start_time > 0 ? `${s.start_time}s` : "—"}
-                    </td>
-                    <td className={styles.startTime}>
-                      {s.release_year != null ? s.release_year : "—"}
-                    </td>
-                    <td>
-                      <div className={styles.genreList}>
-                        {genreNames.length === 0 ? (
-                          <span className={styles.startTime}>—</span>
-                        ) : (
-                          genreNames.map((name) => (
-                            <span key={name} className={styles.genreTag}>
-                              {name}
-                            </span>
-                          ))
-                        )}
-                      </div>
-                    </td>
-                    <td>
-                      <div className={styles.rowActions}>
-                        <button
-                          type="button"
-                          className="btn btn-ghost"
-                          onClick={() => songToFilterEdit(s)}
-                          disabled={busy}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-danger"
-                          onClick={() => setDeleteId(s.id)}
-                          disabled={busy}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
+      <SongTable
+        songs={songs}
+        loading={loading}
+        busy={busy}
+        onEdit={startEdit}
+        onDelete={(id) => setDeleteId(id)}
+      />
 
       {total > 0 ? (
         <div className={styles.pagination}>
@@ -513,127 +215,5 @@ function SongsConsole({ pw, onAuthFail, onSignOut }: SongsConsoleProps) {
         onCancel={() => setDeleteId(null)}
       />
     </main>
-  );
-}
-
-interface SongFormProps {
-  genres: Genre[];
-  initial: FormState;
-  submitLabel: string;
-  busy: boolean;
-  onCancel: () => void;
-  onSubmit: (payload: SongWritePayload) => void;
-}
-
-function SongForm({ genres, initial, submitLabel, busy, onCancel, onSubmit }: SongFormProps) {
-  const [form, setForm] = useState<FormState>(initial);
-
-  const valid = useMemo(() => formIsValid(form), [form]);
-
-  function toggleGenre(id: string) {
-    setForm((prev) => {
-      const next = new Set(prev.genre_ids);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return { ...prev, genre_ids: next };
-    });
-  }
-
-  function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!valid || busy) return;
-    onSubmit(formToPayload(form));
-  }
-
-  return (
-    <form className={styles.formPanel} onSubmit={handleSubmit}>
-      <h2>{submitLabel}</h2>
-      <p className="muted">
-        Tagging a song with the Soundtracks or Israeli Soundtracks genre makes it a +15 “name the
-        film/show” round. For those, put the film/show name in <strong>Artist</strong> (that’s the
-        answer revealed on screen); <strong>Title</strong> is the song/clip name, shown only as a
-        hint. Set Title equal to the film name when there’s no distinct song.
-      </p>
-      <div className={styles.formGrid}>
-        <label className={styles.field}>
-          <span>Title</span>
-          <input
-            type="text"
-            value={form.title}
-            onChange={(e) => setForm({ ...form, title: e.target.value })}
-            maxLength={200}
-            aria-label="Title"
-          />
-        </label>
-        <label className={styles.field}>
-          <span>Artist</span>
-          <input
-            type="text"
-            value={form.artist}
-            onChange={(e) => setForm({ ...form, artist: e.target.value })}
-            maxLength={200}
-            aria-label="Artist"
-          />
-        </label>
-        <label className={styles.field}>
-          <span>YouTube ID (11 chars)</span>
-          <input
-            type="text"
-            value={form.youtube_id}
-            onChange={(e) => setForm({ ...form, youtube_id: e.target.value })}
-            maxLength={11}
-            spellCheck={false}
-            aria-label="YouTube ID"
-          />
-        </label>
-        <label className={styles.field}>
-          <span>Start time (seconds)</span>
-          <input
-            type="number"
-            min={0}
-            value={form.start_time}
-            onChange={(e) => setForm({ ...form, start_time: e.target.value })}
-            aria-label="Start time"
-          />
-        </label>
-        <label className={styles.field}>
-          <span>Release year (optional)</span>
-          <input
-            type="number"
-            min={1900}
-            max={2100}
-            placeholder="e.g. 1985"
-            value={form.release_year}
-            onChange={(e) => setForm({ ...form, release_year: e.target.value })}
-            aria-label="Release year"
-          />
-        </label>
-        <div className={`${styles.field} ${styles.fieldFull}`}>
-          <span>Genres ({form.genre_ids.size} selected)</span>
-          <div className={styles.genres}>
-            {genres.map((g) => {
-              const sel = form.genre_ids.has(g.id);
-              return (
-                <label
-                  key={g.id}
-                  className={`${styles.genreChip} ${sel ? styles.genreSelected : ""}`}
-                >
-                  <input type="checkbox" checked={sel} onChange={() => toggleGenre(g.id)} />
-                  {g.name}
-                </label>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-      <div className={styles.formActions}>
-        <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={busy}>
-          Cancel
-        </button>
-        <button type="submit" className="btn btn-primary" disabled={!valid || busy}>
-          {busy ? "Saving…" : submitLabel}
-        </button>
-      </div>
-    </form>
   );
 }

--- a/frontend/src/pages/ManagerConsolePage.tsx
+++ b/frontend/src/pages/ManagerConsolePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { EndScreen } from "../components/EndScreen";
@@ -7,71 +7,26 @@ import { HostRecoveryLink } from "../components/HostRecoveryLink";
 import { Skeleton } from "../components/Skeleton";
 import { SongExport } from "../components/SongExport";
 import { SoundtrackBadge } from "../components/SoundtrackBadge";
-import { YouTubePlayer, type YouTubePlayerHandle } from "../components/YouTubePlayer";
-import { useToast } from "../context/useToast";
+import { YouTubePlayer } from "../components/YouTubePlayer";
 import { useGameChannel } from "../hooks/useGameChannel";
 import { useKeepBackendWarm } from "../hooks/useKeepBackendWarm";
+import { useManagerToken } from "../hooks/useManagerToken";
 import { usePlayerReady } from "../hooks/usePlayerReady";
 import { useResumeOnVisible } from "../hooks/useResumeOnVisible";
-import { ApiError, awardBonus, endGame } from "../lib/api";
-import {
-  awardAttemptDirect,
-  extendGameDirect,
-  releaseBuzzLockDirect,
-  RpcError,
-} from "../hooks/useManagerActions";
-import { selectNextSongDirect } from "../hooks/useSelectNextSong";
-import { peekNextSongDirect, type PeekedSong } from "../hooks/usePeekNextSong";
-import {
-  clearManagerToken,
-  getManagerToken,
-  parseRecoveryHash,
-  setManagerToken,
-} from "../lib/managerToken";
-import {
-  failScore,
-  log,
-  markScoreStart,
-  startSongStart,
-  type SongStartHandle,
-} from "../lib/telemetry";
-import { fetchSongById } from "../lib/songMetadata";
-import type { Song } from "../lib/types";
+import { useScoring } from "../hooks/useScoring";
+import { useSongPrebuffer } from "../hooks/useSongPrebuffer";
+import { parseRecoveryHash } from "../lib/managerToken";
 import styles from "./ManagerConsolePage.module.css";
 
 export function ManagerConsolePage() {
   const { gameCode = "" } = useParams<{ gameCode: string }>();
-  const { toast } = useToast();
   const { hash, pathname, search } = useLocation();
   const navigate = useNavigate();
-  // Adopt a backup-host-link token (T4.10): /manager/game/<code>#mt=<token>
-  // re-authenticates a host whose localStorage is gone (new device, cleared
-  // browser). Resolution order:
-  //   1. A token already stored for this game wins unconditionally — recovery
-  //      is for tokenless devices. The room knows the game code, so if the
-  //      hash won instead, any guest could craft a well-formed #mt= link that
-  //      silently clobbers the host's working credential (one-click lockout).
-  //   2. Otherwise a well-formed fragment is adopted: persisted for future
-  //      visits and mirrored in a ref so the credential survives the hash
-  //      scrub below even where localStorage writes are blocked (private
-  //      mode) — persistence is best-effort, the live session is not.
-  //   3. Otherwise fall back to that ref (an adoption earlier in this mount);
-  //      keyed by game code so a console-to-console navigation can't reuse it.
-  // Reading storage and the idempotent write inside the memo keep the very
-  // first render authenticated (no "not the host" flash); both are safe under
-  // StrictMode's double-invoke.
-  const adoptedTokenRef = useRef<{ gameCode: string; token: string } | null>(null);
-  const managerToken = useMemo(() => {
-    const stored = getManagerToken(gameCode);
-    if (stored) return stored;
-    const adopted = parseRecoveryHash(hash);
-    if (adopted) {
-      adoptedTokenRef.current = { gameCode, token: adopted };
-      setManagerToken(gameCode, adopted);
-      return adopted;
-    }
-    return adoptedTokenRef.current?.gameCode === gameCode ? adoptedTokenRef.current.token : null;
-  }, [gameCode, hash]);
+  // Adopt a backup-host-link token (T4.10) — see useManagerToken for the full
+  // resolution order (stored wins, else adopt a well-formed #mt= fragment, else
+  // the in-mount ref). Isolated into its own hook so the intentional in-render
+  // ref access stays contained there rather than tainting this render.
+  const managerToken = useManagerToken(gameCode, hash);
 
   // Scrub the adopted token out of the address bar and this history entry so
   // it doesn't linger in screenshots or a shared device's history. replace
@@ -84,112 +39,54 @@ export function ManagerConsolePage() {
   const { state, status, finalBoard } = useGameChannel(gameCode);
   const player = usePlayerReady();
 
-  // Double-buffer: two persistent YouTube players overlaid in one box. One is
-  // the live "active" player (audible, on top); the other is the "standby" that
-  // silently prebuffers the NEXT song during the current round so that clicking
-  // Next round resumes an already-downloaded video (~tens of ms) instead of a
-  // cold YouTube load (~1.2s). They swap roles on commit. See
-  // db/migrations/029_peek_next_song.sql for the read-only picker that tells us
-  // which song to prebuffer. `activeKey` (state) drives opacity/testId; a
-  // mirror ref lets the click handlers and player callbacks read it
-  // synchronously without going stale.
-  const playerARef = useRef<YouTubePlayerHandle | null>(null);
-  const playerBRef = useRef<YouTubePlayerHandle | null>(null);
-  const [activeKey, setActiveKey] = useState<"A" | "B">("A");
-  const activeKeyRef = useRef<"A" | "B">("A");
-  const playersReadyRef = useRef<{ A: boolean; B: boolean }>({ A: false, B: false });
-  // State mirror of the standby player's readiness. playersReadyRef is a ref
-  // (read synchronously by the click handlers), but the waiting-screen preload
-  // effect needs a re-render trigger when the standby finishes constructing, so
-  // we also track it as state. Flipped in onPlayerBReady.
-  const [standbyConstructed, setStandbyConstructed] = useState(false);
-  const activePlayer = (): YouTubePlayerHandle | null =>
-    activeKeyRef.current === "A" ? playerARef.current : playerBRef.current;
-  const standbyPlayer = (): YouTubePlayerHandle | null =>
-    activeKeyRef.current === "A" ? playerBRef.current : playerARef.current;
-  const standbyReady = (): boolean =>
-    activeKeyRef.current === "A" ? playersReadyRef.current.B : playersReadyRef.current.A;
-
-  // The song currently prebuffered into the standby player (or null). Set after
-  // a successful peek+prebuffer; consumed (and cleared) when Next round commits
-  // it. `preloadInFlightRef` dedupes concurrent peeks; `preloadEpochRef` is
-  // bumped on every Next round / swap so a peek that resolves after the host has
-  // already moved on is discarded instead of buffering into the wrong player.
-  const preloadRef = useRef<PeekedSong | null>(null);
-  const preloadInFlightRef = useRef(false);
-  const preloadEpochRef = useRef(0);
-  // I-NextMeta: on the Next-round fast path we optimistically render the peeked
-  // song's metadata BEFORE the round advances server-side. That makes
-  // `currentSong.id` briefly lead `currentRound.song_id`; this ref holds the
-  // optimistically-committed id so the mid-round song-resolver effect below
-  // doesn't mistake the lead for staleness and refetch (and reload) the PREVIOUS
-  // song over the freshly-promoted player. Cleared when the round catches up or
-  // the commit fails.
-  const optimisticSongIdRef = useRef<string | null>(null);
-  // Song-start measurement: the handle is opened on a "Next round" click and
-  // resolved when the player reaches PLAYING (or the timeout fires). It crosses
-  // the click handler → loadVideoById → YouTubePlayer.onPlaying boundary, so it
-  // lives in a ref rather than state.
-  const songStartRef = useRef<SongStartHandle | null>(null);
-  const songStartTimeoutRef = useRef<number | null>(null);
-
   // Keep the Render-hosted API warm while a game is running so the host's
   // occasional REST calls (Bonus / End game / Kick) and late team joins don't
   // hit a mid-game cold start. See useKeepBackendWarm for the why.
   useKeepBackendWarm(state?.game?.status === "playing" || state?.game?.status === "waiting");
 
-  const [currentSong, setCurrentSong] = useState<Song | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [endConfirmOpen, setEndConfirmOpen] = useState(false);
-  const [bonusOpen, setBonusOpen] = useState(false);
-
-  // Optimistic "we just clicked this" markers for the per-round action buttons,
-  // each holding the round id the click happened on. They bridge the ~50-
-  // 100ms gap between the RPC returning and the Realtime UPDATE on game_rounds
-  // (title_claimed_by / artist_claimed_by) or active_games (buzzed_team_id)
-  // arriving -- keeping the button disabled across that gap so it doesn't flash
-  // enabled in the window. The flag is naturally self-clearing on round change
-  // (stale id won't equal the new round.id) and gets reset by the effects
-  // below for tidiness. Cleared in each handler's catch on failure so a
-  // transient RPC error doesn't leave the button permanently disabled.
-  // pendingContinue mirrors pendingWrong: Continue releases the buzz lock, so
-  // it stays disabled until the Realtime UPDATE clears buzzed_team_id.
-  const [pendingTitle, setPendingTitle] = useState<string | null>(null);
-  const [pendingArtist, setPendingArtist] = useState<string | null>(null);
-  const [pendingWrong, setPendingWrong] = useState<string | null>(null);
-  const [pendingContinue, setPendingContinue] = useState<string | null>(null);
-  // Extend-game handoff, same shape as the flags above but keyed on the
-  // expires_at value the click happened on: the banner's button stays disabled
-  // until the Realtime UPDATE lands with the bumped value (at which point the
-  // flag is stale and inert). Cleared on failure so the host can retry.
-  const [pendingExtendFor, setPendingExtendFor] = useState<string | null>(null);
-
-  // Synchronous in-flight locks, one PER ACTION. These are the sole guard
-  // against a same-action double-fire now that the shared `busy` gate is off
-  // the hot handlers (removing it is what stops a *distinct* second click --
-  // e.g. Correct Song then quickly Wrong -- from being silently dropped inside
-  // the first action's window; see F-P1-8 / F-P2-2). useState can't do this
-  // job: `busy` is captured in the closure at render time, so two clicks in
-  // one React tick both read the stale value; useRef.current mutates
-  // synchronously, so the second same-action click sees `true` and bails.
-  // Matters most for handleNextRound, where a duplicate fire would insert an
-  // orphan game_rounds row (the other actions are idempotent via the SQL
-  // function's already-claimed / no-buzz-to-score branches).
-  const titleInFlightRef = useRef(false);
-  const artistInFlightRef = useRef(false);
-  const wrongInFlightRef = useRef(false);
-  const continueInFlightRef = useRef(false);
-  const nextRoundInFlightRef = useRef(false);
-  const extendInFlightRef = useRef(false);
+  // The double-buffer player machinery (peek + prebuffer + swap + song-start
+  // telemetry) and the scoring/round actions (award_attempt / release_buzz_lock
+  // / select_next_song / bonus / end / extend) live in two hooks; the page is
+  // layout + wiring. handleNextRound composes the prebuffer surface, so scoring
+  // takes prebuffer as an argument.
+  const prebuffer = useSongPrebuffer(gameCode, managerToken, state, player);
+  const {
+    playerARef,
+    playerBRef,
+    activeKey,
+    onPlayerReady,
+    onPlayerBReady,
+    handlePlayerPlaying,
+    handlePlayerError,
+    activePlayer,
+  } = prebuffer;
+  const scoring = useScoring(gameCode, managerToken, state, player, prebuffer);
+  const {
+    currentSong,
+    busy,
+    endConfirmOpen,
+    setEndConfirmOpen,
+    bonusOpen,
+    setBonusOpen,
+    pendingTitle,
+    pendingArtist,
+    pendingWrong,
+    pendingContinue,
+    pendingExtendFor,
+    handleCorrectTitle,
+    handleCorrectArtist,
+    handleCorrectSoundtrack,
+    handleContinueRound,
+    handleWrong,
+    handleNextRound,
+    handleExtendGame,
+    handleBonus,
+    performEnd,
+  } = scoring;
 
   // When we get the buzz lock signal, pause playback on the live player.
-  useEffect(() => {
-    if (state?.game.buzzed_team_id != null) {
-      // activePlayer() reads activeKeyRef synchronously, so it always pauses
-      // whichever player is live regardless of swaps.
-      activePlayer()?.pause();
-    }
-  }, [state?.game.buzzed_team_id]);
+  // (Handled inside useScoring so the pause fires alongside the pending-flag
+  // resets that key off the same buzzed_team_id transition.)
 
   // Recover a song the browser paused when the host backgrounded the tab / locked
   // their phone: when the tab becomes visible again, resume the live player — but
@@ -201,610 +98,6 @@ export function ManagerConsolePage() {
     () => state?.game.status === "playing" && state?.game.buzzed_team_id == null,
     () => activePlayer()?.resumeIfPaused(),
   );
-
-  // Warm up the FIRST song during the pre-game "waiting" screen. Mobile
-  // browsers block unmuted playback that resumes after an `await`, so if the
-  // first video isn't loaded until after select_next_song returns, round 1
-  // stays silent until the host taps something a second time. Prebuffering the
-  // first song here lets the "Start game" tap commit an already-buffered
-  // (muted-then-unmuted) video synchronously inside the gesture — the same
-  // in-gesture path every later round already uses. Best-effort: maybePreloadNext
-  // is fully guarded and a miss just falls back to the post-await cold load.
-  const waitingStatus = state?.game.status;
-  useEffect(() => {
-    if (waitingStatus === "waiting") maybePreloadNext();
-    // maybePreloadNext is a hoisted closure over the current render; we only
-    // need to (re)try when the game enters waiting or the standby player
-    // finishes constructing (standbyConstructed).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [waitingStatus, standbyConstructed]);
-
-  // Reset the per-click pending flags whenever the round changes. The
-  // disabled checks already compare against `round?.id` so stale flags
-  // are inert, but clearing them keeps state tidy and avoids confusion
-  // when debugging.
-  const currentRoundId = state?.currentRound?.id ?? null;
-  useEffect(() => {
-    setPendingTitle(null);
-    setPendingArtist(null);
-    setPendingWrong(null);
-    setPendingContinue(null);
-    // The round advanced (or reset): any optimistic Next-round prediction has
-    // now either landed or is moot, so drop the suppression id.
-    optimisticSongIdRef.current = null;
-  }, [currentRoundId]);
-
-  // Wrong and Continue both release the buzz lock, so a follow-up buzz in the
-  // same round must re-enable their buttons. `pendingWrong` / `pendingContinue`
-  // only bridge the gap between the RPC returning and the Realtime UPDATE on
-  // buzzed_team_id; once that UPDATE has landed (lock cleared) the flags have
-  // done their job and must drop or the next buzz's click stays blocked.
-  useEffect(() => {
-    if (state?.game.buzzed_team_id == null) {
-      setPendingWrong(null);
-      setPendingContinue(null);
-    }
-  }, [state?.game.buzzed_team_id]);
-
-  // After a manager-tab refresh mid-round, currentSong is null but the round
-  // row still has a song_id. Resolve it and push it into the player so the
-  // host doesn't have to abandon the round and click Next round. Must stay
-  // loadVideoById (not cueVideoById): on the happy path the Realtime INSERT
-  // for the new round arrives before selectSong's HTTP response, so this
-  // effect races with handleNextRound's loadVideoById. Calling cue while load
-  // is in flight (or vice-versa) puts YT.Player into an inconsistent state and
-  // surfaces as the "Video unavailable" onError overlay.
-  const currentRoundSongId = state?.currentRound?.song_id ?? null;
-  const playerReady = player.ready;
-  useEffect(() => {
-    if (!currentRoundSongId) return;
-    if (currentSong && currentSong.id === currentRoundSongId) return;
-    // I-NextMeta: currentSong is the optimistically-committed next song, ahead of
-    // the round that hasn't advanced yet — NOT a stale leftover. Don't refetch
-    // the old round's song (which would also reload it over the promoted player);
-    // the round will catch up momentarily and the RPC reconciles the metadata.
-    if (currentSong && currentSong.id === optimisticSongIdRef.current) return;
-    let cancelled = false;
-    // fetchSongById retries transient failures with bounded backoff (F-P1-7)
-    // so one blip doesn't leave the post-refresh player empty for the round.
-    void fetchSongById(currentRoundSongId, () => cancelled).then((song) => {
-      if (cancelled || !song) return;
-      setCurrentSong(song);
-      if (playerReady) {
-        activePlayer()?.loadVideoById(song.youtube_id, song.start_time);
-      } else {
-        player.enqueueSong({ youtube_id: song.youtube_id, start_time: song.start_time });
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-    // `player` is a stable hook handle; we only need to re-run when the
-    // current round's song changes or the player flips to ready.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentRoundSongId, currentSong?.id, playerReady]);
-
-  function reportError(err: unknown) {
-    if (err instanceof ApiError) {
-      const reason =
-        err.details && typeof err.details === "object" && err.details !== null
-          ? (err.details as { reason?: unknown }).reason
-          : undefined;
-      if (err.status === 409 && reason === "no_more_songs") {
-        toast(
-          "All songs in your selected genres have been played. End the game or start a new one with more genres.",
-          { variant: "error" },
-        );
-        return;
-      }
-    }
-    if (err instanceof RpcError) {
-      // PL/pgSQL RAISE EXCEPTION '<code>' lands as message = '<code>'.
-      // 'no_buzz_to_score' / 'title_already_claimed' just mean the click was
-      // a no-op (Realtime already cleared the lock or claimed the token);
-      // don't spook the host with an error toast.
-      if (
-        err.message === "no_buzz_to_score" ||
-        err.message === "title_already_claimed" ||
-        err.message === "artist_already_claimed"
-      ) {
-        return;
-      }
-      // 'no_more_songs' is the friendly user-facing error from select_next_song
-      // when the selected-genres pool is exhausted. Mirror the ApiError text
-      // above so the manager sees the same wording regardless of which path
-      // surfaced it.
-      if (err.message === "no_more_songs") {
-        toast(
-          "All songs in your selected genres have been played. End the game or start a new one with more genres.",
-          { variant: "error" },
-        );
-        return;
-      }
-      log("error", "manager_rpc_failed", { message: err.message });
-      toast(err.message, { variant: "error" });
-      return;
-    }
-    log("error", "manager_action_failed", {
-      message: err instanceof Error ? err.message : String(err),
-    });
-    toast(err instanceof Error ? err.message : "Request failed", { variant: "error" });
-  }
-
-  async function loadSongIntoPlayer(song: Song) {
-    if (player.ready) {
-      songStartRef.current?.loadIssued();
-      armSongStartTimeout();
-      activePlayer()?.loadVideoById(song.youtube_id, song.start_time);
-    } else {
-      // Player not ready yet (first song): the load is deferred to
-      // onPlayerReady, which issues loadVideoById and marks loadIssued there.
-      player.enqueueSong({ youtube_id: song.youtube_id, start_time: song.start_time });
-    }
-  }
-
-  // Prebuffer the next song into the standby player so the upcoming Next round
-  // resumes an already-downloaded video. During play it's triggered once the
-  // current round's song is actually PLAYING (so it never contends with the
-  // current song's critical first-play); during the pre-game "waiting" screen
-  // it's triggered by an effect once the standby player is ready, so the very
-  // first "Start game" also commits an already-buffered video in-gesture (see
-  // the waiting-prebuffer effect + handleNextRound for why that matters on
-  // mobile). Read-only `peek_next_song` tells us which song select_next_song
-  // would pick; on the click we commit that exact id. Best-effort throughout:
-  // a peek/prebuffer failure must never disturb the round.
-  function maybePreloadNext() {
-    if (!managerToken) return;
-    const gameStatus = state?.game.status;
-    if (gameStatus !== "playing" && gameStatus !== "waiting") return;
-    // During play, only prebuffer once a round is live so peek excludes the
-    // current song. During waiting there is no round yet — that's expected, and
-    // the first song is the thing we want to warm up.
-    if (gameStatus === "playing" && !state?.currentRound?.id) return;
-    if (preloadRef.current !== null || preloadInFlightRef.current) return;
-    if (!standbyReady()) return;
-    preloadInFlightRef.current = true;
-    const epoch = preloadEpochRef.current;
-    void (async () => {
-      try {
-        const peeked = await peekNextSongDirect(gameCode, managerToken);
-        // A Next round / swap happened while we were peeking: discard so we
-        // don't mute or overwrite what is now the live player.
-        if (epoch !== preloadEpochRef.current) return;
-        if (!peeked) return; // pool exhausted -> nothing to prebuffer
-        preloadRef.current = peeked;
-        standbyPlayer()?.prebuffer(peeked.youtube_id, peeked.start_time);
-      } catch (err) {
-        log("warn", "preload_peek_failed", {
-          message: err instanceof Error ? err.message : String(err),
-        });
-      } finally {
-        preloadInFlightRef.current = false;
-      }
-    })();
-  }
-
-  // Bound the song-start span so a video that never reaches PLAYING (autoplay
-  // blocked, dead embed) is recorded as a timeout outlier rather than left open.
-  function armSongStartTimeout() {
-    if (songStartTimeoutRef.current !== null) window.clearTimeout(songStartTimeoutRef.current);
-    songStartTimeoutRef.current = window.setTimeout(() => {
-      songStartRef.current?.playing("timeout");
-      songStartRef.current = null;
-      songStartTimeoutRef.current = null;
-    }, 8000);
-  }
-
-  // Resolve the open song-start span when the live player actually starts
-  // playing, then prebuffer the next song into the standby (now that the
-  // current song is up, there's idle time and no contention with its start).
-  function handlePlayerPlaying(detection: "statechange" | "poll") {
-    if (songStartTimeoutRef.current !== null) {
-      window.clearTimeout(songStartTimeoutRef.current);
-      songStartTimeoutRef.current = null;
-    }
-    songStartRef.current?.playing(detection);
-    songStartRef.current = null;
-    maybePreloadNext();
-  }
-
-  // A YouTube error on the standby/preload buffer must not alarm the host (the
-  // live song is fine); just abandon the preload so Next round falls back to a
-  // fresh random pick. An error on the live player surfaces as before.
-  function handlePlayerError(key: "A" | "B", code: number) {
-    if (key === activeKeyRef.current) {
-      log("warn", "yt_player_error", { code: String(code) });
-      toast("Video unavailable — click Next round to pick a different song.", {
-        variant: "error",
-      });
-    } else {
-      log("warn", "yt_preload_error", { code: String(code) });
-      preloadRef.current = null;
-    }
-  }
-
-  // Apply an attempt via the direct browser -> Supabase RPC. Migration 021
-  // moved the manager-token gate into the PL/pgSQL function, so we bypass
-  // FastAPI/Render here and cut ~300ms of cross-continent hops off the
-  // critical path. The score commit and the Realtime fan-out happen in the
-  // same DB transaction; the UI then redraws when game_teams / game_rounds
-  // UPDATE events arrive.
-  async function applyAttempt(
-    roundId: string,
-    flags: { title_correct: boolean; artist_correct: boolean; wrong_buzz: boolean },
-  ): Promise<void> {
-    if (!managerToken) return;
-    await awardAttemptDirect(gameCode, managerToken, roundId, flags);
-  }
-
-  // Helper for the optimistic toast on the three scoring buttons. Fired
-  // before the RPC so the click feels instant; the Realtime UPDATE on
-  // game_teams.score is still the source of truth for the displayed score.
-  function buzzedTeamName(): string | null {
-    if (!state) return null;
-    const tid = state.game.buzzed_team_id;
-    if (!tid) return null;
-    return state.teams.get(tid)?.name ?? null;
-  }
-
-  async function handleCorrectTitle() {
-    if (titleInFlightRef.current) return;
-    if (!state?.currentRound || !managerToken) return;
-    if (!state.game.buzzed_team_id) return;
-    titleInFlightRef.current = true;
-    const roundId = state.currentRound.id;
-    const teamName = buzzedTeamName();
-    if (teamName) toast(`+10 to ${teamName}`, { variant: "success" });
-    // Pending flag flips the disabled prop synchronously on click and stays
-    // set until the Realtime UPDATE on game_rounds.title_claimed_by lands
-    // (after which the semantic gate takes over) -- no enable/disable
-    // flicker in the gap.
-    setPendingTitle(roundId);
-    markScoreStart(gameCode, roundId, "title");
-    try {
-      await applyAttempt(roundId, {
-        title_correct: true,
-        artist_correct: false,
-        wrong_buzz: false,
-      });
-    } catch (err) {
-      failScore(roundId, "title");
-      setPendingTitle(null);
-      reportError(err);
-    } finally {
-      titleInFlightRef.current = false;
-    }
-  }
-
-  async function handleCorrectArtist() {
-    if (artistInFlightRef.current) return;
-    if (!state?.currentRound || !managerToken) return;
-    if (!state.game.buzzed_team_id) return;
-    artistInFlightRef.current = true;
-    const roundId = state.currentRound.id;
-    const teamName = buzzedTeamName();
-    if (teamName) toast(`+5 to ${teamName}`, { variant: "success" });
-    setPendingArtist(roundId);
-    markScoreStart(gameCode, roundId, "artist");
-    try {
-      await applyAttempt(roundId, {
-        title_correct: false,
-        artist_correct: true,
-        wrong_buzz: false,
-      });
-    } catch (err) {
-      failScore(roundId, "artist");
-      setPendingArtist(null);
-      reportError(err);
-    } finally {
-      artistInFlightRef.current = false;
-    }
-  }
-
-  // Soundtrack rounds (current song has is_soundtrack=true) use a single
-  // "Correct +15" button instead of the title/artist split. The team's job is
-  // to name the work (film / TV / game / musical), not the song title; awarding
-  // both flags at once sums to 15 points via the existing award_attempt
-  // function -- no SQL change needed. Both tokens claim together; nothing more
-  // can be scored on this round, so we let it sit in the fully-scored state
-  // (lock held, player paused) and wait for the manager's "Next round" click,
-  // mirroring how a regular round behaves once both title + artist are claimed.
-  async function handleCorrectSoundtrack() {
-    if (titleInFlightRef.current || artistInFlightRef.current) return;
-    if (!state?.currentRound || !managerToken) return;
-    if (!state.game.buzzed_team_id) return;
-    titleInFlightRef.current = true;
-    artistInFlightRef.current = true;
-    const roundId = state.currentRound.id;
-    const teamName = buzzedTeamName();
-    if (teamName) toast(`+15 to ${teamName}`, { variant: "success" });
-    setPendingTitle(roundId);
-    setPendingArtist(roundId);
-    markScoreStart(gameCode, roundId, "soundtrack");
-    try {
-      await applyAttempt(roundId, {
-        title_correct: true,
-        artist_correct: true,
-        wrong_buzz: false,
-      });
-    } catch (err) {
-      failScore(roundId, "soundtrack");
-      setPendingTitle(null);
-      setPendingArtist(null);
-      reportError(err);
-    } finally {
-      titleInFlightRef.current = false;
-      artistInFlightRef.current = false;
-    }
-  }
-
-  async function handleContinueRound() {
-    if (continueInFlightRef.current) return;
-    if (!managerToken) return;
-    continueInFlightRef.current = true;
-    // Optimistic toast fires before the RPC so the click feels instant; the
-    // Realtime UPDATE on active_games.buzzed_team_id is still the source of
-    // truth for re-arming the buzzers.
-    toast("Round continued", { variant: "info" });
-    // Keep Continue disabled until the lock actually clears via Realtime, the
-    // same handoff pendingWrong uses -- no enable/disable flash in the gap.
-    setPendingContinue(state?.currentRound?.id ?? null);
-    try {
-      await releaseBuzzLockDirect(gameCode, managerToken);
-      activePlayer()?.play();
-    } catch (err) {
-      setPendingContinue(null);
-      reportError(err);
-    } finally {
-      continueInFlightRef.current = false;
-    }
-  }
-
-  // Wrong is a one-click verdict: it fires award_attempt with wrong_buzz=true,
-  // re-arms the buzzers, and resumes the song (no separate "Continue round"
-  // press needed). Per game-rules.md §4 the -3 is waived only when the round's
-  // one-shot free-guess flag is armed (`free_guess_active`), which the SQL
-  // arms after a correct attempt and consumes on the very next attempt. We
-  // mirror that exact flag here so the optimistic toast matches the score the
-  // server will commit -- reading "any token claimed" instead would wrongly
-  // suppress the -3 toast for every later wrong in a round that had a correct.
-  // Playback resume is held until the RPC commits so a failed Wrong leaves the
-  // song paused with the lock still held -- the manager can simply retry.
-  async function handleWrong() {
-    if (wrongInFlightRef.current) return;
-    if (!state?.currentRound || !managerToken) return;
-    if (!state.game.buzzed_team_id) return;
-    wrongInFlightRef.current = true;
-    const roundId = state.currentRound.id;
-    const teamName = buzzedTeamName();
-    const freeGuess = state.currentRound.free_guess_active;
-    if (teamName && !freeGuess) toast(`-3 to ${teamName}`, { variant: "info" });
-    setPendingWrong(roundId);
-    try {
-      await applyAttempt(roundId, {
-        title_correct: false,
-        artist_correct: false,
-        wrong_buzz: true,
-      });
-      activePlayer()?.play();
-    } catch (err) {
-      setPendingWrong(null);
-      reportError(err);
-    } finally {
-      wrongInFlightRef.current = false;
-    }
-  }
-
-  async function handleNextRound() {
-    if (nextRoundInFlightRef.current) return;
-    if (!managerToken) return;
-    nextRoundInFlightRef.current = true;
-    // Bump the preload epoch so any in-flight peek is discarded rather than
-    // buffering into a player we're about to repurpose.
-    preloadEpochRef.current += 1;
-    // Open the song-start span at the click instant (before the toast) so it
-    // captures click → RPC → load → audio actually playing.
-    const songStart = startSongStart({ game_code: gameCode });
-    songStartRef.current = songStart;
-    // Optimistic toast confirms the click immediately.
-    toast("Loading next round...", { variant: "info" });
-    // Snapshot + clear the prebuffered song now so a late preload can't reuse it.
-    const preloaded = preloadRef.current;
-    preloadRef.current = null;
-    // Pre-swap snapshot for the rollback in the catch below: which player was
-    // live and which song card was up before the optimistic in-gesture swap.
-    const prevKey = activeKeyRef.current;
-    const prevSong = currentSong;
-
-    // FAST PATH — start the prebuffered song *synchronously inside this tap*,
-    // BEFORE awaiting the RPC. Mobile browsers only allow unmuted playback that
-    // begins within a user gesture; resuming after `await select_next_song`
-    // counts as blocked autoplay, which is exactly the reported bug (round 1 /
-    // Next round stayed silent until a stray buzz + Continue finally unlocked
-    // it). We pass preloaded.song_id to the RPC below, so the video we begin
-    // playing here is guaranteed to be the one the round records — it's safe to
-    // start it before the round is committed server-side. commitPrebuffered
-    // resumes an already-downloaded (muted) buffer, so the unmute+play lands in
-    // the gesture and the room hears it immediately.
-    let committedPreloaded = false;
-    if (preloaded) {
-      songStart.loadIssued();
-      armSongStartTimeout();
-      const promoted = standbyPlayer();
-      const demoted = activePlayer();
-      promoted?.commitPrebuffered(preloaded.start_time);
-      demoted?.stop();
-      const nextKey = activeKeyRef.current === "A" ? "B" : "A";
-      activeKeyRef.current = nextKey;
-      setActiveKey(nextKey);
-      committedPreloaded = true;
-      // I-NextMeta: the prebuffered audio is already playing, so render the new
-      // song's card in-gesture from the peeked metadata (mig 038) instead of
-      // leaving the PREVIOUS title up until select_next_song resolves ~150ms
-      // later. Record the id first so the song-resolver effect treats this as an
-      // optimistic lead (not staleness) and doesn't reload the old song. The
-      // RPC's authoritative row reconciles the card below (same values).
-      optimisticSongIdRef.current = preloaded.song_id;
-      setCurrentSong({
-        id: preloaded.song_id,
-        title: preloaded.title,
-        artist: preloaded.artist,
-        youtube_id: preloaded.youtube_id,
-        start_time: preloaded.start_time,
-        is_soundtrack: preloaded.is_soundtrack,
-      });
-    }
-
-    try {
-      if (committedPreloaded && preloaded) {
-        // Confirm/record the round for the exact song we already started.
-        const result = await selectNextSongDirect(gameCode, managerToken, preloaded.song_id);
-        songStart.rpcDone({
-          roundNumber: result.round_number,
-          songId: result.song.id,
-          youtubeId: result.song.youtube_id,
-          preloaded: true,
-        });
-        setCurrentSong(result.song);
-        if (result.song.id !== preloaded.song_id) {
-          // Defensive: the RPC picked something other than what we prebuffered
-          // and already began playing (should not happen with an explicit
-          // song_id). Cold-load the real song onto the now-live player.
-          await loadSongIntoPlayer(result.song);
-        }
-      } else {
-        // Slow path (first round without a warmed buffer, preload missed, or
-        // pool was empty at peek time): random pick + cold load on the live
-        // player. On mobile this load lands after the await, so it can't reliably
-        // autoplay — but the waiting-screen prebuffer normally routes round 1
-        // through the fast path above, leaving this as a rare fallback.
-        const result = await selectNextSongDirect(gameCode, managerToken);
-        songStart.rpcDone({
-          roundNumber: result.round_number,
-          songId: result.song.id,
-          youtubeId: result.song.youtube_id,
-          preloaded: false,
-        });
-        setCurrentSong(result.song);
-        await loadSongIntoPlayer(result.song);
-      }
-    } catch (err) {
-      songStart.fail("select_next_song_failed");
-      songStartRef.current = null;
-      optimisticSongIdRef.current = null;
-      // The round failed to advance server-side, so the optimistic in-gesture
-      // swap (which has to happen before the await for mobile autoplay) must
-      // not stand. Roll all of it back: silence the promoted player, restore
-      // the pre-click active player + song card, and reload the still-current
-      // round's song so the room isn't left in silence (best-effort on strict
-      // mobile autoplay — this load lands outside the gesture). The peeked
-      // song goes back into the standby buffer: the round never advanced, so
-      // it is still exactly what select_next_song would record, and a retry
-      // click keeps the in-gesture fast path.
-      if (committedPreloaded && preloaded) {
-        activePlayer()?.stop();
-        activeKeyRef.current = prevKey;
-        setActiveKey(prevKey);
-        setCurrentSong(prevSong);
-        if (prevSong) activePlayer()?.loadVideoById(prevSong.youtube_id, prevSong.start_time);
-        preloadRef.current = preloaded;
-        standbyPlayer()?.prebuffer(preloaded.youtube_id, preloaded.start_time);
-      }
-      reportError(err);
-    } finally {
-      nextRoundInFlightRef.current = false;
-    }
-  }
-
-  // The expiry banner's "Keep playing +1h" -> extend_game direct RPC (mig
-  // 039), pushing active_games.expires_at out an hour. The Realtime UPDATE on
-  // expires_at is what moves the banner back to the subtle hint for everyone;
-  // the toast just confirms the commit to the host who clicked.
-  async function handleExtendGame() {
-    if (extendInFlightRef.current) return;
-    if (!state || !managerToken) return;
-    extendInFlightRef.current = true;
-    setPendingExtendFor(state.game.expires_at);
-    try {
-      const newExpiresAt = await extendGameDirect(gameCode, managerToken);
-      const endsAt = new Date(newExpiresAt).toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-      toast(`Game extended — now ends at ${endsAt}`, { variant: "success" });
-    } catch (err) {
-      setPendingExtendFor(null);
-      reportError(err);
-    } finally {
-      extendInFlightRef.current = false;
-    }
-  }
-
-  async function handleBonus(teamId: string, teamName: string) {
-    if (busy || !managerToken) return;
-    // Close the picker and acknowledge the click immediately, but do NOT
-    // claim success yet: the bonus is the one Render-routed scoring call, so
-    // on a cold start it can hang for many seconds or fail outright, and an
-    // optimistic "+4" here let the host believe a bonus landed that the room
-    // never saw (F-P1-5). The success toast waits for the call to resolve;
-    // `busy` keeps Bonus + End game gated while it's in flight (the per-round
-    // scoring buttons stay deliberately independent of it).
-    setBonusOpen(false);
-    toast(`Sending +4 to ${teamName}...`, { variant: "info" });
-    setBusy(true);
-    try {
-      await awardBonus(gameCode, managerToken, { team_id: teamId });
-      toast(`+4 bonus to ${teamName}`, { variant: "success" });
-    } catch (err) {
-      reportError(err);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function performEnd() {
-    if (busy || !managerToken) return;
-    // Toast fires before the network call so the manager gets immediate
-    // feedback the click registered; if endGame() fails reportError() will
-    // surface the failure on top.
-    toast("Ending game...", { variant: "info" });
-    setBusy(true);
-    try {
-      await endGame(gameCode, managerToken);
-      playerARef.current?.stop();
-      playerBRef.current?.stop();
-      clearManagerToken(gameCode);
-    } catch (err) {
-      reportError(err);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // onReady for the initially-active player (A). Drives the reactive ready gate
-  // (Start button) and flushes any deferred first song into the live player.
-  function onPlayerReady() {
-    playersReadyRef.current.A = true;
-    player.setReady();
-    const queued = player.flushPendingSong();
-    if (queued) {
-      // This is the deferred first-song load; mark loadIssued here so the
-      // song-start span's load_to_playing child measures from the real load.
-      songStartRef.current?.loadIssued();
-      armSongStartTimeout();
-      activePlayer()?.loadVideoById(queued.youtube_id, queued.start_time);
-    }
-  }
-
-  // onReady for the standby player (B). It only ever plays after a swap, so it
-  // doesn't gate the Start button or flush the first song — it just records
-  // readiness so we don't prebuffer into a player that hasn't constructed yet.
-  // The state flip wakes the waiting-prebuffer effect so the first song warms
-  // up as soon as both the standby is ready and the game is in "waiting".
-  function onPlayerBReady() {
-    playersReadyRef.current.B = true;
-    setStandbyConstructed(true);
-  }
 
   if (!managerToken) {
     return (

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import asyncpg
 import pytest
@@ -28,6 +29,19 @@ import pytest_asyncio
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+
+# A dedicated LOGIN role the RLS tests connect *as* directly (its own DSN),
+# instead of doing `SET ROLE anon` on the superuser connection. `SET ROLE` on a
+# superuser session leaks superuser/role state across the reused testcontainer
+# and was the root cause of the recurring `test_rls_anon` flake (spurious "DID
+# NOT RAISE InsufficientPrivilegeError" when the file ran after the rest of the
+# suite). Postgres's `anon` role is NOLOGIN (see migration 006), so it can't be
+# connected to directly; this role is LOGIN + INHERIT and is GRANTed membership
+# in `anon`, so every policy/GRANT targeting `anon` applies to it -- while it is
+# genuinely NOT a superuser and does NOT bypass RLS. Test-only: created in the
+# `_migrated` setup fixture, never in a migration file (so it never reaches prod).
+ANON_LOGIN_ROLE = "anon_login_test"
+ANON_LOGIN_PASSWORD = "anon_login_test_pw"  # noqa: S105 - throwaway local test role
 
 # Truncated between tests so each function starts clean. Durable tables
 # (songs/genres/song_genres) are included so tests populate exactly what they need.
@@ -75,9 +89,24 @@ def database_url() -> Iterator[str]:
         container.stop()
 
 
+def _anon_login_dsn(migrated_url: str) -> str:
+    """Derive the anon-login DSN from the migrated (superuser) DSN.
+
+    Same host/port/dbname/query; only the user+password change to the dedicated
+    non-superuser login role. Keeps the tests pointed at the identical database
+    the migrations were applied to, just with anon's effective privileges.
+    """
+    parts = urlsplit(migrated_url)
+    host = parts.hostname or "localhost"
+    netloc = f"{quote(ANON_LOGIN_ROLE)}:{quote(ANON_LOGIN_PASSWORD)}@{host}"
+    if parts.port is not None:
+        netloc += f":{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def _migrated(database_url: str) -> AsyncIterator[str]:
-    """Apply every migration once per session.
+    """Apply every migration once per session, then provision the anon-login role.
 
     `loop_scope="session"` is required because pytest-asyncio defaults to a
     function-scoped event loop; without this, the session-scoped fixture
@@ -90,6 +119,25 @@ async def _migrated(database_url: str) -> AsyncIterator[str]:
                 await conn.execute(sql)
             except Exception as e:
                 raise RuntimeError(f"Migration {name} failed: {e}") from e
+        # Provision the dedicated non-superuser LOGIN role the RLS tests connect
+        # as (see ANON_LOGIN_ROLE). Idempotent: created only if missing, then its
+        # attributes + `anon` membership are re-asserted so a reused container
+        # (external $DATABASE_URL / testcontainer reuse) converges to the same
+        # state. NOSUPERUSER + NOBYPASSRLS + INHERIT make it a true anon stand-in.
+        # The interpolated values are hardcoded module constants, not user input.
+        provision_role_sql = f"""
+            DO $$
+            BEGIN
+              IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{ANON_LOGIN_ROLE}') THEN
+                CREATE ROLE {ANON_LOGIN_ROLE} LOGIN PASSWORD '{ANON_LOGIN_PASSWORD}';
+              END IF;
+            END $$;
+            ALTER ROLE {ANON_LOGIN_ROLE}
+              LOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE INHERIT
+              PASSWORD '{ANON_LOGIN_PASSWORD}';
+            GRANT anon TO {ANON_LOGIN_ROLE};
+            """  # noqa: S608 - constants, not user input
+        await conn.execute(provision_role_sql)
     finally:
         await conn.close()
     yield database_url
@@ -114,14 +162,37 @@ async def db(_migrated: str) -> AsyncIterator[asyncpg.Connection]:
 
 @pytest_asyncio.fixture
 async def anon_conn(db: asyncpg.Connection, _migrated: str) -> AsyncIterator[asyncpg.Connection]:
-    """A fresh connection with `SET ROLE anon`, for RLS tests.
+    """A fresh connection authenticated *as* the dedicated non-superuser login
+    role (ANON_LOGIN_ROLE), for RLS tests.
+
+    This connects with the login role's own DSN rather than doing `SET ROLE anon`
+    on a superuser connection -- the latter leaked superuser/role state across
+    the reused testcontainer and caused the recurring `test_rls_anon` flake. The
+    login role inherits `anon`'s privileges via role membership, so RLS policies
+    and GRANTs that target `anon` apply, while it is genuinely not a superuser and
+    does not bypass RLS.
 
     The `db` fixture is requested only to ensure truncation happens first; the
     anon connection itself is separate.
     """
-    conn = await asyncpg.connect(_migrated)
+    conn = await asyncpg.connect(_anon_login_dsn(_migrated))
     try:
-        await conn.execute("SET ROLE anon")
+        # Prove we're really testing anon-level privileges: a non-superuser
+        # login role, not superuser-with-SET-ROLE. If this ever regressed to a
+        # superuser session the RLS denial assertions would silently pass for
+        # the wrong reason (superuser bypasses every check).
+        ident = await conn.fetchrow(
+            "SELECT session_user, current_user, "
+            "(SELECT rolsuper FROM pg_roles WHERE rolname = current_user) AS is_super, "
+            "(SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) AS bypass_rls"
+        )
+        assert ident is not None
+        assert ident["session_user"] == ANON_LOGIN_ROLE, (
+            f"anon_conn must authenticate as {ANON_LOGIN_ROLE}, got {ident['session_user']}"
+        )
+        assert ident["current_user"] == ANON_LOGIN_ROLE
+        assert ident["is_super"] is False, "anon_conn must NOT be a superuser"
+        assert ident["bypass_rls"] is False, "anon_conn must NOT bypass RLS"
         yield conn
     finally:
         await conn.close()


### PR DESCRIPTION
## Summary

Phase 7 T7.2 — decompose the two god components. **Pure, no-behavior-change refactor**: existing code moved into hooks/components; no RPC call changed, no toast timing changed, no optimistic-then-await ordering changed. The existing tests are the safety net and stayed green without weakening any assertion.

Stacked on #205 (`fix/t7.5-rls-fixture-expiry-tests`) to avoid plan-file conflicts; GitHub will auto-retarget to `main` once #205 merges.

### Part 1 — `ManagerConsolePage`
Left as layout + wiring; the logic moved into hooks:
- **`useSongPrebuffer`** (`frontend/src/hooks/useSongPrebuffer.ts`) — the double-buffer YouTube machinery: `peek_next_song` + prebuffer, the active/standby swap, the song-start telemetry span, the waiting-screen first-song warm-up, and the player callbacks.
- **`useScoring`** (`frontend/src/hooks/useScoring.ts`) — the scoring/round actions: `award_attempt` (Correct Song / Correct Artist / Wrong / Soundtrack), `release_buzz_lock` (Continue), `select_next_song` (Next round), `extend_game`, plus the Render-routed Bonus / End. Owns `currentSong`, the pending-flag handoffs, the per-action in-flight refs, and the buzz-pause / reset / mid-round-resolver effects. `handleNextRound` composes the prebuffer surface, so the two hooks stay coupled exactly as the single component was.
- **`useManagerToken`** (`frontend/src/hooks/useManagerToken.ts`) — the backup-host-link token resolution (T4.10), pulled into its own small hook. The slimmed-down page made the React-Compiler `react-hooks/refs` lint rule able to fully analyze the render (it silently bails on very large components), and it flags the *pre-existing* intentional in-render ref access in that memo. Isolating it keeps the documented exception contained to one small, well-named hook instead of tainting the whole page render.

All 64 `ManagerConsolePage.test.tsx` cases pass **unchanged**.

### Part 2 — `AdminSongsPage`
Left as layout + wiring; extracted:
- **`SongTable`** (`frontend/src/components/SongTable.tsx`) — the catalog table (header, stale-while-revalidate dimming, skeletons, empty state, per-row Edit/Delete).
- **`SongEditForm`** (`frontend/src/components/SongEditForm.tsx`) — the create/edit form (field state, validation, genre multi-select). Now takes the raw `song` and owns the Song→form mapping internally, so the page never touches `FormState`.
- **`useAdminSongs`** (`frontend/src/hooks/useAdminSongs.ts`) — catalog data + filter/pagination state, the load/refetch effects, and the create/edit/delete/import handlers.

**Page-index clamp fix:** a delete or filter that shrinks the result set could leave the page index pointing past the last page (e.g. delete the last row of page 3 of 3 → `totalPages` drops to 2 but `page` stays 3, stranding the operator on an empty "Page 3 of 2"). Added a small effect that snaps `page` back to `totalPages` when it exceeds it (guarded on `total > 0`), which triggers a refetch on a page that actually has rows. Added a discriminating test (fails without the fix, passes with it).

No user-visible behavior change, so no CHANGELOG entry (the clamp is a latent-bug fix an operator wouldn't notice in normal use). No schema/RPC/RLS/contract change, so no docs update.

## Test plan
- `frontend/` — `npm run format:check && npm run lint && npm run typecheck && npm run test:run`: all green (452 tests).
- `npx vitest run --coverage`: green — statements 92%, branches 85.2%, functions 92%, lines 96% (all above the 85/80/85/85 thresholds).
- `ManagerConsolePage.test.tsx` (64) and `AdminSongsPage.test.tsx` (22, incl. the new clamp test) pass; no existing assertion weakened.
- Verified the new clamp test fails when the clamp effect is removed and passes with it.
