### PR TITLE
Cap bulk-import upload at 5 MB (413 on oversized) — F-P2-6

### DIFF
--- a/backend/app/db/errors.py
+++ b/backend/app/db/errors.py
@@ -55,6 +55,11 @@ class GoneError(DomainError):
     status = 410
 
 
+class PayloadTooLargeError(DomainError):
+    code = "payload_too_large"
+    status = 413
+
+
 class RateLimitedError(DomainError):
     code = "rate_limited"
     status = 429

--- a/backend/app/routers/admin_songs.py
+++ b/backend/app/routers/admin_songs.py
@@ -9,7 +9,7 @@ import anyio
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile, status
 
 from app.constants import SOUNDTRACK_GENRE_SLUGS
-from app.db.errors import NotFoundError, mapped_postgrest_errors
+from app.db.errors import NotFoundError, PayloadTooLargeError, mapped_postgrest_errors
 from app.db.supabase_client import SupabaseClientLike, get_supabase_client
 from app.middleware.admin_auth import require_admin
 from app.middleware.rate_limit import limiter
@@ -228,11 +228,52 @@ async def delete_song(request: Request, song_id: UUID) -> None:
 
 _REQUIRED_FILE = File(...)
 
+# Hard cap on the multipart upload buffered into the single free-tier worker's
+# RAM. The real catalog CSV is ~40 KB / ~1000 rows, so 5 MB is very generous
+# while still bounding a runaway upload before it can OOM the worker.
+MAX_IMPORT_BYTES = 5 * 1024 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+def _too_large() -> PayloadTooLargeError:
+    return PayloadTooLargeError(
+        f"upload exceeds the {MAX_IMPORT_BYTES}-byte limit",
+        details={"limit_bytes": MAX_IMPORT_BYTES},
+    )
+
+
+async def _read_capped(file: UploadFile) -> bytes:
+    """Buffer the upload, refusing to read past ``MAX_IMPORT_BYTES``.
+
+    Reads in bounded chunks and stops the moment the cap is exceeded, so a
+    missing or lying ``Content-Length`` can't push more than the cap into RAM.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await file.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_IMPORT_BYTES:
+            raise _too_large()
+        chunks.append(chunk)
+    return b"".join(chunks)
+
 
 @router.post("/bulk-import", response_model=BulkImportSummary)
 @limiter.limit("5/minute")
 async def bulk_import(request: Request, file: UploadFile = _REQUIRED_FILE) -> BulkImportSummary:
-    raw = await file.read()
+    # Fast-path reject on a declared Content-Length before buffering anything;
+    # the streamed read below is the real backstop for a missing/lying header.
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > MAX_IMPORT_BYTES:
+                raise _too_large()
+        except ValueError:
+            pass
+    raw = await _read_capped(file)
     rows = parse_csv(raw)
     summary = await apply_import(get_supabase_client(), rows)
     return BulkImportSummary(

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -358,6 +358,8 @@ All under `/admin/songs/*`. **Admin-password auth required** on every endpoint (
 
 Bulk import is idempotent on `youtube_id`: existing songs are updated, new ones are inserted.
 
+The upload is capped at **5 MB** (the real catalog CSV is ~40 KB). An over-cap body is rejected with **`413 payload_too_large`** before it is parsed — enforced both on a declared `Content-Length` and via a streamed read, so a missing or under-declared header can't bypass the cap.
+
 ---
 
 ## 3. Postgres RPC (PostgREST)

--- a/tests/backend/test_admin_songs_bulk_import.py
+++ b/tests/backend/test_admin_songs_bulk_import.py
@@ -85,6 +85,20 @@ async def test_admin_required(client) -> None:
     assert resp.status_code == 401
 
 
+async def test_under_cap_upload_still_imports(admin_client) -> None:
+    """A normal, well-under-cap upload is unaffected by the size cap (F-P2-6)."""
+    from app.routers.admin_songs import MAX_IMPORT_BYTES
+
+    csv = _csv([["Hello", "Adele", "YQHsXMglC9A", "0", "rock"]])
+    assert len(csv) < MAX_IMPORT_BYTES
+    resp = await admin_client.post(
+        "/admin/songs/bulk-import",
+        files={"file": ("songs.csv", io.BytesIO(csv), "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["inserted"] == 1
+
+
 async def test_bulk_import_persists_release_year(admin_client, db) -> None:
     header = "title,artist,youtube_id,start_time,genres,release_year\n"
     body = "Yr Song,Yr Artist,YQHsXMglC9A,0,rock,1994\n"

--- a/tests/backend/test_admin_songs_import_size_cap.py
+++ b/tests/backend/test_admin_songs_import_size_cap.py
@@ -1,0 +1,122 @@
+"""Bulk-import upload size cap (F-P2-6).
+
+Over-cap uploads must be refused with HTTP 413 *before* the CSV is parsed or
+any DB call is made. These tests run without Docker: the app is built with a
+stub supabase client whose ``table()`` raises, so a request that reaches the
+DB fails loudly — proving the 413 short-circuit happens first.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import os
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+ADMIN_PASSWORD = "test-admin-pw"
+
+
+class _NoDBClient:
+    """Supabase-shaped stub that refuses any DB access."""
+
+    def table(self, name: str) -> Any:  # pragma: no cover - must never be hit
+        raise AssertionError(f"DB was touched (table={name!r}); 413 should short-circuit first")
+
+    def rpc(self, name: str, params: dict[str, Any] | None = None) -> Any:  # pragma: no cover
+        raise AssertionError(f"DB was touched (rpc={name!r}); 413 should short-circuit first")
+
+
+@pytest.fixture
+def _env() -> Iterator[None]:
+    previous = {
+        key: os.environ.get(key)
+        for key in ("ADMIN_PASSWORD", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "CORS_ORIGINS")
+    }
+    os.environ["ADMIN_PASSWORD"] = ADMIN_PASSWORD
+    os.environ["SUPABASE_URL"] = "http://stub-supabase.test"
+    os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "stub-key"
+    os.environ["CORS_ORIGINS"] = "http://test"
+    yield
+    for key, value in previous.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.fixture
+def nodb_app(_env: None) -> Iterator[Any]:
+    """Build the app wired to a no-DB stub client.
+
+    Uses distinct fixture names (``nodb_app`` / ``nodb_admin_client``) so this
+    module never shadows the DB-backed fixtures in ``conftest.py``, and it
+    saves/restores the prior client factory so running this module before a
+    DB-backed module can't leak the stub into it.
+    """
+    from app import config as config_module
+    from app.db import supabase_client as supabase_module
+
+    previous_factory = supabase_module._factory
+    config_module.get_settings.cache_clear()
+    supabase_module.set_supabase_client_factory(_NoDBClient)
+
+    import app.main as main_module
+
+    main_module = importlib.reload(main_module)
+    try:
+        yield main_module.app
+    finally:
+        supabase_module.set_supabase_client_factory(previous_factory)
+
+
+@pytest_asyncio.fixture
+async def nodb_admin_client(nodb_app: Any) -> AsyncIterator[Any]:
+    from httpx import ASGITransport, AsyncClient
+
+    from app.middleware import rate_limit
+
+    rate_limit.reset()
+    transport = ASGITransport(app=nodb_app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Admin-Password": ADMIN_PASSWORD},
+    ) as c:
+        yield c
+    rate_limit.reset()
+
+
+def _oversized_csv() -> bytes:
+    from app.routers.admin_songs import MAX_IMPORT_BYTES
+
+    header = b"title,artist,youtube_id,start_time,genres\n"
+    filler = b"x" * (MAX_IMPORT_BYTES + 1024)
+    return header + filler
+
+
+async def test_over_cap_returns_413_and_skips_db(nodb_admin_client) -> None:
+    resp = await nodb_admin_client.post(
+        "/admin/songs/bulk-import",
+        files={"file": ("big.csv", io.BytesIO(_oversized_csv()), "text/csv")},
+    )
+    assert resp.status_code == 413, resp.text
+    body = resp.json()
+    assert body["error"] == "payload_too_large"
+    # _NoDBClient.table would have raised (→ 500) if the DB were reached.
+
+
+async def test_lying_content_length_still_capped(nodb_admin_client) -> None:
+    """A too-small declared Content-Length can't smuggle an oversized body past
+    the streamed read backstop."""
+    payload = _oversized_csv()
+    resp = await nodb_admin_client.post(
+        "/admin/songs/bulk-import",
+        files={"file": ("big.csv", io.BytesIO(payload), "text/csv")},
+        headers={"Content-Length": "10"},
+    )
+    assert resp.status_code == 413, resp.text
+    assert resp.json()["error"] == "payload_too_large"


### PR DESCRIPTION
## Summary

F-P2-6: cap the admin bulk-import CSV upload size. `POST /admin/songs/bulk-import` previously did an unbounded `await file.read()`, buffering the entire multipart body into the single free-tier worker's RAM — a large upload could OOM the worker. It's admin-gated (`require_admin`), so this is trusted-principal / self-inflicted (low severity), but a cheap hardening.

- New `MAX_IMPORT_BYTES = 5 * 1024 * 1024` (5 MB) module constant. The real catalog CSV is ~40 KB / ~1000 rows, so 5 MB is very generous.
- Reject oversized uploads with **HTTP 413** *before* parsing/DB access, via a new `PayloadTooLargeError(DomainError)` (`status=413`, `code="payload_too_large"`) — mapped through the existing `domain_error_handler`, keeping the JSON envelope shape (`{"error", "message", "details"}`) consistent.
- Enforced two ways: a fast reject on a declared `Content-Length`, plus a streamed, chunked read that stops the moment the cap is exceeded — so a missing or under-declared `Content-Length` cannot buffer more than the cap into RAM.
- Happy path for normal-sized uploads is unchanged.
- Documented the cap + 413 in `docs/api-contracts.md`.

No CHANGELOG entry: internal admin-only hardening, not player-visible.

## Test plan

- Added `tests/backend/test_admin_songs_import_size_cap.py` (no Docker): builds the app with a stub supabase client whose `table()`/`rpc()` raise, proving the 413 short-circuits before any DB call. Covers (a) over-cap -> 413 + no DB, (b) an under-declared `Content-Length` still gets capped by the streamed read.
- Added `test_under_cap_upload_still_imports` to `tests/backend/test_admin_songs_bulk_import.py` confirming a normal well-under-cap upload still imports (happy path unchanged).
- `pytest -m "not stress"` (full backend + db suite): **294 passed, 1 skipped** on a throwaway testcontainer.
- `ruff check .`, `ruff format --check .`, `mypy app` from `backend/`: all clean.
