### PR TITLE
Add UNIQUE(songs.youtube_id) integrity constraint (mig 042, T6.3)

### DIFF
--- a/db/migrations/042_songs_youtube_id_unique.sql
+++ b/db/migrations/042_songs_youtube_id_unique.sql
@@ -1,0 +1,20 @@
+-- 042_songs_youtube_id_unique.sql
+-- Integrity: enforce one catalog row per YouTube video.
+--
+-- songs.youtube_id (char(11) NOT NULL, mig 002) had no uniqueness constraint,
+-- so nothing at the DB level stopped two songs rows pointing at the same
+-- YouTube video. The bulk-CSV importer already dedupes on youtube_id and the
+-- admin CRUD path is single-row, but a data-entry slip or a direct write could
+-- still create a duplicate -- which would then let the same video surface twice
+-- in one game's pool. This constraint makes duplicates impossible at the source.
+--
+-- Prod was verified dupe-free on youtube_id before adding (read-only prod query,
+-- 2026-07-10), so no dedup / data-merge is needed -- purely additive. NB: the
+-- known Avicii "Wake Me Up" pair is two DISTINCT youtube_ids (a same-song,
+-- different-video double upload), not a youtube_id duplicate.
+--
+-- Idempotent: a UNIQUE INDEX (which enforces uniqueness exactly like a UNIQUE
+-- constraint) created with IF NOT EXISTS is a clean no-op on re-apply. A bare
+-- ALTER TABLE ... ADD CONSTRAINT would error on the second pass, so it is
+-- avoided -- CI applies the whole migration set twice to verify idempotency.
+CREATE UNIQUE INDEX IF NOT EXISTS songs_youtube_id_key ON songs (youtube_id);

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -45,7 +45,8 @@ CREATE TABLE songs (
   release_year  integer                        -- original release year (mig 031); nullable
                   CHECK (release_year IS NULL OR release_year BETWEEN 1900 AND 2100),
   created_at    timestamptz NOT NULL DEFAULT now(),
-  updated_at    timestamptz NOT NULL DEFAULT now()
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (youtube_id)                          -- one catalog row per YouTube video (mig 042; via UNIQUE INDEX songs_youtube_id_key)
 );
 
 CREATE TABLE genres (
@@ -351,7 +352,8 @@ db/migrations/
 ├── 038_peek_next_song_metadata.sql -- peek_next_song also returns the candidate's title/artist/is_soundtrack so Next-round can label the song in-gesture
 ├── 039_extend_game.sql          -- token-gated "Keep playing +1h" TTL bump: expires_at = GREATEST(expires_at, now()) + 1h
 ├── 040_drop_total_rounds_column.sql -- finally DROP the orphan active_games.total_rounds (mig 015 only relaxed it)
-└── 041_buzz_in_scope_team_to_game.sql -- buzz_in only locks for a team that belongs to the game (EXISTS guard); closes a cross-game score-write vector
+├── 041_buzz_in_scope_team_to_game.sql -- buzz_in only locks for a team that belongs to the game (EXISTS guard); closes a cross-game score-write vector
+└── 042_songs_youtube_id_unique.sql   -- enforce UNIQUE(songs.youtube_id) via idempotent UNIQUE INDEX; one catalog row per YouTube video
 ```
 
 All migrations are written to be idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`, `DROP POLICY IF EXISTS … ; CREATE POLICY …`. Re-running them is safe.

--- a/tests/db/test_songs_youtube_id_unique.py
+++ b/tests/db/test_songs_youtube_id_unique.py
@@ -1,0 +1,43 @@
+"""songs.youtube_id uniqueness (migration 042).
+
+A UNIQUE INDEX (songs_youtube_id_key) enforces one catalog row per YouTube
+video, so a second songs row with an already-used youtube_id must be rejected
+with a unique-violation (SQLSTATE 23505). Distinct youtube_ids are unaffected.
+
+Spec: docs/data-model.md (songs table -- UNIQUE (youtube_id)).
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from ._helpers import create_test_song
+
+pytestmark = pytest.mark.needs_docker
+
+
+@pytest.mark.asyncio
+async def test_duplicate_youtube_id_rejected(db: asyncpg.Connection) -> None:
+    """Inserting a second song with the same youtube_id raises UniqueViolation."""
+    await create_test_song(db, title="First", youtube_id="dupTubeId11")
+
+    with pytest.raises(asyncpg.UniqueViolationError) as exc_info:
+        await create_test_song(db, title="Second", youtube_id="dupTubeId11")
+
+    # SQLSTATE 23505 = unique_violation.
+    assert exc_info.value.sqlstate == "23505"
+
+
+@pytest.mark.asyncio
+async def test_distinct_youtube_ids_allowed(db: asyncpg.Connection) -> None:
+    """Two songs with different youtube_ids coexist -- the constraint only
+    forbids exact duplicates, not near-duplicates (e.g. a same-song, different
+    video upload)."""
+    id_a = await create_test_song(db, title="Song A", youtube_id="aaaaaaaaaaa")
+    id_b = await create_test_song(db, title="Song B", youtube_id="bbbbbbbbbbb")
+
+    assert id_a != id_b
+
+    count = await db.fetchval("SELECT count(*) FROM songs")
+    assert count == 2


### PR DESCRIPTION
## Summary

T6.3 (Phase 6, D-8): add a `UNIQUE(songs.youtube_id)` integrity constraint so the catalog can never hold two rows for the same YouTube video.

- **Migration `db/migrations/042_songs_youtube_id_unique.sql`** — `CREATE UNIQUE INDEX IF NOT EXISTS songs_youtube_id_key ON songs (youtube_id);`. A unique index enforces uniqueness exactly like a `UNIQUE` constraint and `IF NOT EXISTS` is cleanly idempotent (CI applies the whole set twice); a bare `ALTER TABLE ... ADD CONSTRAINT` would error on the second pass, so it is avoided.
- Prod was verified **dupe-free on `youtube_id`** before adding (read-only prod query, 2026-07-10), so this is purely additive — no dedup / data-merge. The known Avicii "Wake Me Up" pair is two distinct youtube_ids, not a duplicate.
- **`db/seed/songs.sql`** is already dupe-safe: its songs INSERT is guarded by `WHERE NOT EXISTS (... youtube_id ...)` and its 12 VALUES rows have distinct youtube_ids, so seeding against the new index cannot violate it. The e2e `tests/e2e/fixtures/admin-api.ts` creates songs via the admin API with test-generated ids (no hardcoded dupes). No seed/fixture change needed.
- **Docs (`docs/data-model.md`)** — added `UNIQUE (youtube_id)` to the `songs` DDL block and appended mig 042 to the migration ledger. No `rpc-functions.md` / `security-rls.md` / CHANGELOG change (internal schema integrity, not player-visible).

## Test plan

- New `tests/db/test_songs_youtube_id_unique.py`: a second songs row with an already-used `youtube_id` raises `UniqueViolationError` (SQLSTATE 23505); two distinct youtube_ids coexist.
- `DATABASE_URL="" ./.venv/Scripts/python.exe -m pytest -c pyproject.toml --rootdir=. -p no:cov ../tests/db/test_songs_youtube_id_unique.py` -> **2 passed** on a throwaway testcontainer (conftest applies the full migration set incl. 042, so a green run also proves 042 applies cleanly in-sequence).
- Labeled `run-stress` + `run-e2e` so CI replays all migrations twice (idempotency) and seeds `db/seed/songs.sql` against the new constraint.
