### PR TITLE
Fix flaky e2e: raise YouTube data-ready gate 20s->40s (#222)

### DIFF
--- a/tests/e2e/fixtures/manager-context.ts
+++ b/tests/e2e/fixtures/manager-context.ts
@@ -71,9 +71,15 @@ export async function openManagerAndCreateGame(
   }
 
   // 6. Wait for the YouTube player wrapper to flip to ready so the Start
-  //    button enables.
+  //    button enables. `data-ready` only flips once the real YouTube IFrame
+  //    Player fires onReady, which depends on the third-party YT API + iframe
+  //    loading from www.youtube.com on the runner — latency varies, and a slow
+  //    window occasionally blew past 20s on attempt 1 (recovered on retry, but
+  //    logged as flaky; issue #222). The gate resolves the instant the attribute
+  //    flips, so a higher ceiling costs nothing on the happy path; it only
+  //    absorbs slow-YouTube windows.
   await expect(page.getByTestId("youtube-player")).toHaveAttribute("data-ready", "true", {
-    timeout: 20_000,
+    timeout: 40_000,
   });
 
   return { page, gameCode, managerToken };

--- a/tests/e2e/host_recovery.spec.ts
+++ b/tests/e2e/host_recovery.spec.ts
@@ -40,8 +40,10 @@ test("wiped-localStorage host recovers console access via the backup host link",
 
   // 4. The recovered console is actually functional, not just rendered:
   //    Start game advances to round 1 (a token-gated select_next_song RPC).
+  // 40s ceiling: the YouTube IFrame API's onReady depends on a third-party
+  // load from www.youtube.com whose latency varies on the runner (issue #222).
   await expect(page.getByTestId("youtube-player")).toHaveAttribute("data-ready", "true", {
-    timeout: 20_000,
+    timeout: 40_000,
   });
   await expect(page.getByTestId("start-round")).toBeEnabled();
   await page.getByTestId("start-round").click();

--- a/tests/e2e/manager_cleanup_yt_csp.spec.ts
+++ b/tests/e2e/manager_cleanup_yt_csp.spec.ts
@@ -201,11 +201,14 @@ test.describe("manager-cleanup-yt-csp branch", () => {
     // guards against. Wait for both players to be ready and give the prebuffer
     // time to load + pause, THEN snapshot the baseline, so the idle window
     // measures steady state (which must stay bounded).
+    // 40s ceiling on both players: onReady hinges on the third-party YouTube
+    // IFrame API loading from www.youtube.com, whose latency varies on the
+    // runner and occasionally exceeded 20s in a slow-network window (issue #222).
     await expect(page.getByTestId("youtube-player")).toHaveAttribute("data-ready", "true", {
-      timeout: 20_000,
+      timeout: 40_000,
     });
     await expect(page.getByTestId("youtube-player-preload")).toHaveAttribute("data-ready", "true", {
-      timeout: 20_000,
+      timeout: 40_000,
     });
     await page.waitForTimeout(8_000); // let the one-time first-song prebuffer load + freeze
 


### PR DESCRIPTION
## Summary

Fixes #222. The e2e suite occasionally logged `1 flaky` when the manager fixture's YouTube `data-ready="true"` gate timed out on attempt 1 under a slow-network window, then passed on Playwright retry (run stays green but noisy, with a small risk of a double-flake turning a run red).

`data-ready` flips to `true` only when the real YouTube IFrame Player fires `onReady` (`YouTubePlayer.tsx`), which depends on the YT API script + iframe loading from `www.youtube.com` on the GitHub-hosted runner — a third-party network dependency whose latency varies. When it exceeds the fixture's 20s gate, attempt 1 fails.

Per the issue's recommended mitigation (#1), this raises the gate from **20s → 40s**. The `expect(...).toHaveAttribute` resolves the instant the attribute flips, so the higher ceiling costs nothing on the happy path (player usually ready in a few seconds) — it only absorbs slow-YouTube windows.

Applied to **all four** live-YouTube ready gates in the suite that share the identical root cause, not just the one named in the issue, so the same flake can't simply resurface from another spec:

- `tests/e2e/fixtures/manager-context.ts` (the fixture used by every game spec — the one observed in #222)
- `tests/e2e/host_recovery.spec.ts`
- `tests/e2e/manager_cleanup_yt_csp.spec.ts` (active + preload players)

Test-only change — no product/runtime code touched, so no CHANGELOG entry (test-fixture tweaks are excluded per the repo's changelog policy).

## Test plan

- `run-e2e` label added so the Playwright suite runs against a throwaway local Supabase stack on this PR; expect a clean `33 passed` with **no `flaky`** line.
- Post-merge, the E2E workflow runs automatically on the `main` push — the second validation that the flake is gone.
