### PR TITLE
ci(e2e): bump Node 20->22 to match frontend.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           # cache-dependency-path is repo-root-relative (setup-node ignores the
           # step-level working-directory), so it names frontend/package-lock.json.
           cache: "npm"


### PR DESCRIPTION
## Summary

Bumps the E2E workflow's `actions/setup-node` from `node-version: "20"` to `"22"`, matching `frontend.yml` (both jobs use `"22"`). Removes a pre-existing divergence surfaced by the CI-cache audit — the frontend now installs and runs under the same Node major across every workflow, and the npm cache (added in #226) is shared cleanly.

Node 22 is the current LTS; the frontend already installs + builds + tests under it in `frontend.yml`, and Playwright supports Node 22. No app code changes.

Not user-visible → no CHANGELOG entry.

## Test plan

- `e2e.yml` parses as valid YAML; the e2e `setup-node` `with:` resolves to `{node-version: "22", cache: "npm", cache-dependency-path: "frontend/package-lock.json"}`.
- Labeled `run-e2e` so the full Playwright multi-context E2E job runs on Node 22 on this PR — the real verification that the whole game flow passes under the bumped runtime. (Note: the suite has a known intermittent third-party YouTube-IFrame flake, issue #222, unrelated to the Node version.)
