### PR TITLE
Document indefinite game_history retention as an accepted tradeoff (T5.4)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,7 +24,7 @@ active_games (PK: game_code) ◄────────────────
 
 **Durable** (never auto-deleted): `songs`, `genres`, `song_genres`.
 **Ephemeral** (deleted 4h after `started_at`): `active_games`, `game_teams`, `game_rounds`. Pruned by pg_cron.
-**Durable game history** (never pruned; mig 033): `game_history`, `game_history_teams`, `game_history_songs` — an end-of-game snapshot written by `archive_game()` so a finished game survives the 4h sweep. Operator-only (no `anon` read).
+**Durable game history** (never pruned; mig 033): `game_history`, `game_history_teams`, `game_history_songs` — an end-of-game snapshot written by `archive_game()` so a finished game survives the 4h sweep. Operator-only (no `anon` read). Indefinite retention (incl. team names) is a **consciously accepted** tradeoff — the strings are pseudonyms and the archive is operator-only; see `security-rls.md` §4 (T5.4).
 
 The only FK crossing the durable ↔ ephemeral boundary is `game_rounds.song_id → songs.id`, with `ON DELETE SET NULL` so deleting a song doesn't break in-progress rounds. The history tables likewise keep a soft `game_history_songs.song_id → songs.id` (ON DELETE SET NULL) but **denormalize** title/artist/youtube_id, so a later catalog edit or delete can't rewrite the recorded history.
 

--- a/docs/planning/phases/phase-5-security.md
+++ b/docs/planning/phases/phase-5-security.md
@@ -25,7 +25,7 @@
 - [x] ✅ **Shipped in Phase 3** (mig 037 / PR #168): RLS enabled, anon/authenticated revoked, table dropped from the Realtime publication; RLS suite covers it.
 
 ### T5.4 · `game_history` retention/PII `[S–M]` — extra_finding
-- [ ] Add a retention sweep or anonymize team names on archive (they're currently kept indefinitely, unlike the 4h ephemeral tables). Decide retention window with the maintainer if non-obvious.
+- [x] **Keep forever + document as accepted** (maintainer decision 2026-07-11). No retention sweep / anonymization job: `game_history` team names are user-chosen pseudonyms (not PII) and the archive is operator-only (RLS + no anon grant, mig 033), so indefinite retention is a consciously-accepted tradeoff rather than a gap. Documented in `security-rls.md` §4 (new "Durable game history is retained indefinitely (T5.4)" entry) + a pointer in `data-model.md`. If the posture ever changes, the noted lighter first step is a `pg_cron` sweep nulling `game_history_teams.name` past a window. Docs-only; no code/migration.
 
 ## Decision-resolved tasks (per §05, 2026-07-04)
 

--- a/docs/security-rls.md
+++ b/docs/security-rls.md
@@ -200,7 +200,7 @@ If we ever add per-user scoping, RLS policies become more restrictive and Realti
 
 ### Accepted design tradeoffs (decided per §05, documented — not mitigated)
 
-Two abuse surfaces were surfaced by the security review and **consciously accepted** rather than fixed, because the fix costs more than the risk for a casual, in-the-room party game. They are recorded here so "we didn't think of it" can never be confused with "we decided it was fine."
+Several design tradeoffs were surfaced by the security review and **consciously accepted** rather than fixed, because the fix costs more than the risk for a casual, in-the-room party game. They are recorded here so "we didn't think of it" can never be confused with "we decided it was fine."
 
 **Buzzing is unauthenticated by design (D-4).** Teams hold no per-team secret. Any client that knows the 6-char game code can call `buzz_in` for any `team_id` in that game (every `game_teams` row is anon-readable by design — see §2), and anyone can join with a name that matches an existing team. So a client *could* buzz as the wrong team, or an outsider who has the code *could* grief-buzz. This is deliberate:
 - **The host is the integrity check.** The buzzing team's name shows on the manager console *and* the shared display in real time. A wrong or malicious buzz is visible and correctable in the moment — the host uses **Continue round** to re-open the lock, or **Wrong** to deduct — exactly as they would for any human dispute at the table.
@@ -215,6 +215,12 @@ The same-name **reclaim** ergonomic that pairs with this (F-P2-1 — a team re-j
 - **The clip is audibly playing to the entire room.** The "answer" to *name that tune* is literally being broadcast — it is not a secret the DB is leaking, it's the game. Reading it in devtools beats listening by seconds, if at all.
 - **The cheat is narrow and self-defeating.** It requires devtools open mid-round at a party where you're supposed to be listening; it wins a casual trivia point at the cost of playing the game.
 - **Hiding it would tax the hot path.** The clients that render the player and the reveal legitimately need the round's song reference; withholding it would force a per-round server-gated reveal round-trip (latency + complexity) for negligible benefit. Documented per D-2.
+
+**Durable game history is retained indefinitely (T5.4 — accepted).** The `game_history` / `game_history_teams` / `game_history_songs` archive (mig 033) snapshots every game that played ≥1 round and is **never pruned**, so team names persist far beyond the 4h TTL of the live tables. Retention was reviewed and **accepted as-is** — no retention sweep, no anonymization job — because:
+- **The stored strings are pseudonyms, not PII.** Team names are free-text party handles chosen per game (see §9); no accounts, emails, or real identities are collected, so there is no personal data with a basis to expire.
+- **The archive is operator-only.** RLS is enabled with no anon policy and the base grants are revoked from `anon`/`authenticated` (mig 033), so the history is reachable only via the service-role key in the Supabase SQL editor — never by players or the anon web client.
+- **Volume is negligible.** One parent row per game that played a round, plus a handful of child rows; the table grows slowly and is an audit/analytics convenience, so unbounded growth is not a practical concern.
+If the privacy posture ever changes (e.g. names become linkable to real identities), the lighter first step is a `pg_cron` sweep that nulls `game_history_teams.name` past a retention window — mirroring `cleanup_expired_games` — rather than deleting the whole record.
 
 ## 5. Secret Inventory
 


### PR DESCRIPTION
## Summary

Phase 5 / **T5.4** — `game_history` retention / PII. Per the maintainer's decision (2026-07-11), indefinite retention of the durable game-history archive (`game_history` / `_teams` / `_songs`, mig 033) is **consciously accepted and documented** rather than mitigated with a retention sweep or an anonymization job. Rationale:

- The stored team names are **user-chosen pseudonyms, not PII** — no accounts, emails, or real identities are collected.
- The archive is **operator-only**: RLS enabled with no anon policy and base grants revoked from `anon`/`authenticated` (mig 033), so it's reachable only via the service-role key in the Supabase SQL editor.
- **Volume is negligible** — one parent row per game that played a round; the table grows slowly and is an audit/analytics convenience.

This mirrors the existing "accept + document" pattern used for D-2 / D-4. Docs-only — no code, no migration, no user-visible change (so no CHANGELOG entry).

Documented in:
- `docs/security-rls.md` §4 — new "Durable game history is retained indefinitely (T5.4)" accepted-tradeoff entry (and broadened the section intro from "Two abuse surfaces" to "Several design tradeoffs"). Notes that if the privacy posture ever changes, the lighter first step is a `pg_cron` sweep nulling `game_history_teams.name` past a window, not deletion.
- `docs/data-model.md` — traceability pointer on the durable-history line.
- `docs/planning/phases/phase-5-security.md` — T5.4 box ticked with the decision.

## Test plan

Docs-only change; no tests affected. CI runs CodeQL only (backend/frontend workflows are path-filtered, e2e is label-gated).
