### PR TITLE
Add protocol-level load-test harness (tests/load): N-games x M-teams capacity checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ Thumbs.db
 supabase/.branches/
 supabase/.temp/
 
+# Load-test run artifacts (reports + per-run game manager tokens)
+tests/load/results/
+
 # Playwright
 test-results/
 playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ tests/db/        pytest + testcontainers-postgres (needs Docker).
 tests/backend/   pytest + httpx against FastAPI.
 tests/e2e/       Playwright; separate package.json.
 tests/smoke/     Post-deploy manual checks.
+tests/load/      Manual capacity harness (N games x M teams); never in CI. See its README.
 docs/            The spec. Code that contradicts a doc must update the doc in the same PR.
 .github/workflows/  CI. Do not modify without asking (see ci-and-repo-config rule).
 ```

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -166,6 +166,18 @@ Run manually after each prod deploy.
 | `post_deploy.sh` | curl `/health`; create game (no auth) and capture `manager_token`; join 2 teams; start round (with token); end game (with token); cleanup |
 | `prod_realtime.spec.ts` | Playwright against prod URL; one buzzer race round end-to-end |
 
+### 4.6 Load tests: `tests/load/`
+
+Run manually (never in CI) against prod or a local stack to answer capacity
+questions: N concurrent games × M teams × R rounds. Protocol-level Node
+harness — REST for create/join/bonus/end/kick, direct PostgREST RPCs for the
+hot path, one Realtime WebSocket per simulated device — with seeded flow
+coverage of every manager button, expected-score ledger verification, latency
+percentiles, and Realtime delivery/miss measurement. Zero new dependencies
+(supabase-js borrowed from `frontend/node_modules`). See `tests/load/README.md`
+for scenarios, thresholds, and the one-IP / connection-quota caveats, and
+`tests/load/RUN-PROMPTS.md` for the canned run procedures.
+
 ## 5. Phase Schedule
 
 | Phase | Tests written | Coverage gates active? |

--- a/tests/load/FINDINGS.md
+++ b/tests/load/FINDINGS.md
@@ -57,6 +57,8 @@ Rules (mirrors `.claude/rules/lessons-learned.md` discipline):
 |---|---|---|---|---|
 | 2026-07-14 | smoke #1 (1×3×11, fast, prod) | WARN | buzz_in p95 94ms; 2/220 RT misses; lock_set p95 2177ms | 1 (harness bug, fixed) |
 | 2026-07-14 | smoke #2 (1×3×11, fast, prod) | PASS | buzz_in p95 93ms; select p95 82ms; RT p95 ~610-630ms; 0/220 misses; all invariants green | 0 |
+| 2026-07-14 | smoke #3 (1×3×11, --rt-budget 3, prod) | FAIL | one device's channel had a multi-second delivery gap: 6/129 misses, fake 6-7s lock_set tail | 2 (1 harness bug fixed; 1 info below) |
+| 2026-07-14 | smoke #4 (--rt-budget 3) + #5 (full) | PASS | after matcher hardening: 0 misses both, RT p95 ~560-640ms, 0 reconnects | 0 |
 
 ## Findings
 
@@ -75,3 +77,26 @@ Rules (mirrors `.claude/rules/lessons-learned.md` discipline):
   up in the real checks, treat it as a genuine Realtime-latency finding, not a
   harness artifact.
 - **Status:** resolved
+
+### 2026-07-14 — smoke — transient Realtime per-channel delivery gap on prod (info)
+- **Severity:** info
+- **Symptom:** smoke #3 (only 3 Realtime connections — nowhere near quota):
+  one device missed 4 consecutive `round_insert` events plus 1 lock/score
+  event (~a several-second window); nothing in the harness or backend erred.
+  Two lock_set "deliveries" of 6.3s/7.7s in the same run turned out to be a
+  harness matcher false-match (a later round's buzz by the same winning team
+  satisfying the stale expectation), fixed by binding lock_set expectations to
+  `current_round_id` — after which reruns were clean (0 misses).
+- **Evidence:** `results/smoke-rtbudget-prev-*/report.json` (6/129 misses,
+  round_insert missRate 12.9% on a 3-device audience); reruns #4/#5 clean.
+- **Diagnosis:** consistent with a brief Supabase Realtime channel hiccup
+  (events during a gap are simply not replayed on a channel). The product
+  self-heals via hydrate-on-subscribe + 60s backstop resync, so players would
+  see at most seconds of staleness — but the raw channel is not lossless.
+  The harness now surfaces `realtime:reconnects` / `realtime:channel_errors`
+  counters so future gaps are attributable in the report.
+- **Action:** harness hardened (round-bound lock_set matcher + channel-health
+  counters). Watch the real checks: if misses recur with reconnects > 0,
+  that's the same phenomenon; if misses recur with 0 reconnects, dig deeper
+  (silent gap without rejoin would be a stronger finding).
+- **Status:** open (behavior to watch during checks 1-5)

--- a/tests/load/FINDINGS.md
+++ b/tests/load/FINDINGS.md
@@ -1,0 +1,77 @@
+# Load-test findings log
+
+Every issue, anomaly, or capacity ceiling surfaced by a load-test run gets an
+entry here — including WARNs that turned out benign (write down *why* they're
+benign). This file is the durable memory of what the stack can and cannot
+take; the per-run `results/<label>/report.md` files are gitignored, so
+anything worth keeping must be copied into an entry below.
+
+Rules (mirrors `.claude/rules/lessons-learned.md` discipline):
+
+- One entry per distinct finding, newest first. Update an existing entry
+  instead of duplicating it if a later run adds evidence.
+- A run with verdict PASS and nothing surprising still gets a one-line entry
+  in the **Run ledger** table so coverage is auditable.
+- If a finding is a real product bug, note the GitHub issue number once filed.
+
+## Entry template
+
+```markdown
+### YYYY-MM-DD — <check label> — <short title>
+- **Severity:** blocker | major | minor | info
+- **Symptom:** what the report/monitor showed (verdict line, numbers)
+- **Evidence:** key figures from report.md/report.json, console log lines,
+  Grafana/Loki queries + results, Supabase dashboard observations,
+  pg_stat snapshots — enough that someone can re-derive the conclusion
+- **Diagnosis:** root cause (or best current hypothesis, marked as such)
+- **Action:** issue filed (#N) / fix shipped (PR #N) / accepted as capacity
+  limit / harness bug fixed / none needed (why)
+- **Status:** open | resolved | accepted
+```
+
+## Monitoring notes for load runs (read before diagnosing)
+
+- **Synthetic runs emit no Faro telemetry.** The harness is protocol-level
+  (no browsers), so Grafana Loki `{service_name="sound-clash-web"}` and Tempo
+  traces will NOT show the synthetic traffic. During a load run, Loki is
+  useful for one thing: spotting impact on *real* users (e.g.
+  `stale_buzz_lock_resynced` warns or error spikes from a live party in the
+  same window).
+- **Supabase-side metrics** (Realtime concurrent connections, DB CPU/IO,
+  connection pool) live in the Supabase dashboard (Reports → Database /
+  Realtime). As of 2026-07-14 there is no Supabase metrics scrape into
+  Grafana Cloud (that wiring is a known owed item) — check
+  `list_datasources` before assuming.
+- **DB-side ground truth** is available read-only and ungated:
+  `supabase db query --linked "select state, count(*) from pg_stat_activity group by state"`
+  before/during/after a run shows backend+PostgREST pool pressure (note:
+  Realtime *WebSocket* client count is NOT visible in pg_stat_activity — the
+  dashboard is the only place to read it).
+- The harness's own `report.json` (latency distributions, Realtime delivery
+  misses, subscribe failures, 429 counts) is the primary instrument; external
+  monitoring corroborates.
+
+## Run ledger
+
+| date | check | verdict | report highlights | findings |
+|---|---|---|---|---|
+| 2026-07-14 | smoke #1 (1×3×11, fast, prod) | WARN | buzz_in p95 94ms; 2/220 RT misses; lock_set p95 2177ms | 1 (harness bug, fixed) |
+| 2026-07-14 | smoke #2 (1×3×11, fast, prod) | PASS | buzz_in p95 93ms; select p95 82ms; RT p95 ~610-630ms; 0/220 misses; all invariants green | 0 |
+
+## Findings
+
+### 2026-07-14 — smoke — kicked device counted as false Realtime misses
+- **Severity:** minor (harness bug, not a product bug)
+- **Symptom:** smoke #1 verdict WARN: 2/220 Realtime deliveries reported as
+  misses, lock_set p95 2177ms with a 9316ms outlier.
+- **Evidence:** the kick flow closes the kicked team's device mid-run; open
+  expectations registered before the kick still counted that device in their
+  audience, so its (impossible) deliveries were booked as misses.
+- **Diagnosis:** measurement artifact in `lib/driver.mjs` — `kickOne()` closed
+  the device without removing it from open expectations' audiences.
+- **Action:** fixed in the same PR that added the harness (audience pruned
+  before close). Smoke #2 re-ran clean: 0/220 misses, all PASS. The 9.3s
+  lock_set outlier did not reproduce; if a similar near-window outlier shows
+  up in the real checks, treat it as a genuine Realtime-latency finding, not a
+  harness artifact.
+- **Status:** resolved

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,130 @@
+# Load tests (`tests/load/`)
+
+Protocol-level load harness that answers: **will the live stack survive a real
+event** — several simultaneous games, 10–30 teams each, 15 rounds, every
+manager button exercised?
+
+It simulates whole games exactly the way real devices talk to the stack:
+
+- **REST** (FastAPI on Render): create game, join teams, bonus, kick, end.
+- **Direct PostgREST RPCs** (the hot path, same anon key + args the browser
+  sends): `buzz_in`, `award_attempt`, `release_buzz_lock`, `select_next_song`,
+  `peek_next_song`, `extend_game`.
+- **Supabase Realtime**: one WebSocket **per simulated device** (each team
+  phone + manager + display), subscribing the exact channel the app uses
+  (`game:<code>`, three `postgres_changes` bindings filtered by `game_code`),
+  with the app's hydrate-on-subscribe reads and 60s backstop resync.
+
+No browsers and no YouTube: video playback is client-local and puts zero load
+on the backend, so a protocol harness measures the part that can actually
+fall over. Zero new dependencies — supabase-js is borrowed from
+`frontend/node_modules` via `createRequire` (needs Node ≥ 22 for the native
+WebSocket; this repo's machines run Node 24).
+
+## Commands
+
+```bash
+# from the repo root
+node tests/load/loadtest.mjs smoke                       # tiny self-check: 1 game, 3 teams, every flow once
+node tests/load/loadtest.mjs run --label check1-5x10  --games 5  --teams 10 --rounds 15 --seed 101
+node tests/load/loadtest.mjs run --label check2-10x10 --games 10 --teams 10 --rounds 15 --seed 202
+node tests/load/loadtest.mjs run --label check3-20x10 --games 20 --teams 10 --rounds 15 --seed 303
+node tests/load/loadtest.mjs run --label check4-1x30  --games 1  --teams 30 --rounds 15 --seed 404
+node tests/load/loadtest.mjs cleanup --dir tests/load/results/<label>   # end leftover games after a crash
+```
+
+Flags: `--pace realistic|fast` (default realistic: human-speed rounds),
+`--kick` (exercise the kick-team button late in each game), `--skip-bonus`,
+`--skip-resync`, `--genres rock,pop`, `--target prod|local`,
+`--create-rate/--join-rate/--mgr-rate` (per-minute REST pacing, defaults sit
+just under the backend's per-IP limits — only raise them if the backend's
+limits were temporarily raised too).
+
+Endpoints come from `frontend/.env.production` (prod) or `frontend/.env.local`
+(local); `LOADTEST_SUPABASE_URL` / `LOADTEST_SUPABASE_ANON_KEY` /
+`LOADTEST_API_URL` override.
+
+## What a run does
+
+1. **Preflight** — waits out the Render cold start via `/health`, resolves
+   genre UUIDs, checks the song pool covers the round count, and warns if any
+   real game is currently `playing` on the target.
+2. **Setup** — creates all games and joins all teams, **paced under the
+   backend's per-IP rate limits** (create 10/min, join 30/min — from one test
+   machine every request shares one bucket, so e.g. the 20-games×10-teams
+   check spends ~10 minutes here by design). Then opens every device's
+   Realtime socket. Setup finishes for *all* games before any round starts, so
+   the play phase is a true N-concurrent-games window.
+3. **Play** — each game runs its seeded round loop concurrently: pick a flow
+   (see below), `select_next_song`, sometimes `peek_next_song`, listen delay,
+   buzz(es), manager verdict(s), think-time delays. `extend_game` fires once
+   per game (~⅔ through), bonus is mixed in, kick optionally.
+4. **Verify** — final `game_teams` scores are fetched over anon PostgREST and
+   compared against the locally-kept expected ledger (which mirrors mig 043
+   scoring: title +10, artist +5, both +15, wrong −3, free-guess waiver 0).
+5. **Teardown** — every game gets `POST /games/{code}/end`; sockets close.
+   Game codes + manager tokens are journaled to `results/<label>/games.json`
+   as they're created, so `cleanup` can always end leftovers after a crash.
+6. **Report** — `results/<label>/report.md` + `report.json`, plus a
+   `status.json` heartbeat (updated every 2s) for detached monitoring.
+
+## Round flows (the "many combinations of buttons")
+
+| flow | what it exercises |
+|---|---|
+| `race_title` / `race_both` | all teams buzz simultaneously (the race), winner gets Correct Song / both tokens |
+| `single_title` / `single_artist` | lone buzz, one verdict |
+| `split_title_artist` | Correct Song → Continue → second team buzzes → Correct Artist |
+| `wrong_then_title` | Wrong (−3, auto-release) → another team wins the title |
+| `wrong_chain` | Wrong → Wrong → third team takes both (+15) |
+| `free_guess_waiver` | Correct Song → Continue → Wrong for **0** (mig 017 waiver) → Correct Artist |
+| `race_wrong_race` | full race, winner wrong, full re-race, winner scores |
+| `no_buzz_skip` | nobody buzzes; Next Round on an open round |
+| `bonus_after_title` | scoring + the Bonus REST endpoint |
+
+Flow choice is seeded (`--seed`) → a run is reproducible. `smoke` forces every
+flow exactly once.
+
+## Invariants (any violation ⇒ FAIL)
+
+- Every buzz race yields **exactly one** `locked=true` winner; losers see the
+  winner's id.
+- `award_attempt`'s returned delta and running total match the local ledger at
+  every step; final DB scores match exactly; kicked teams are gone.
+- `select_next_song` returns exactly `previous+1` round numbers; all rounds
+  complete; every game ends cleanly.
+
+## Metrics & verdicts
+
+- **RPC/REST latency** percentiles per operation (from the test machine).
+- **Realtime delivery**: action fired → `postgres_changes` event observed at
+  each subscribed device, for three families: buzz-lock set, round insert,
+  score update. Events not seen within 10s count as **misses**.
+- **Subscription outcomes**: sockets established vs failed (failures at high
+  device counts usually mean the Supabase plan's concurrent-connection quota —
+  a capacity finding, reported as WARN, not a code bug).
+- Thresholds are advisory (encoded in `lib/metrics.mjs`); read the
+  distributions in the report before reacting to a WARN.
+
+## Caveats
+
+- **One machine, one IP.** REST setup shares the per-IP rate-limit buckets
+  (real parties don't), and all latency includes this machine's RTT. Hot-path
+  RPCs go straight to PostgREST and are not affected.
+- **Realtime quota**: N games × (teams+2) sockets. 240 devices (check 3)
+  exceeds the Supabase free-tier concurrent-connection quota (200) by design —
+  that check probes the ceiling.
+- Runs create real (ephemeral, 4h TTL) games on the target and their swept
+  rows land in the durable `game_history` archive; team names are prefixed
+  `LT-` so they're recognizable. Every run ends its games; `cleanup` catches
+  crashes; the pg_cron sweeper is the final backstop.
+- `results/` is gitignored (it contains per-game manager tokens — ephemeral
+  secrets for games the harness itself created).
+
+## Findings discipline
+
+Per-run reports are gitignored, so **every** finding — violations, WARNs,
+capacity ceilings, harness bugs, and even clean PASSes (one ledger row) — must
+be recorded in the committed `tests/load/FINDINGS.md`, with the monitoring
+evidence (Grafana/Loki checks, pg_stat snapshots) described there. The run
+procedures in `RUN-PROMPTS.md` walk through it step by step.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -28,8 +28,9 @@ WebSocket; this repo's machines run Node 24).
 node tests/load/loadtest.mjs smoke                       # tiny self-check: 1 game, 3 teams, every flow once
 node tests/load/loadtest.mjs run --label check1-5x10  --games 5  --teams 10 --rounds 15 --seed 101
 node tests/load/loadtest.mjs run --label check2-10x10 --games 10 --teams 10 --rounds 15 --seed 202
-node tests/load/loadtest.mjs run --label check3-20x10 --games 20 --teams 10 --rounds 15 --seed 303
+node tests/load/loadtest.mjs run --label check3-20x10 --games 20 --teams 10 --rounds 15 --seed 303 --rt-budget 180
 node tests/load/loadtest.mjs run --label check4-1x30  --games 1  --teams 30 --rounds 15 --seed 404
+node tests/load/loadtest.mjs run --label check5-soak-3x10x60 --games 3 --teams 10 --rounds 60 --seed 505   # long soak
 node tests/load/loadtest.mjs cleanup --dir tests/load/results/<label>   # end leftover games after a crash
 ```
 
@@ -38,7 +39,10 @@ Flags: `--pace realistic|fast` (default realistic: human-speed rounds),
 `--skip-resync`, `--genres rock,pop`, `--target prod|local`,
 `--create-rate/--join-rate/--mgr-rate` (per-minute REST pacing, defaults sit
 just under the backend's per-IP limits — only raise them if the backend's
-limits were temporarily raised too).
+limits were temporarily raised too), `--rt-budget N` (cap concurrent Realtime
+subscriptions; shed order display → manager → teams round-robin, everything
+still plays via RPC — use 180 on the Supabase free tier, whose quota is ~200
+concurrent connections).
 
 Endpoints come from `frontend/.env.production` (prod) or `frontend/.env.local`
 (local); `LOADTEST_SUPABASE_URL` / `LOADTEST_SUPABASE_ANON_KEY` /
@@ -111,9 +115,12 @@ flow exactly once.
 - **One machine, one IP.** REST setup shares the per-IP rate-limit buckets
   (real parties don't), and all latency includes this machine's RTT. Hot-path
   RPCs go straight to PostgREST and are not affected.
-- **Realtime quota**: N games × (teams+2) sockets. 240 devices (check 3)
-  exceeds the Supabase free-tier concurrent-connection quota (200) by design —
-  that check probes the ceiling.
+- **Realtime quota**: N games × (teams+2) sockets. The project runs on the
+  Supabase **free tier** (~200 concurrent Realtime connections), so check 3
+  (240 devices) runs with `--rt-budget 180` — the harness sheds display, then
+  manager, then one team device per game from the *measurement* audience while
+  every device still plays. With the budget set, any subscribe failure is a
+  real finding. Remove the budget only after upgrading the plan.
 - Runs create real (ephemeral, 4h TTL) games on the target and their swept
   rows land in the durable `game_history` archive; team names are prefixed
   `LT-` so they're recognizable. Every run ends its games; `cleanup` catches

--- a/tests/load/RUN-PROMPTS.md
+++ b/tests/load/RUN-PROMPTS.md
@@ -1,0 +1,128 @@
+# Load-check run prompts
+
+Copy-paste prompts for running each load check in a **fresh Claude Code
+session**. One check at a time — never two concurrently (they'd confound each
+other's measurements and share the one-IP rate-limit buckets).
+
+**Session settings for every check:** model **Opus 4.8** (`/model opus`),
+default (medium) effort. The harness does the heavy lifting; the session just
+launches, watches, and reads the report. Keep Fable for design/analysis work.
+
+**Recommended order & rough duration** (realistic pace, includes the
+rate-limit-paced setup):
+
+| # | check | duration | why this order |
+|---|---|---|---|
+| 1 | `check1-5x10` — 5 games × 10 teams | ~10 min | baseline, matches a real multi-room event |
+| 2 | `check4-1x30` — 1 game × 30 teams | ~8 min | single-game fan-out + 30-way buzz races |
+| 3 | `check2-10x10` — 10 games × 10 teams | ~12 min | scale step |
+| 4 | `check3-20x10` — 20 games × 10 teams | ~18 min | ceiling probe (240 Realtime sockets — may exceed the Supabase plan's connection quota by design) |
+
+Run during a quiet window (the harness warns if a real game is `playing`).
+
+---
+
+## Template (all four checks use this; only the ARGS line differs)
+
+```
+Run the Sound Clash load check against production using the committed harness in tests/load/ (read tests/load/README.md first if anything is unclear). Do exactly this:
+
+1. Confirm the harness exists in the working tree (tests/load/loadtest.mjs). If it is missing, `git checkout feature/load-test-harness` first (or fetch main if the PR merged).
+
+1b. Baseline snapshot BEFORE launching (both are read-only and safe):
+   - `supabase db query --linked "select state, count(*) from pg_stat_activity group by state order by 2 desc"` (Bash, dangerouslyDisableSandbox: true) — save the output for comparison.
+   - Note the current time (UTC) so the Grafana/Loki window in step 4b is exact.
+
+2. Launch the run DETACHED — it runs longer than foreground Bash allows, and background Bash tasks get reaped on this machine. Use the PowerShell tool with dangerouslyDisableSandbox: true (the sandbox blocks egress to Supabase/Render):
+
+   Start-Process -FilePath "node" -ArgumentList <ARGS> -WorkingDirectory "C:\Users\yulin\GBA\Sound-Clash" -RedirectStandardOutput "C:\Users\yulin\GBA\Sound-Clash\tests\load\results\<LABEL>-console.log" -RedirectStandardError "C:\Users\yulin\GBA\Sound-Clash\tests\load\results\<LABEL>-console.err.log" -WindowStyle Hidden
+
+   (Create tests\load\results first if missing. Console logs live NEXT TO the run dir, not inside it — the harness archives/recreates results/<LABEL>/ at start.)
+
+3. Watch it with the Monitor tool (persistent: false, timeout_ms: 3600000):
+
+   dir="C:/Users/yulin/GBA/Sound-Clash/tests/load/results/<LABEL>"
+   prevkey=""
+   nofile=0
+   while true; do
+     if [ ! -f "$dir/status.json" ]; then
+       nofile=$((nofile+1))
+       if [ "$nofile" -gt 8 ]; then echo "STARTUP FAILED: status.json never appeared after ~2 min — read tests/load/results/<LABEL>-console.err.log"; break; fi
+     else
+       nofile=0
+       line=$(node -e "const s=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));console.log('phase='+s.phase+' rounds='+s.roundsDone+'/'+s.roundsTotal+' errors='+s.errorCount+' violations='+s.violationCount+' done='+s.done+' verdict='+s.verdict)" "$dir/status.json" 2>/dev/null || echo parse-retry)
+       key=$(echo "$line" | sed 's/rounds=[0-9]*/rounds=/')
+       if [ "$key" != "$prevkey" ]; then echo "$line"; prevkey="$key"; fi
+       case "$line" in *"done=true"*) break;; esac
+       now=$(date +%s); mt=$(stat -c %Y "$dir/status.json" 2>/dev/null || echo "$now")
+       if [ $((now-mt)) -gt 120 ]; then echo "STALLED: status.json silent for $((now-mt))s — process likely died, check the console log"; break; fi
+     fi
+     sleep 15
+   done
+
+   The setup phase is deliberately slow (REST create/join paced under the backend's per-IP rate limits) — a long "phase=setup" is expected, not a hang.
+
+   While the monitor runs, take one MID-RUN snapshot during the play phase:
+   `supabase db query --linked "select state, count(*) from pg_stat_activity group by state order by 2 desc"` — this shows DB connection pressure at peak.
+
+4. When done=true: Read tests/load/results/<LABEL>/report.md. Give me a plain-language summary: overall verdict, the latency table, the Realtime delivery table (including miss rate and subscription failures), invariant violations, and the per-game completion table. If the verdict is FAIL — or anything looks off — read report.json and the console log, and diagnose before summarizing.
+
+4b. Monitoring corroboration (read tests/load/FINDINGS.md "Monitoring notes" first — synthetic runs emit NO Faro telemetry, so don't expect the harness traffic in Loki/Tempo):
+   - Grafana MCP: query Loki `{service_name="sound-clash-web"}` over the run window for errors and `stale_buzz_lock_resynced` — anything there means a REAL user/party overlapped the run; note it.
+   - Grafana MCP: `list_datasources` — if a Supabase/Prometheus metrics datasource exists (it did not as of 2026-07-14), pull Realtime connection + DB metrics for the window.
+   - Compare the pg_stat_activity snapshots (before/mid-run) and include the delta in your summary.
+   - The Supabase dashboard's Realtime connection graph can't be read from here; if subscribe failures were reported, tell the user to check the dashboard's Realtime report for the window.
+
+5. Document the outcome in tests/load/FINDINGS.md (this is REQUIRED, even on a clean PASS):
+   - Append a row to the "Run ledger" table (date, check, verdict, highlights, findings count).
+   - For EVERY violation, unexpected error, WARN-level check, capacity ceiling (e.g. subscribe failures), stall, or harness bug: add a full entry using the file's template, including the report.json figures and any Grafana/pg_stat evidence.
+   - Commit on branch `feature/load-test-findings` (create from the current branch if missing, reuse and push if it exists), push, and open a PR titled "Load-test findings: <LABEL>" if none is open for that branch yet (one PR accumulates all four checks). Never commit to main; never merge.
+
+6. If the run STALLED or crashed: read the console/err logs, then run `node tests/load/loadtest.mjs cleanup --dir tests/load/results/<LABEL>` (PowerShell or Bash, sandbox disabled) so no synthetic games linger, document the crash as a finding per step 5, and report the failure.
+
+Do not start any other load check in parallel. Do not modify the harness; if it has a bug, document it in FINDINGS.md and report it.
+```
+
+---
+
+## Check 1 — 5 parallel games × 10 teams × 15 rounds
+
+`<LABEL>` = `check1-5x10`, `<ARGS>` =
+
+```
+"tests/load/loadtest.mjs","run","--label","check1-5x10","--games","5","--teams","10","--rounds","15","--seed","101","--kick"
+```
+
+## Check 2 — 10 parallel games × 10 teams × 15 rounds
+
+`<LABEL>` = `check2-10x10`, `<ARGS>` =
+
+```
+"tests/load/loadtest.mjs","run","--label","check2-10x10","--games","10","--teams","10","--rounds","15","--seed","202"
+```
+
+## Check 3 — 20 parallel games × 10 teams × 15 rounds
+
+`<LABEL>` = `check3-20x10`, `<ARGS>` =
+
+```
+"tests/load/loadtest.mjs","run","--label","check3-20x10","--games","20","--teams","10","--rounds","15","--seed","303"
+```
+
+Note for the summary: this check opens 240 Realtime sockets. On the Supabase
+free tier the concurrent-connection quota is 200, so subscription failures
+here are the expected capacity finding — report how many failed and whether
+game correctness still held (it should: game control is RPC-driven, Realtime
+is fan-out only).
+
+## Check 4 — 1 game × 30 teams × 15 rounds
+
+`<LABEL>` = `check4-1x30`, `<ARGS>` =
+
+```
+"tests/load/loadtest.mjs","run","--label","check4-1x30","--games","1","--teams","30","--rounds","15","--seed","404"
+```
+
+Note for the summary: the interesting numbers are the 30-way buzz-race
+invariant (exactly one winner, every round) and lock-propagation p95 across
+32 subscribed devices.

--- a/tests/load/RUN-PROMPTS.md
+++ b/tests/load/RUN-PROMPTS.md
@@ -16,7 +16,8 @@ rate-limit-paced setup):
 | 1 | `check1-5x10` — 5 games × 10 teams | ~10 min | baseline, matches a real multi-room event |
 | 2 | `check4-1x30` — 1 game × 30 teams | ~8 min | single-game fan-out + 30-way buzz races |
 | 3 | `check2-10x10` — 10 games × 10 teams | ~12 min | scale step |
-| 4 | `check3-20x10` — 20 games × 10 teams | ~18 min | ceiling probe (240 Realtime sockets — may exceed the Supabase plan's connection quota by design) |
+| 4 | `check3-20x10` — 20 games × 10 teams | ~18 min | biggest concurrent-games window (Realtime capped at 180 subscriptions for the free-tier quota) |
+| 5 | `check5-soak-3x10x60` — 3 games × 10 teams × 60 rounds | ~25 min | soak: catches drift/degradation over time that short checks miss |
 
 Run during a quiet window (the harness warns if a real game is `playing`).
 
@@ -106,14 +107,15 @@ Do not start any other load check in parallel. Do not modify the harness; if it 
 `<LABEL>` = `check3-20x10`, `<ARGS>` =
 
 ```
-"tests/load/loadtest.mjs","run","--label","check3-20x10","--games","20","--teams","10","--rounds","15","--seed","303"
+"tests/load/loadtest.mjs","run","--label","check3-20x10","--games","20","--teams","10","--rounds","15","--seed","303","--rt-budget","180"
 ```
 
-Note for the summary: this check opens 240 Realtime sockets. On the Supabase
-free tier the concurrent-connection quota is 200, so subscription failures
-here are the expected capacity finding — report how many failed and whether
-game correctness still held (it should: game control is RPC-driven, Realtime
-is fan-out only).
+Note for the summary: 240 devices play, but only 180 subscribe to Realtime
+(`--rt-budget 180` sheds all 20 displays, all 20 managers, and one team device
+per game) because the project runs on the Supabase free tier (~200 concurrent
+connections). With the budget in place, ANY subscribe failure is a real
+finding, not expected quota noise. Game control is RPC-driven, so all 20 games
+must still complete correctly regardless of Realtime.
 
 ## Check 4 — 1 game × 30 teams × 15 rounds
 
@@ -126,3 +128,20 @@ is fan-out only).
 Note for the summary: the interesting numbers are the 30-way buzz-race
 invariant (exactly one winner, every round) and lock-propagation p95 across
 32 subscribed devices.
+
+## Check 5 — soak: 3 games × 10 teams × 60 rounds
+
+`<LABEL>` = `check5-soak-3x10x60`, `<ARGS>` =
+
+```
+"tests/load/loadtest.mjs","run","--label","check5-soak-3x10x60","--games","3","--teams","10","--rounds","60","--seed","505"
+```
+
+Note for the summary: this is the drift check — beyond the standard verdicts,
+compare early-vs-late behavior: does Realtime delivery latency or the miss
+rate grow as rounds accumulate? Do reconnects climb? Does any game fail late
+(rounds 40+)? Use the report.json latency distributions plus the console log's
+periodic progress lines to judge whether performance was flat across the ~25
+minutes. Each game plays 60 distinct songs, so `game_rounds` rows accumulate —
+watch whether `select_next_song` latency trends upward as the played-set
+grows.

--- a/tests/load/lib/driver.mjs
+++ b/tests/load/lib/driver.mjs
@@ -1,0 +1,397 @@
+// GameDriver: owns one simulated game end-to-end — create + joins (REST,
+// paced under the per-IP rate limits), one Realtime device per participant,
+// the seeded round loop, teardown, and final score verification.
+
+import { performance } from "node:perf_hooks";
+import { Device } from "./supa.mjs";
+import { FLOWS, pickFlow } from "./flows.mjs";
+import { fetchJson, LoadError, mulberry32, rngRange, rngInt, sleep, mapLimit } from "./util.mjs";
+
+const RT_WINDOW_MS = 10000; // an event not seen within 10s counts as a miss
+
+const PACES = {
+  realistic: { listen: [3000, 8000], think: [900, 2600], between: [2000, 5000], short: [500, 1500] },
+  fast: { listen: [300, 900], think: [120, 400], between: [250, 700], short: [80, 200] },
+};
+
+export class GameDriver {
+  constructor({ index, cfg, env, pacers, metrics, log, registry, seed }) {
+    this.index = index;
+    this.cfg = cfg;
+    this.env = env;
+    this.pacers = pacers;
+    this.metrics = metrics;
+    this.log = log;
+    this.registry = registry; // records {code, manager_token} for cleanup
+    this.rng = mulberry32(seed);
+    this.pace = PACES[cfg.pace];
+    this.bonusEnabled = cfg.bonus;
+
+    this.code = null;
+    this.managerToken = null;
+    this.roster = []; // [{id, name}]
+    this.kicked = [];
+    this.devices = new Map(); // teamId -> Device, plus "mgr" / "display"
+    this.ledger = new Map(); // teamId -> expected score
+    this.expectations = []; // open Realtime expectations
+
+    this.roundNum = 0;
+    this.roundId = null;
+    this.lockHeld = null;
+    this.freeGuess = false;
+    this.roundsDone = 0;
+    this.flowHistogram = {};
+    this.completed = false;
+    this.scoresVerified = false;
+    this.failReason = null;
+  }
+
+  get mgr() {
+    return this.devices.get("mgr");
+  }
+  deviceFor(team) {
+    return this.devices.get(team.id);
+  }
+  tag() {
+    return `G${String(this.index).padStart(2, "0")}`;
+  }
+
+  think(kind) {
+    return sleep(Math.round(rngRange(this.rng, this.pace[kind])));
+  }
+
+  violation(message) {
+    this.metrics.addViolation(this.tag(), message);
+    this.log.error(`${this.tag()} INVARIANT: ${message}`);
+  }
+  error(message) {
+    this.metrics.addError(this.tag(), message);
+    this.log.error(`${this.tag()} ${message}`);
+  }
+  anomaly(message) {
+    this.metrics.addAnomaly(`${this.tag()} ${message}`);
+  }
+
+  // ---- REST (FastAPI on Render; paced; 429 => wait out the minute window) --
+
+  async rest(pacer, method, path, { body, token, okStatuses = [200, 201, 204], name } = {}) {
+    for (let attempt = 1; ; attempt++) {
+      if (pacer) await pacer.take();
+      const t0 = performance.now();
+      let res;
+      try {
+        res = await fetchJson(`${this.env.apiUrl}${path}`, {
+          method,
+          body,
+          headers: token ? { "X-Manager-Token": token } : {},
+        });
+      } catch (err) {
+        throw new LoadError(`${method} ${path} network failure: ${err.message}`, { game: this.code });
+      }
+      if (res.status !== 429) {
+        // 429 attempts are counted separately; they must not pollute the
+        // latency distribution or the error-rate denominator.
+        this.metrics.addLatency(`rest:${name || path}`, performance.now() - t0);
+        this.metrics.bump("actions");
+      }
+      if (res.status === 429) {
+        // slowapi fixed one-minute windows, no Retry-After header: wait out
+        // the window and retry. Counted separately — with correct pacing this
+        // should be rare, and it is a one-IP artifact real users don't share.
+        this.metrics.bump("rest:429");
+        if (attempt > 4) throw new LoadError(`${method} ${path} still 429 after ${attempt} attempts`, {});
+        this.log.warn(`${this.tag()} 429 on ${method} ${path} — backing off 61s (attempt ${attempt})`);
+        await sleep(61000);
+        continue;
+      }
+      if (!okStatuses.includes(res.status)) {
+        throw new LoadError(
+          `${method} ${path} -> HTTP ${res.status} ${res.json ? JSON.stringify(res.json) : res.text?.slice(0, 200)}`,
+          { game: this.code },
+        );
+      }
+      return res.json;
+    }
+  }
+
+  // ---- Realtime expectations ------------------------------------------------
+
+  expectRt(family, matchFn) {
+    const audience = [...this.devices.values()].filter((dv) => dv.subState === "subscribed").map((dv) => dv.id);
+    if (audience.length === 0) return;
+    this.expectations.push({
+      family,
+      matchFn,
+      t0: performance.now(),
+      audience: new Set(audience),
+      matched: new Set(),
+    });
+  }
+
+  onEvent = (device, table, payload) => {
+    for (const exp of this.expectations) {
+      if (!exp.audience.has(device.id) || exp.matched.has(device.id)) continue;
+      if (exp.matchFn(table, payload)) {
+        exp.matched.add(device.id);
+        this.metrics.addRtDelivery(exp.family, performance.now() - exp.t0);
+        break; // FIFO: an event settles at most one expectation per device
+      }
+    }
+  };
+
+  // Called by the orchestrator's sweeper and once at teardown (force=true).
+  sweepExpectations(force = false) {
+    const now = performance.now();
+    this.expectations = this.expectations.filter((exp) => {
+      const expired = force || now - exp.t0 > RT_WINDOW_MS;
+      const complete = exp.matched.size >= exp.audience.size;
+      if (complete) return false;
+      if (expired) {
+        for (const id of exp.audience) {
+          if (!exp.matched.has(id)) this.metrics.addRtMiss(exp.family);
+        }
+        return false;
+      }
+      return true;
+    });
+  }
+
+  // ---- lifecycle -------------------------------------------------------------
+
+  async setup() {
+    const created = await this.rest(this.pacers.create, "POST", "/games", {
+      body: { selected_genres: this.cfg.genreIds },
+      okStatuses: [201],
+      name: "create_game",
+    });
+    this.code = created.game_code;
+    this.managerToken = created.manager_token;
+    this.registry.add({ code: this.code, manager_token: this.managerToken });
+    this.log.info(`${this.tag()} created game ${this.code}`);
+
+    for (let i = 1; i <= this.cfg.teams; i++) {
+      const name = `LT-${this.tag()}-T${String(i).padStart(2, "0")}`;
+      const joined = await this.rest(this.pacers.join, "POST", `/games/${this.code}/teams`, {
+        body: { name },
+        okStatuses: [201],
+        name: "join_team",
+      });
+      this.roster.push({ id: joined.id, name });
+      this.ledger.set(joined.id, 0);
+    }
+    this.log.info(`${this.tag()} joined ${this.roster.length} teams`);
+
+    // One Realtime device per participant, exactly like real phones/screens.
+    const specs = [
+      { id: `${this.tag()}/mgr`, key: "mgr", role: "manager" },
+      { id: `${this.tag()}/display`, key: "display", role: "display" },
+      ...this.roster.map((t, i) => ({ id: `${this.tag()}/T${String(i + 1).padStart(2, "0")}`, key: t.id, role: "team" })),
+    ];
+    for (const s of specs) {
+      this.devices.set(
+        s.key,
+        new Device({ id: s.id, role: s.role, gameCode: this.code, env: this.env, metrics: this.metrics, onEvent: this.onEvent }),
+      );
+    }
+    // Stagger channel joins a little (a 240-subscribe stampede is not what a
+    // real party does; phones trickle in over the lobby minute).
+    const outcomes = await mapLimit([...this.devices.values()], 6, async (dv) => {
+      await sleep(rngInt(this.rng, 0, 400));
+      return dv.subscribe();
+    });
+    for (const o of outcomes) this.metrics.bump(o === "subscribed" ? "subscribe:ok" : "subscribe:failed");
+    const failed = outcomes.filter((o) => o !== "subscribed").length;
+    if (failed > 0) this.log.warn(`${this.tag()} ${failed}/${outcomes.length} realtime subscriptions failed`);
+    if (this.cfg.resync) {
+      // Each resync timer gets its OWN PRNG stream: sharing this.rng would let
+      // wall-clock-timed ticks interleave with the play loop's draws and break
+      // --seed reproducibility of the flow sequence.
+      let dvIdx = 0;
+      for (const dv of this.devices.values()) dv.startResync(mulberry32(this.cfg.seed + this.index * 100003 + ++dvIdx));
+    }
+  }
+
+  async advance() {
+    const nextN = this.roundNum + 1;
+    this.expectRt("round_insert", (table, p) => table === "game_rounds" && p.eventType === "INSERT" && p.new?.round_number === nextN);
+    const { data } = await this.mgr.rpc("select_next_song", {
+      p_game_code: this.code,
+      p_manager_token: this.managerToken,
+      p_song_id: null, // explicit null — PostgREST drops undefined keys
+    });
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row) {
+      throw new LoadError(`select_next_song returned no row for round ${nextN} — song pool exhausted mid-run?`, {
+        game: this.code,
+      });
+    }
+    if (row.round_number !== nextN) {
+      this.violation(`select_next_song returned round ${row.round_number}, expected ${nextN}`);
+    }
+    this.roundNum = row.round_number;
+    this.roundId = row.round_id;
+    this.freeGuess = false;
+    this.lockHeld = null;
+  }
+
+  async peek() {
+    const { data } = await this.mgr.rpc("peek_next_song", {
+      p_game_code: this.code,
+      p_manager_token: this.managerToken,
+    });
+    const rows = Array.isArray(data) ? data : data ? [data] : [];
+    if (rows.length > 1) this.anomaly(`peek_next_song returned ${rows.length} rows`);
+  }
+
+  async extendOnce() {
+    const { data } = await this.mgr.rpc("extend_game", {
+      p_game_code: this.code,
+      p_manager_token: this.managerToken,
+    });
+    if (typeof data !== "string" || Number.isNaN(Date.parse(data))) {
+      this.violation(`extend_game returned unparsable expires_at: ${JSON.stringify(data)}`);
+    }
+  }
+
+  async bonusTo(team, points) {
+    // Acquire the pacer BEFORE registering the expectation: queueing time in
+    // the shared manager-REST pacer must not be charged to Realtime delivery.
+    await this.pacers.mgrRest.take();
+    const expectedTotal = this.ledger.get(team.id) + points;
+    this.expectRt(
+      "score_update",
+      (table, p) => table === "game_teams" && p.eventType === "UPDATE" && p.new?.id === team.id && p.new?.score === expectedTotal,
+    );
+    const res = await this.rest(null, "POST", `/games/${this.code}/bonus`, {
+      body: { team_id: team.id, points },
+      token: this.managerToken,
+      okStatuses: [200],
+      name: "bonus",
+    });
+    if (res.team_total_score !== expectedTotal) {
+      this.violation(`bonus total ${res.team_total_score} != ledger ${expectedTotal} (team ${team.name})`);
+    }
+    this.ledger.set(team.id, res.team_total_score);
+  }
+
+  async kickOne() {
+    if (this.roster.length < 3) return;
+    // Kick the current last-place team (a realistic host action).
+    const target = [...this.roster].sort((a, b) => this.ledger.get(a.id) - this.ledger.get(b.id))[0];
+    await this.rest(this.pacers.mgrRest, "DELETE", `/games/${this.code}/teams/${target.id}`, {
+      token: this.managerToken,
+      okStatuses: [204],
+      name: "kick_team",
+    });
+    this.roster = this.roster.filter((t) => t.id !== target.id);
+    this.kicked.push(target);
+    this.ledger.delete(target.id);
+    const dv = this.devices.get(target.id);
+    if (dv) {
+      // A closed device can no longer deliver events; drop it from open
+      // expectations so the kick doesn't register as false Realtime misses.
+      for (const exp of this.expectations) exp.audience.delete(dv.id);
+      await dv.close();
+      this.devices.delete(target.id);
+    }
+    this.log.info(`${this.tag()} kicked ${target.name}`);
+  }
+
+  async play(forcedFlows = null, onRoundDone = () => {}) {
+    for (let r = 1; r <= this.cfg.rounds; r++) {
+      const flow = forcedFlows
+        ? FLOWS.find((f) => f.name === forcedFlows[(r - 1) % forcedFlows.length])
+        : pickFlow(this);
+      if (this.roster.length < flow.minTeams) {
+        // roster shrank below the forced flow's needs (kick) — fall back
+        const fallback = FLOWS.find((f) => f.name === "single_title");
+        await this.runRound(fallback);
+      } else {
+        await this.runRound(flow);
+      }
+      this.roundsDone = r;
+      onRoundDone();
+      if (this.cfg.kick && r === Math.max(2, this.cfg.rounds - 2)) await this.kickOne();
+      if (r === Math.ceil(this.cfg.rounds * 0.66)) await this.extendOnce();
+    }
+    this.completed = true;
+  }
+
+  async runRound(flow) {
+    this.flowHistogram[flow.name] = (this.flowHistogram[flow.name] || 0) + 1;
+    await this.advance();
+    if (this.rng() < 0.4) {
+      await this.think("short");
+      await this.peek(); // manager console prebuffers the next video
+    }
+    await this.think("listen"); // the song is "playing"
+    await flow.run(this);
+    await this.think("between");
+  }
+
+  // Fetch authoritative final scores over anon PostgREST and compare with the
+  // local ledger. Runs BEFORE end so state is still live.
+  async verifyFinalScores() {
+    const url =
+      `${this.env.supabaseUrl}/rest/v1/game_teams?select=id,name,score&game_code=eq.${this.code}`;
+    const res = await fetchJson(url, {
+      headers: { apikey: this.env.anonKey, Authorization: `Bearer ${this.env.anonKey}` },
+    });
+    if (res.status !== 200 || !Array.isArray(res.json)) {
+      this.error(`final score fetch failed: HTTP ${res.status}`);
+      return;
+    }
+    const byId = new Map(res.json.map((t) => [t.id, t]));
+    let ok = true;
+    for (const team of this.roster) {
+      const dbRow = byId.get(team.id);
+      if (!dbRow) {
+        this.violation(`team ${team.name} missing from final DB state`);
+        ok = false;
+      } else if (dbRow.score !== this.ledger.get(team.id)) {
+        this.violation(`final score for ${team.name}: db=${dbRow.score} expected=${this.ledger.get(team.id)}`);
+        ok = false;
+      }
+    }
+    for (const k of this.kicked) {
+      if (byId.has(k.id)) {
+        this.violation(`kicked team ${k.name} still present in final DB state`);
+        ok = false;
+      }
+    }
+    this.scoresVerified = ok;
+    if (ok) this.log.info(`${this.tag()} final scores verified (${this.roster.length} teams)`);
+  }
+
+  async end() {
+    if (!this.code) return;
+    try {
+      await this.rest(this.pacers.mgrRest, "POST", `/games/${this.code}/end`, {
+        token: this.managerToken,
+        okStatuses: [200, 404, 410], // 404/410 = already gone; aligned with cleanup
+        name: "end_game",
+      });
+      this.registry.markEnded(this.code);
+    } catch (err) {
+      this.error(`end_game failed: ${err.message}`);
+    }
+  }
+
+  async closeDevices() {
+    await Promise.all([...this.devices.values()].map((dv) => dv.close().catch(() => {})));
+  }
+
+  snapshot() {
+    return {
+      index: this.index,
+      code: this.code,
+      teams: this.roster.length + this.kicked.length,
+      roundsPlanned: this.cfg.rounds,
+      roundsDone: this.roundsDone,
+      completed: this.completed,
+      scoresVerified: this.scoresVerified,
+      failReason: this.failReason,
+      flowHistogram: this.flowHistogram,
+    };
+  }
+}

--- a/tests/load/lib/driver.mjs
+++ b/tests/load/lib/driver.mjs
@@ -15,9 +15,12 @@ const PACES = {
 };
 
 export class GameDriver {
-  constructor({ index, cfg, env, pacers, metrics, log, registry, seed }) {
+  constructor({ index, cfg, env, pacers, metrics, log, registry, seed, rtPlan = null }) {
     this.index = index;
     this.cfg = cfg;
+    // Realtime subscription plan for this game (null = subscribe everything):
+    // { display: bool, manager: bool, teamSubs: number } — see planSubscriptions.
+    this.rtPlan = rtPlan;
     this.env = env;
     this.pacers = pacers;
     this.metrics = metrics;
@@ -193,15 +196,34 @@ export class GameDriver {
         new Device({ id: s.id, role: s.role, gameCode: this.code, env: this.env, metrics: this.metrics, onEvent: this.onEvent }),
       );
     }
+    // Apply the Realtime budget plan: unsubscribed devices still play via
+    // RPC/REST, they just don't count in delivery-measurement audiences.
+    const plan = this.rtPlan || { display: true, manager: true, teamSubs: Infinity };
+    const toSubscribe = [];
+    let teamSlots = plan.teamSubs;
+    for (const dv of this.devices.values()) {
+      if (dv.role === "team") {
+        if (teamSlots > 0) {
+          toSubscribe.push(dv);
+          teamSlots--;
+        }
+      } else if ((dv.role === "manager" && plan.manager) || (dv.role === "display" && plan.display)) {
+        toSubscribe.push(dv);
+      }
+    }
+    const skipped = this.devices.size - toSubscribe.length;
+    if (skipped > 0) this.metrics.bump("subscribe:skipped_budget", skipped);
+
     // Stagger channel joins a little (a 240-subscribe stampede is not what a
     // real party does; phones trickle in over the lobby minute).
-    const outcomes = await mapLimit([...this.devices.values()], 6, async (dv) => {
+    const outcomes = await mapLimit(toSubscribe, 6, async (dv) => {
       await sleep(rngInt(this.rng, 0, 400));
       return dv.subscribe();
     });
     for (const o of outcomes) this.metrics.bump(o === "subscribed" ? "subscribe:ok" : "subscribe:failed");
     const failed = outcomes.filter((o) => o !== "subscribed").length;
     if (failed > 0) this.log.warn(`${this.tag()} ${failed}/${outcomes.length} realtime subscriptions failed`);
+    if (skipped > 0) this.log.info(`${this.tag()} ${skipped} device(s) not subscribed (rt-budget)`);
     if (this.cfg.resync) {
       // Each resync timer gets its OWN PRNG stream: sharing this.rng would let
       // wall-clock-timed ticks interleave with the play loop's draws and break

--- a/tests/load/lib/flows.mjs
+++ b/tests/load/lib/flows.mjs
@@ -15,18 +15,22 @@ import { pick } from "./util.mjs";
 // possible. Invariant: exactly one caller gets locked=true; losers see the
 // winner's id. Returns the winning team.
 export async function volleyBuzz(d, teams) {
-  // The matcher must only accept THIS buzz's null->team transition: a correct
-  // award later bumps locked_at with buzzed_team_id still set (an echo that
-  // must not satisfy a stale expectation), and multi-buzz flows register
-  // several lock_set expectations per round. REPLICA IDENTITY FULL (mig 009)
-  // gives us the full old row to detect the fresh transition; the winner id
-  // is bound as soon as the race resolves.
+  // The matcher must only accept THIS buzz's null->team transition in THIS
+  // round: a correct award later bumps locked_at with buzzed_team_id still set
+  // (an echo), multi-buzz flows register several lock_set expectations per
+  // round, and a device that dropped this event must not match a LATER round's
+  // buzz by the same team (seconds later — it would masquerade as a slow
+  // delivery instead of a miss). REPLICA IDENTITY FULL (mig 009) gives the
+  // full old row for the fresh-transition check; the winner id is bound as
+  // soon as the race resolves.
   const ref = { teamId: null };
+  const expectedRoundId = d.roundId;
   d.expectRt(
     "lock_set",
     (table, p) =>
       table === "active_games" &&
       p.eventType === "UPDATE" &&
+      p.new?.current_round_id === expectedRoundId &&
       !!p.new?.buzzed_team_id &&
       !p.old?.buzzed_team_id &&
       (!ref.teamId || p.new.buzzed_team_id === ref.teamId),

--- a/tests/load/lib/flows.mjs
+++ b/tests/load/lib/flows.mjs
@@ -1,0 +1,291 @@
+// Round flow catalog. Each flow is one realistic combination of the manager's
+// buttons (Correct Song / Correct Artist / Wrong / Continue / Next / Bonus)
+// plus team buzz behavior. Flows drive the game exclusively through the same
+// wire calls real browsers make and keep a local expected-score ledger that
+// mirrors the DB's authoritative scoring rules (mig 043):
+//   title +10, artist +5, both +15, wrong -3 (0 if free-guess active).
+// Correct awards KEEP the buzz lock; wrong awards auto-release it;
+// release_buzz_lock is the explicit "Continue round".
+
+import { pick } from "./util.mjs";
+
+// ---- primitives (operate on a GameDriver `d`) ------------------------------
+
+// All (or a subset of) teams press the buzzer as close to simultaneously as
+// possible. Invariant: exactly one caller gets locked=true; losers see the
+// winner's id. Returns the winning team.
+export async function volleyBuzz(d, teams) {
+  // The matcher must only accept THIS buzz's null->team transition: a correct
+  // award later bumps locked_at with buzzed_team_id still set (an echo that
+  // must not satisfy a stale expectation), and multi-buzz flows register
+  // several lock_set expectations per round. REPLICA IDENTITY FULL (mig 009)
+  // gives us the full old row to detect the fresh transition; the winner id
+  // is bound as soon as the race resolves.
+  const ref = { teamId: null };
+  d.expectRt(
+    "lock_set",
+    (table, p) =>
+      table === "active_games" &&
+      p.eventType === "UPDATE" &&
+      !!p.new?.buzzed_team_id &&
+      !p.old?.buzzed_team_id &&
+      (!ref.teamId || p.new.buzzed_team_id === ref.teamId),
+  );
+  const results = await Promise.all(
+    teams.map((t) =>
+      d
+        .deviceFor(t)
+        .rpc("buzz_in", { p_game_code: d.code, p_team_id: t.id })
+        .catch((err) => ({ err })),
+    ),
+  );
+  const rows = results.map((r) => (r.err ? null : Array.isArray(r.data) ? r.data[0] : r.data));
+  results.forEach((r, i) => {
+    if (r.err) d.error(`buzz_in threw for ${teams[i].name}: ${r.err.message}`);
+  });
+  const winners = teams.filter((_, i) => rows[i]?.locked === true);
+  if (winners.length !== 1) {
+    d.violation(`buzz race with ${teams.length} teams produced ${winners.length} winners (round ${d.roundNum})`);
+    // Recover so the run can continue: adopt the DB's view of the lock holder.
+    const winnerId = rows.find((r) => r?.locked_team_id)?.locked_team_id;
+    const winner = teams.find((t) => t.id === winnerId) || null;
+    ref.teamId = winner ? winner.id : null;
+    d.lockHeld = winner ? winner.id : null;
+    return winner;
+  }
+  const winner = winners[0];
+  ref.teamId = winner.id;
+  rows.forEach((row, i) => {
+    if (row && row.locked === false && row.locked_team_id && row.locked_team_id !== winner.id) {
+      d.anomaly(`loser ${teams[i].name} saw lock holder ${row.locked_team_id} != winner ${winner.id} (round ${d.roundNum})`);
+    }
+  });
+  d.lockHeld = winner.id;
+  return winner;
+}
+
+export async function singleBuzz(d, team) {
+  const winner = await volleyBuzz(d, [team]);
+  if (winner && winner.id !== team.id) d.violation(`single buzz by ${team.name} won by someone else`);
+  return winner;
+}
+
+// Manager scores the held buzz. Cross-checks the RPC's returned delta and
+// running total against the local ledger (immediate corruption detection).
+export async function award(d, team, { title = false, artist = false, wrong = false }) {
+  const delta = wrong ? (d.freeGuess ? 0 : -3) : (title ? 10 : 0) + (artist ? 5 : 0);
+  const expectedTotal = d.ledger.get(team.id) + delta;
+  if (delta !== 0) {
+    d.expectRt(
+      "score_update",
+      (table, p) => table === "game_teams" && p.eventType === "UPDATE" && p.new?.id === team.id && p.new?.score === expectedTotal,
+    );
+  }
+  const { data } = await d.mgr.rpc("award_attempt", {
+    p_game_code: d.code,
+    p_round_id: d.roundId,
+    p_correct_title: title,
+    p_correct_artist: artist,
+    p_wrong: wrong,
+    p_manager_token: d.managerToken,
+  });
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    d.violation(`award_attempt returned no row (team ${team.name}, round ${d.roundNum})`);
+    return;
+  }
+  if (row.points_delta !== delta) {
+    d.violation(`award delta ${row.points_delta} != expected ${delta} (team ${team.name}, round ${d.roundNum})`);
+  }
+  if (row.team_total_score !== expectedTotal) {
+    d.violation(`running total ${row.team_total_score} != ledger ${expectedTotal} (team ${team.name}, round ${d.roundNum})`);
+  }
+  d.ledger.set(team.id, row.team_total_score);
+  if (wrong) {
+    d.freeGuess = false; // waiver consumed (or was never armed)
+    d.lockHeld = null; // wrong auto-releases the lock
+  } else {
+    d.freeGuess = true; // any correct claim arms the free guess
+  }
+}
+
+// "Continue round": release the lock with no score.
+export async function release(d) {
+  await d.mgr.rpc("release_buzz_lock", { p_game_code: d.code, p_manager_token: d.managerToken });
+  d.lockHeld = null;
+}
+
+// ---- the catalog -----------------------------------------------------------
+
+const otherThan = (d, ...exclude) => {
+  const ids = new Set(exclude.map((t) => t.id));
+  return d.roster.filter((t) => !ids.has(t.id));
+};
+
+export const FLOWS = [
+  {
+    name: "race_title",
+    weight: 18,
+    minTeams: 2,
+    async run(d) {
+      const winner = await volleyBuzz(d, d.roster);
+      await d.think("think");
+      if (winner) await award(d, winner, { title: true });
+    },
+  },
+  {
+    name: "race_both",
+    weight: 12,
+    minTeams: 2,
+    async run(d) {
+      const winner = await volleyBuzz(d, d.roster);
+      await d.think("think");
+      if (winner) await award(d, winner, { title: true, artist: true });
+    },
+  },
+  {
+    name: "single_title",
+    weight: 10,
+    minTeams: 1,
+    async run(d) {
+      const team = pick(d.rng, d.roster);
+      await singleBuzz(d, team);
+      await d.think("think");
+      await award(d, team, { title: true });
+    },
+  },
+  {
+    name: "single_artist",
+    weight: 8,
+    minTeams: 1,
+    async run(d) {
+      const team = pick(d.rng, d.roster);
+      await singleBuzz(d, team);
+      await d.think("think");
+      await award(d, team, { artist: true });
+    },
+  },
+  {
+    name: "split_title_artist",
+    weight: 12,
+    minTeams: 2,
+    async run(d) {
+      const a = pick(d.rng, d.roster);
+      await singleBuzz(d, a);
+      await d.think("think");
+      await award(d, a, { title: true });
+      await d.think("think");
+      await release(d);
+      const b = pick(d.rng, otherThan(d, a));
+      await singleBuzz(d, b);
+      await d.think("think");
+      await award(d, b, { artist: true });
+    },
+  },
+  {
+    name: "wrong_then_title",
+    weight: 14,
+    minTeams: 2,
+    async run(d) {
+      const a = pick(d.rng, d.roster);
+      await singleBuzz(d, a);
+      await d.think("think");
+      await award(d, a, { wrong: true }); // -3, lock auto-released
+      await d.think("think");
+      const b = pick(d.rng, otherThan(d, a));
+      await singleBuzz(d, b);
+      await d.think("think");
+      await award(d, b, { title: true });
+    },
+  },
+  {
+    name: "wrong_chain",
+    weight: 8,
+    minTeams: 3,
+    async run(d) {
+      const a = pick(d.rng, d.roster);
+      await singleBuzz(d, a);
+      await d.think("think");
+      await award(d, a, { wrong: true });
+      const b = pick(d.rng, otherThan(d, a));
+      await singleBuzz(d, b);
+      await d.think("think");
+      await award(d, b, { wrong: true });
+      const c = pick(d.rng, otherThan(d, a, b));
+      await singleBuzz(d, c);
+      await d.think("think");
+      await award(d, c, { title: true, artist: true });
+    },
+  },
+  {
+    name: "free_guess_waiver",
+    weight: 8,
+    minTeams: 3,
+    async run(d) {
+      // A claims the title (+10, arms free guess), manager continues, B answers
+      // wrong for 0 (waived), C takes the artist (+5). Exercises mig 017.
+      const a = pick(d.rng, d.roster);
+      await singleBuzz(d, a);
+      await d.think("think");
+      await award(d, a, { title: true });
+      await release(d);
+      const b = pick(d.rng, otherThan(d, a));
+      await singleBuzz(d, b);
+      await d.think("think");
+      await award(d, b, { wrong: true }); // delta 0: free guess waives the -3
+      const c = pick(d.rng, otherThan(d, a, b));
+      await singleBuzz(d, c);
+      await d.think("think");
+      await award(d, c, { artist: true });
+    },
+  },
+  {
+    name: "race_wrong_race",
+    weight: 5,
+    minTeams: 2,
+    async run(d) {
+      const w1 = await volleyBuzz(d, d.roster);
+      await d.think("think");
+      if (w1) await award(d, w1, { wrong: true });
+      await d.think("think");
+      const w2 = await volleyBuzz(d, d.roster);
+      await d.think("think");
+      if (w2) await award(d, w2, { artist: true });
+    },
+  },
+  {
+    name: "no_buzz_skip",
+    weight: 3,
+    minTeams: 1,
+    async run(d) {
+      await d.think("between"); // song plays, nobody buzzes, manager moves on
+    },
+  },
+  {
+    name: "bonus_after_title",
+    weight: 5,
+    minTeams: 1,
+    async run(d) {
+      const team = pick(d.rng, d.roster);
+      await singleBuzz(d, team);
+      await d.think("think");
+      await award(d, team, { title: true });
+      const lucky = pick(d.rng, d.roster);
+      await d.bonusTo(lucky, 4); // manager's default bonus button
+    },
+  },
+];
+
+export function pickFlow(d) {
+  const eligible = FLOWS.filter((f) => d.roster.length >= f.minTeams && (d.bonusEnabled || f.name !== "bonus_after_title"));
+  const total = eligible.reduce((s, f) => s + f.weight, 0);
+  let roll = d.rng() * total;
+  for (const f of eligible) {
+    roll -= f.weight;
+    if (roll <= 0) return f;
+  }
+  return eligible[eligible.length - 1];
+}
+
+// The smoke run forces every flow once, deterministically.
+export const SMOKE_FLOW_SEQUENCE = FLOWS.map((f) => f.name);

--- a/tests/load/lib/metrics.mjs
+++ b/tests/load/lib/metrics.mjs
@@ -1,0 +1,239 @@
+// Metrics collection + verdicts + report rendering.
+//
+// Three Realtime "families" are measured end-to-end (t0 = the moment the
+// triggering RPC is fired, t1 = the postgres_changes event arriving at each
+// subscribed simulated device — i.e. what a real player would perceive):
+//   lock_set     buzz pressed -> everyone sees the buzz lock
+//   round_insert next round   -> everyone sees the new round
+//   score_update award        -> everyone sees the score change
+
+import { summarizeLatencies } from "./util.mjs";
+
+// Advisory thresholds: [PASS-max, WARN-max] in ms (beyond WARN-max = FAIL).
+// The real deliverable is the distribution table; these encode "would a
+// player at a party notice".
+const LATENCY_THRESHOLDS = {
+  "rpc:buzz_in": [350, 700],
+  "rpc:award_attempt": [500, 1000],
+  "rpc:select_next_song": [700, 1500],
+};
+const RT_THRESHOLDS = {
+  lock_set: [1200, 2500],
+  round_insert: [1500, 3000],
+  score_update: [1500, 3000],
+};
+const RT_MISS_RATE = [0.005, 0.02]; // PASS <= 0.5%, WARN <= 2%
+
+export class Metrics {
+  constructor() {
+    this.latencies = new Map(); // name -> number[]
+    this.rt = new Map(); // family -> { dts: number[], misses: number, expected: number }
+    this.errors = []; // { where, message, fatal }
+    this.anomalies = []; // soft oddities worth reading, not verdict-driving
+    this.violations = []; // invariant breaches -> hard FAIL
+    this.counters = new Map(); // name -> number
+  }
+
+  addLatency(name, ms) {
+    if (!this.latencies.has(name)) this.latencies.set(name, []);
+    this.latencies.get(name).push(ms);
+  }
+
+  rtFamily(family) {
+    if (!this.rt.has(family)) this.rt.set(family, { dts: [], misses: 0, expected: 0 });
+    return this.rt.get(family);
+  }
+  addRtDelivery(family, ms) {
+    const f = this.rtFamily(family);
+    f.dts.push(ms);
+    f.expected += 1;
+  }
+  addRtMiss(family) {
+    const f = this.rtFamily(family);
+    f.misses += 1;
+    f.expected += 1;
+  }
+
+  bump(name, by = 1) {
+    this.counters.set(name, (this.counters.get(name) || 0) + by);
+  }
+
+  addError(where, message) {
+    this.errors.push({ where, message });
+  }
+  addAnomaly(message) {
+    this.anomalies.push(message);
+  }
+  addViolation(where, message) {
+    this.violations.push({ where, message });
+  }
+
+  // ---- verdicts ---------------------------------------------------------
+
+  summarize({ games, totalActions }) {
+    const checks = [];
+    const grade = (name, value, [passMax, warnMax], unit = "ms") => {
+      if (value === null || value === undefined) return;
+      const level = value <= passMax ? "PASS" : value <= warnMax ? "WARN" : "FAIL";
+      checks.push({ name, level, value: `${unit === "ms" ? Math.round(value) : value}${unit}` });
+    };
+
+    checks.push({
+      name: "invariants (race winners, scores, round counts)",
+      level: this.violations.length === 0 ? "PASS" : "FAIL",
+      value: `${this.violations.length} violations`,
+    });
+
+    const failedGames = games.filter((g) => !g.completed).length;
+    checks.push({
+      name: "all games completed all rounds and ended",
+      level: failedGames === 0 ? "PASS" : "FAIL",
+      value: `${games.length - failedGames}/${games.length} games`,
+    });
+
+    for (const [name, th] of Object.entries(LATENCY_THRESHOLDS)) {
+      const s = summarizeLatencies(this.latencies.get(name) || []);
+      if (s) grade(`${name} p95`, s.p95, th);
+    }
+    for (const [family, th] of Object.entries(RT_THRESHOLDS)) {
+      const f = this.rt.get(family);
+      if (f && f.dts.length) grade(`realtime ${family} p95`, summarizeLatencies(f.dts).p95, th);
+    }
+
+    let rtExpected = 0;
+    let rtMisses = 0;
+    for (const f of this.rt.values()) {
+      rtExpected += f.expected;
+      rtMisses += f.misses;
+    }
+    if (rtExpected > 0) {
+      const rate = rtMisses / rtExpected;
+      const level = rate <= RT_MISS_RATE[0] ? "PASS" : rate <= RT_MISS_RATE[1] ? "WARN" : "FAIL";
+      checks.push({
+        name: "realtime delivery misses (event not seen within 10s)",
+        level,
+        value: `${rtMisses}/${rtExpected} (${(rate * 100).toFixed(2)}%)`,
+      });
+    }
+
+    const subFailed = this.counters.get("subscribe:failed") || 0;
+    const subOk = this.counters.get("subscribe:ok") || 0;
+    checks.push({
+      name: "realtime subscriptions established",
+      // Failures here are a CAPACITY finding (plan quota), not a code bug.
+      level: subFailed === 0 ? "PASS" : "WARN",
+      value: `${subOk} ok / ${subFailed} failed`,
+    });
+
+    const unexpectedErrors = this.errors.length;
+    const errRate = totalActions > 0 ? unexpectedErrors / totalActions : 0;
+    checks.push({
+      name: "unexpected errors",
+      level: unexpectedErrors === 0 ? "PASS" : errRate <= 0.005 ? "WARN" : "FAIL",
+      value: `${unexpectedErrors} (${(errRate * 100).toFixed(2)}% of ${totalActions} actions)`,
+    });
+
+    const overall = checks.some((c) => c.level === "FAIL")
+      ? "FAIL"
+      : checks.some((c) => c.level === "WARN")
+        ? "WARN"
+        : "PASS";
+    return { overall, checks };
+  }
+
+  latencyTable() {
+    const rows = [];
+    for (const [name, vals] of [...this.latencies.entries()].sort()) {
+      const s = summarizeLatencies(vals);
+      if (s) rows.push({ name, ...s });
+    }
+    return rows;
+  }
+
+  rtTable() {
+    const rows = [];
+    for (const [family, f] of this.rt.entries()) {
+      const s = summarizeLatencies(f.dts) || { count: 0, p50: null, p95: null, p99: null, max: null };
+      rows.push({
+        family,
+        deliveries: f.dts.length,
+        misses: f.misses,
+        missRate: f.expected ? `${((f.misses / f.expected) * 100).toFixed(2)}%` : "n/a",
+        ...s,
+      });
+    }
+    return rows;
+  }
+}
+
+// ---- report rendering ----------------------------------------------------
+
+function mdTable(headers, rows) {
+  const line = (cells) => `| ${cells.join(" | ")} |`;
+  return [line(headers), line(headers.map(() => "---")), ...rows.map(line)].join("\n");
+}
+
+export function renderReportMd({ label, config, phases, verdict, metrics, games, flowHistogram, notes }) {
+  const lines = [];
+  lines.push(`# Load test report: ${label}`);
+  lines.push("");
+  lines.push(`Overall verdict: **${verdict.overall}**`);
+  lines.push("");
+  lines.push("## Config");
+  lines.push("```json");
+  lines.push(JSON.stringify(config, null, 2));
+  lines.push("```");
+  lines.push("");
+  lines.push("## Phases");
+  lines.push(mdTable(["phase", "duration"], phases.map((p) => [p.name, `${Math.round(p.ms / 1000)}s`])));
+  lines.push("");
+  lines.push("## Verdict checks");
+  lines.push(mdTable(["check", "level", "value"], verdict.checks.map((c) => [c.name, c.level, c.value])));
+  lines.push("");
+  lines.push("## RPC / REST latency (ms, from this machine)");
+  lines.push(
+    mdTable(
+      ["operation", "count", "p50", "p95", "p99", "max"],
+      metrics.latencyTable().map((r) => [r.name, r.count, r.p50, r.p95, r.p99, r.max]),
+    ),
+  );
+  lines.push("");
+  lines.push("## Realtime delivery (action fired -> event seen by a subscribed device, ms)");
+  lines.push(
+    mdTable(
+      ["family", "deliveries", "misses", "miss rate", "p50", "p95", "p99", "max"],
+      metrics.rtTable().map((r) => [r.family, r.deliveries, r.misses, r.missRate, r.p50, r.p95, r.p99, r.max]),
+    ),
+  );
+  lines.push("");
+  lines.push("## Per-game results");
+  lines.push(
+    mdTable(
+      ["game", "code", "teams", "rounds", "completed", "final scores verified"],
+      games.map((g) => [g.index, g.code || "-", g.teams, `${g.roundsDone}/${g.roundsPlanned}`, g.completed ? "yes" : `NO (${g.failReason || "?"})`, g.scoresVerified ? "yes" : "NO"]),
+    ),
+  );
+  lines.push("");
+  lines.push("## Flow coverage");
+  lines.push(mdTable(["flow", "rounds"], Object.entries(flowHistogram).map(([k, v]) => [k, v])));
+  lines.push("");
+  if (metrics.violations.length) {
+    lines.push("## Invariant violations");
+    for (const v of metrics.violations.slice(0, 50)) lines.push(`- [${v.where}] ${v.message}`);
+    lines.push("");
+  }
+  if (metrics.errors.length) {
+    lines.push("## Unexpected errors (first 50)");
+    for (const e of metrics.errors.slice(0, 50)) lines.push(`- [${e.where}] ${e.message}`);
+    lines.push("");
+  }
+  if (metrics.anomalies.length) {
+    lines.push("## Anomalies (soft, first 50)");
+    for (const a of metrics.anomalies.slice(0, 50)) lines.push(`- ${a}`);
+    lines.push("");
+  }
+  lines.push("## Notes / caveats");
+  for (const n of notes) lines.push(`- ${n}`);
+  lines.push("");
+  return lines.join("\n");
+}

--- a/tests/load/lib/metrics.mjs
+++ b/tests/load/lib/metrics.mjs
@@ -206,6 +206,14 @@ export function renderReportMd({ label, config, phases, verdict, metrics, games,
     ),
   );
   lines.push("");
+  lines.push("## Counters");
+  lines.push(
+    mdTable(
+      ["counter", "value"],
+      [...metrics.counters.entries()].sort().map(([k, v]) => [k, v]),
+    ),
+  );
+  lines.push("");
   lines.push("## Per-game results");
   lines.push(
     mdTable(

--- a/tests/load/lib/supa.mjs
+++ b/tests/load/lib/supa.mjs
@@ -82,10 +82,20 @@ export class Device {
         if (status === "SUBSCRIBED") {
           this.subscribedCount += 1;
           this.subState = "subscribed";
+          if (this.subscribedCount > 1) {
+            // A rejoin means a delivery gap — surface it so misses in the
+            // report are attributable to channel health, not mystery.
+            this.metrics.bump("realtime:reconnects");
+            this.metrics.addAnomaly(`${this.id} channel re-subscribed (reconnect #${this.subscribedCount - 1})`);
+          }
           // The real app re-hydrates over REST on every (re)subscribe.
           this.hydrate().catch(() => {});
           settle("subscribed");
         } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          if (this.subState === "subscribed" && !this.closed) {
+            this.metrics.bump("realtime:channel_errors");
+            this.metrics.addAnomaly(`${this.id} channel ${status} after being subscribed`);
+          }
           if (this.subState !== "subscribed") this.subState = "error";
           settle("error");
         } else if (status === "CLOSED") {

--- a/tests/load/lib/supa.mjs
+++ b/tests/load/lib/supa.mjs
@@ -1,0 +1,168 @@
+// Simulated device layer. Each Device mirrors what one real browser does:
+// its own supabase-js client (own Realtime WebSocket), the exact channel the
+// app subscribes (`game:<code>`, three postgres_changes bindings filtered by
+// game_code), the same hydrate-on-SUBSCRIBED REST reads, and the same 60s
+// backstop resync cadence. supabase-js is borrowed from frontend/node_modules
+// via createRequire — no new dependency (Node >= 22 provides the native
+// WebSocket realtime-js needs).
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { REPO_ROOT, LoadError, rngInt } from "./util.mjs";
+
+const frontendRequire = createRequire(path.join(REPO_ROOT, "frontend", "package.json"));
+const { createClient } = frontendRequire("@supabase/supabase-js");
+
+const RPC_TIMEOUT_MS = 20000;
+const SUBSCRIBE_TIMEOUT_MS = 15000;
+
+// Mirrors frontend/src/hooks/useGameChannel.ts ACTIVE_GAME_COLUMNS.
+const ACTIVE_GAME_COLUMNS =
+  "game_code,status,selected_genres,selected_decades,round_number,current_song_id,current_round_id,buzzed_team_id,locked_at,started_at,ended_at,expires_at";
+
+export class Device {
+  /**
+   * @param {object} opts
+   * @param {string} opts.id       e.g. "G03/T07", "G03/mgr", "G03/display"
+   * @param {string} opts.role     "team" | "manager" | "display"
+   * @param {string} opts.gameCode 6-char game code
+   * @param {object} opts.env      resolved endpoints
+   * @param {object} opts.metrics  Metrics collector
+   * @param {(device: Device, table: string, payload: object) => void} opts.onEvent
+   */
+  constructor({ id, role, gameCode, env, metrics, onEvent }) {
+    this.id = id;
+    this.role = role;
+    this.gameCode = gameCode;
+    this.env = env;
+    this.metrics = metrics;
+    this.onEvent = onEvent;
+    this.subState = "idle"; // idle | subscribed | error | timeout | closed
+    this.subscribedCount = 0;
+    this.channel = null;
+    this.resyncTimer = null;
+    this.closed = false;
+    // Same client options as frontend/src/lib/supabase.ts.
+    this.client = createClient(env.supabaseUrl, env.anonKey, {
+      realtime: { params: { eventsPerSecond: 10 } },
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  // Subscribe exactly like useGameChannel: one channel, three bindings, all
+  // filtered by game_code. Resolves with the first terminal status; later
+  // transitions keep updating subState (reconnects are counted).
+  subscribe() {
+    return new Promise((resolve) => {
+      const filter = `game_code=eq.${this.gameCode}`;
+      const ch = this.client.channel(`game:${this.gameCode}`);
+      for (const table of ["active_games", "game_teams", "game_rounds"]) {
+        ch.on("postgres_changes", { event: "*", schema: "public", table, filter }, (payload) => {
+          try {
+            this.onEvent(this, table, payload);
+          } catch {
+            // measurement must never crash the drive loop
+          }
+        });
+      }
+      let settled = false;
+      const settle = (state) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(state);
+        }
+      };
+      const timer = setTimeout(() => {
+        this.subState = "timeout";
+        settle("timeout");
+      }, SUBSCRIBE_TIMEOUT_MS);
+      ch.subscribe((status) => {
+        if (status === "SUBSCRIBED") {
+          this.subscribedCount += 1;
+          this.subState = "subscribed";
+          // The real app re-hydrates over REST on every (re)subscribe.
+          this.hydrate().catch(() => {});
+          settle("subscribed");
+        } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          if (this.subState !== "subscribed") this.subState = "error";
+          settle("error");
+        } else if (status === "CLOSED") {
+          if (!this.closed) this.subState = "closed";
+        }
+      });
+      this.channel = ch;
+    });
+  }
+
+  get reconnects() {
+    return Math.max(0, this.subscribedCount - 1);
+  }
+
+  // The app's three authoritative hydrate reads (Promise.all in useGameChannel).
+  async hydrate() {
+    const t0 = performance.now();
+    const [g, t, r] = await Promise.all([
+      this.client
+        .from("active_games")
+        .select(ACTIVE_GAME_COLUMNS)
+        .eq("game_code", this.gameCode)
+        .maybeSingle(),
+      this.client.from("game_teams").select("*").eq("game_code", this.gameCode),
+      this.client.from("game_rounds").select("*").eq("game_code", this.gameCode),
+    ]);
+    this.metrics.addLatency("rest:hydrate", performance.now() - t0);
+    if (g.error || t.error || r.error) {
+      this.metrics.addAnomaly(`hydrate error on ${this.id}: ${(g.error || t.error || r.error).message}`);
+    }
+    return g.data;
+  }
+
+  // Background resync like the app's quiet backstop (60s cadence; the app
+  // tightens to 15s while a lock is held — simplified to a flat cadence here).
+  startResync(rng, everyMs = 60000) {
+    const tick = async () => {
+      if (this.closed) return;
+      await this.hydrate().catch(() => {});
+      if (!this.closed) this.resyncTimer = setTimeout(tick, everyMs + rngInt(rng, 0, 10000));
+    };
+    this.resyncTimer = setTimeout(tick, everyMs + rngInt(rng, 0, 10000));
+  }
+
+  /**
+   * Measured RPC call. PostgREST TABLE returns arrive as arrays — callers get
+   * the raw data and unwrap. Named errors listed in expectedErrors return
+   * {expectedError} instead of throwing.
+   */
+  async rpc(name, params, { expectedErrors = [] } = {}) {
+    const t0 = performance.now();
+    const { data, error } = await this.client
+      .rpc(name, params)
+      .abortSignal(AbortSignal.timeout(RPC_TIMEOUT_MS));
+    const ms = performance.now() - t0;
+    this.metrics.addLatency(`rpc:${name}`, ms);
+    this.metrics.bump("actions"); // wire-call count: the error-rate denominator
+    if (error) {
+      const known = expectedErrors.find((e) => (error.message || "").includes(e));
+      if (known) return { expectedError: known, ms };
+      throw new LoadError(`rpc ${name} failed: ${error.message} (code=${error.code})`, {
+        device: this.id,
+        game: this.gameCode,
+        rpc: name,
+      });
+    }
+    return { data, ms };
+  }
+
+  async close() {
+    this.closed = true;
+    if (this.resyncTimer) clearTimeout(this.resyncTimer);
+    try {
+      if (this.channel) await this.client.removeChannel(this.channel);
+      this.client.realtime.disconnect();
+    } catch {
+      // closing is best-effort
+    }
+  }
+}

--- a/tests/load/lib/util.mjs
+++ b/tests/load/lib/util.mjs
@@ -1,0 +1,178 @@
+// Shared plumbing for the load harness: seeded PRNG, pacing, HTTP, env resolution.
+// No dependencies beyond Node builtins — supabase-js is borrowed from
+// frontend/node_modules via createRequire (see supa.mjs).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// tests/load/lib/ -> repo root is three levels up.
+export const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Deterministic PRNG so a run is reproducible from its --seed.
+export function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export const rngInt = (rng, min, max) => min + Math.floor(rng() * (max - min + 1));
+export const rngRange = (rng, [min, max]) => min + rng() * (max - min);
+export const pick = (rng, arr) => arr[Math.floor(rng() * arr.length)];
+
+export function pickWeighted(rng, items) {
+  const total = items.reduce((s, it) => s + it.weight, 0);
+  let roll = rng() * total;
+  for (const it of items) {
+    roll -= it.weight;
+    if (roll <= 0) return it;
+  }
+  return items[items.length - 1];
+}
+
+export function percentile(sorted, p) {
+  if (sorted.length === 0) return null;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+export function summarizeLatencies(values) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    p50: Math.round(percentile(sorted, 50)),
+    p95: Math.round(percentile(sorted, 95)),
+    p99: Math.round(percentile(sorted, 99)),
+    max: Math.round(sorted[sorted.length - 1]),
+  };
+}
+
+// Serializing interval pacer. The backend rate-limits per client IP with
+// fixed per-minute windows and NO Retry-After header (slowapi), so the only
+// safe strategy from a single test machine is a steady request gap below the
+// limit. capacity is 1 by design: bursts can straddle a window boundary.
+export class Pacer {
+  constructor(perMinute, label) {
+    this.intervalMs = Math.ceil(60000 / perMinute);
+    this.label = label;
+    this.nextAt = 0;
+    this.queue = Promise.resolve();
+  }
+  take() {
+    const prev = this.queue;
+    let release;
+    this.queue = new Promise((r) => (release = r));
+    return prev.then(async () => {
+      const now = Date.now();
+      const waitMs = Math.max(0, this.nextAt - now);
+      this.nextAt = Math.max(now, this.nextAt) + this.intervalMs;
+      if (waitMs > 0) await sleep(waitMs);
+      release();
+    });
+  }
+}
+
+export class LoadError extends Error {
+  constructor(message, context = {}) {
+    super(message);
+    this.name = "LoadError";
+    this.context = context;
+  }
+}
+
+// fetch with timeout + JSON handling. Returns {status, json, text}.
+export async function fetchJson(url, { method = "GET", headers = {}, body, timeoutMs = 20000 } = {}) {
+  const res = await fetch(url, {
+    method,
+    headers: body ? { "Content-Type": "application/json", ...headers } : headers,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // non-JSON body (e.g. Cloudflare HTML error page); keep text for context
+    }
+  }
+  return { status: res.status, json, text };
+}
+
+// Minimal .env parser (KEY=VALUE lines, # comments). Vite env files are not
+// auto-loaded by Node, so the harness reads them itself.
+export function parseEnvFile(filePath) {
+  const out = {};
+  if (!fs.existsSync(filePath)) return out;
+  for (const line of fs.readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const m = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/.exec(line);
+    if (m && !line.trim().startsWith("#")) out[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+// Resolve the target endpoints. prod reads the committed frontend/.env.production
+// (browser-public values by definition); local reads frontend/.env.local.
+// LOADTEST_* env vars override everything for ad-hoc targets.
+export function resolveEnv(target) {
+  const file =
+    target === "local"
+      ? path.join(REPO_ROOT, "frontend", ".env.local")
+      : path.join(REPO_ROOT, "frontend", ".env.production");
+  const vals = parseEnvFile(file);
+  const env = {
+    target,
+    supabaseUrl: process.env.LOADTEST_SUPABASE_URL || vals.VITE_SUPABASE_URL,
+    anonKey: process.env.LOADTEST_SUPABASE_ANON_KEY || vals.VITE_SUPABASE_ANON_KEY,
+    apiUrl: process.env.LOADTEST_API_URL || vals.VITE_API_URL,
+  };
+  if (!env.supabaseUrl || !env.anonKey || !env.apiUrl) {
+    throw new LoadError(
+      `missing endpoint config for target=${target}: expected VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY / VITE_API_URL in ${file} (or LOADTEST_* env overrides)`,
+    );
+  }
+  return env;
+}
+
+export class Logger {
+  constructor() {
+    this.startedAt = Date.now();
+  }
+  stamp() {
+    const s = Math.floor((Date.now() - this.startedAt) / 1000);
+    return `[+${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}]`;
+  }
+  info(msg) {
+    console.log(`${this.stamp()} ${msg}`);
+  }
+  warn(msg) {
+    console.log(`${this.stamp()} WARN ${msg}`);
+  }
+  error(msg) {
+    console.log(`${this.stamp()} ERROR ${msg}`);
+  }
+}
+
+// Run up to `limit` async thunks concurrently (used to stagger Realtime
+// channel joins instead of slamming 240 subscribes into one instant).
+export async function mapLimit(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}

--- a/tests/load/loadtest.mjs
+++ b/tests/load/loadtest.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+// Sound Clash load-test harness (protocol-level, zero new dependencies).
+//
+// Simulates whole games against the real stack the way real devices do it:
+// REST for create/join/bonus/end/kick (FastAPI on Render), direct PostgREST
+// RPCs for the hot path (buzz_in / award_attempt / release_buzz_lock /
+// select_next_song / peek_next_song / extend_game), and one Supabase Realtime
+// WebSocket per simulated device. No browsers, no YouTube — those are
+// client-local and don't load the backend.
+//
+//   node tests/load/loadtest.mjs run --label check1-5x10 --games 5 --teams 10 --rounds 15 --seed 101
+//   node tests/load/loadtest.mjs smoke
+//   node tests/load/loadtest.mjs cleanup --dir tests/load/results/<label>
+//
+// See tests/load/README.md for scenarios, thresholds and caveats.
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { GameDriver } from "./lib/driver.mjs";
+import { SMOKE_FLOW_SEQUENCE } from "./lib/flows.mjs";
+import { Metrics, renderReportMd } from "./lib/metrics.mjs";
+import { fetchJson, Logger, LoadError, Pacer, REPO_ROOT, resolveEnv, sleep } from "./lib/util.mjs";
+
+const log = new Logger();
+
+// ---------------------------------------------------------------------------
+// CLI
+
+function parseCli() {
+  const [, , command = "run", ...rest] = process.argv;
+  const { values } = parseArgs({
+    args: rest,
+    options: {
+      label: { type: "string" },
+      games: { type: "string", default: "1" },
+      teams: { type: "string", default: "10" },
+      rounds: { type: "string", default: "15" },
+      seed: { type: "string" }, // no default here so smoke can detect "not given"
+      pace: { type: "string", default: "realistic" }, // realistic | fast
+      target: { type: "string", default: "prod" }, // prod | local
+      genres: { type: "string", default: "rock,pop" },
+      kick: { type: "boolean", default: false },
+      "skip-bonus": { type: "boolean", default: false },
+      "skip-resync": { type: "boolean", default: false },
+      outdir: { type: "string" },
+      dir: { type: "string" }, // cleanup target
+      "create-rate": { type: "string", default: "9" }, // per minute (< backend's 10)
+      "join-rate": { type: "string", default: "27" }, // per minute (< backend's 30)
+      "mgr-rate": { type: "string", default: "80" }, // per minute (< backend's 100)
+    },
+    allowPositionals: false,
+  });
+  return { command, values };
+}
+
+// ---------------------------------------------------------------------------
+// Run registry (game codes + manager tokens, so leftover games can always be
+// ended). Lives in the gitignored results dir; tokens are per-game secrets
+// for 4h synthetic games we created ourselves.
+
+class Registry {
+  constructor(file) {
+    this.file = file;
+    this.games = [];
+  }
+  add(g) {
+    this.games.push({ ...g, ended: false });
+    this.flush();
+  }
+  markEnded(code) {
+    const g = this.games.find((x) => x.code === code);
+    if (g) g.ended = true;
+    this.flush();
+  }
+  flush() {
+    fs.writeFileSync(this.file, JSON.stringify({ games: this.games }, null, 2));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight helpers
+
+async function waitForBackend(env) {
+  const t0 = Date.now();
+  for (let i = 0; i < 18; i++) {
+    try {
+      const res = await fetchJson(`${env.apiUrl}/health`, { timeoutMs: 10000 });
+      if (res.status === 200 && res.json?.status === "ok") {
+        return { warmupMs: Date.now() - t0, supabase: res.json.supabase };
+      }
+    } catch {
+      // Render free-tier cold start: keep knocking
+    }
+    await sleep(5000);
+  }
+  throw new LoadError("backend /health never became ok (waited ~4.5 minutes)");
+}
+
+async function pgrest(env, pathAndQuery) {
+  const res = await fetchJson(`${env.supabaseUrl}/rest/v1/${pathAndQuery}`, {
+    headers: { apikey: env.anonKey, Authorization: `Bearer ${env.anonKey}` },
+  });
+  if (res.status !== 200) throw new LoadError(`PostgREST ${pathAndQuery} -> HTTP ${res.status}`);
+  return res.json;
+}
+
+async function resolveGenres(env, slugsCsv) {
+  const slugs = slugsCsv.split(",").map((s) => s.trim()).filter(Boolean);
+  const all = await pgrest(env, "genres?select=id,slug");
+  const ids = slugs.map((slug) => {
+    const hit = all.find((g) => g.slug === slug);
+    if (!hit) throw new LoadError(`genre slug not found: ${slug} (have: ${all.map((g) => g.slug).join(", ")})`);
+    return hit.id;
+  });
+  return { slugs, ids };
+}
+
+async function countSongPool(env, genreIds) {
+  // Mirror the picker's eligibility (mig 045 skips songs flagged unavailable),
+  // otherwise the guard can pass while the real playable pool is smaller.
+  const [rows, dead] = await Promise.all([
+    pgrest(env, `song_genres?select=song_id&genre_id=in.(${genreIds.join(",")})&limit=10000`),
+    pgrest(env, "songs?select=id&unavailable_at=not.is.null&limit=10000"),
+  ]);
+  const unavailable = new Set(dead.map((s) => s.id));
+  return new Set(rows.map((r) => r.song_id).filter((id) => !unavailable.has(id))).size;
+}
+
+async function warnIfLiveGames(env) {
+  try {
+    const rows = await pgrest(env, "active_games?select=game_code&status=eq.playing&ended_at=is.null&limit=10");
+    if (rows.length > 0) {
+      log.warn(`preflight: ${rows.length} game(s) currently in status=playing on this target — a real party may be live. The load run proceeds but consider re-running off-hours.`);
+      return rows.length;
+    }
+  } catch (err) {
+    log.warn(`preflight live-games check failed: ${err.message}`);
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// The run
+
+async function runLoadTest(values, { forcedFlows = null } = {}) {
+  const cfg = {
+    label: values.label,
+    games: Number(values.games),
+    teams: Number(values.teams),
+    rounds: Number(values.rounds),
+    seed: Number(values.seed ?? "1"),
+    pace: values.pace === "fast" ? "fast" : "realistic",
+    target: values.target,
+    genres: values.genres,
+    kick: values.kick,
+    bonus: !values["skip-bonus"],
+    resync: !values["skip-resync"],
+    createRate: Number(values["create-rate"]),
+    joinRate: Number(values["join-rate"]),
+    mgrRate: Number(values["mgr-rate"]),
+  };
+  if (!cfg.label) throw new LoadError("--label is required for run");
+  const env = resolveEnv(cfg.target);
+
+  // Results dir: fixed path per label (Monitor-friendly); archive a previous run.
+  const outBase = values.outdir || path.join(REPO_ROOT, "tests", "load", "results");
+  const runDir = path.join(outBase, cfg.label);
+  if (fs.existsSync(runDir)) fs.renameSync(runDir, `${runDir}-prev-${Date.now()}`);
+  fs.mkdirSync(runDir, { recursive: true });
+
+  const metrics = new Metrics();
+  const registry = new Registry(path.join(runDir, "games.json"));
+  const phases = [];
+  const phaseStart = { t: Date.now(), name: "preflight" };
+  const nextPhase = (name) => {
+    phases.push({ name: phaseStart.name, ms: Date.now() - phaseStart.t });
+    phaseStart.t = Date.now();
+    phaseStart.name = name;
+    log.info(`=== phase: ${name} ===`);
+  };
+
+  // Status heartbeat for detached monitoring.
+  const status = {
+    label: cfg.label,
+    phase: "preflight",
+    startedAt: new Date().toISOString(),
+    gamesTotal: cfg.games,
+    gamesCreated: 0,
+    teamsJoined: 0,
+    teamsTotal: cfg.games * cfg.teams,
+    roundsDone: 0,
+    roundsTotal: cfg.games * cfg.rounds,
+    errorCount: 0,
+    violationCount: 0,
+    done: false,
+    verdict: null,
+  };
+  const statusFile = path.join(runDir, "status.json");
+  const writeStatus = () => {
+    status.phase = phaseStart.name;
+    status.errorCount = metrics.errors.length;
+    status.violationCount = metrics.violations.length;
+    status.now = new Date().toISOString();
+    try {
+      fs.writeFileSync(statusFile, JSON.stringify(status, null, 2));
+    } catch {
+      // never let status writing kill the run
+    }
+  };
+  const statusTimer = setInterval(writeStatus, 2000);
+  const progressTimer = setInterval(() => {
+    log.info(`progress: phase=${phaseStart.name} rounds=${status.roundsDone}/${status.roundsTotal} errors=${status.errorCount} violations=${status.violationCount}`);
+  }, 15000);
+  writeStatus();
+
+  log.info(`load test '${cfg.label}': ${cfg.games} game(s) x ${cfg.teams} teams x ${cfg.rounds} rounds, pace=${cfg.pace}, seed=${cfg.seed}, target=${cfg.target}`);
+  const devicesTotal = cfg.games * (cfg.teams + 2);
+  log.info(`simulated devices: ${devicesTotal} (${cfg.teams} teams + manager + display per game), one Realtime socket each`);
+  const setupEtaS = Math.round((cfg.games * 60) / cfg.createRate + (cfg.games * cfg.teams * 60) / cfg.joinRate);
+  log.info(`setup ETA ~${setupEtaS}s (REST create/join paced under the backend's per-IP rate limits: ${cfg.createRate}/min create, ${cfg.joinRate}/min join)`);
+
+  // Preflight.
+  const health = await waitForBackend(env);
+  metrics.addLatency("render_warmup", health.warmupMs);
+  log.info(`backend healthy in ${health.warmupMs}ms (supabase=${health.supabase})`);
+  const { slugs, ids: genreIds } = await resolveGenres(env, cfg.genres);
+  cfg.genreIds = genreIds;
+  const pool = await countSongPool(env, genreIds);
+  log.info(`song pool for [${slugs.join(", ")}]: ~${pool} songs (need ${cfg.rounds}/game)`);
+  if (pool < cfg.rounds * 2) {
+    throw new LoadError(`song pool too small (${pool}) for ${cfg.rounds} rounds — pick more genres via --genres`);
+  }
+  const liveGames = await warnIfLiveGames(env);
+
+  const pacers = {
+    create: new Pacer(cfg.createRate, "create"),
+    join: new Pacer(cfg.joinRate, "join"),
+    mgrRest: new Pacer(cfg.mgrRate, "mgrRest"),
+  };
+
+  const drivers = Array.from(
+    { length: cfg.games },
+    (_, i) =>
+      new GameDriver({
+        index: i + 1,
+        cfg,
+        env,
+        pacers,
+        metrics,
+        log,
+        registry,
+        seed: cfg.seed + (i + 1) * 7919,
+      }),
+  );
+
+  // SIGINT: end every created game before exiting, so nothing lingers.
+  let interrupted = false;
+  process.on("SIGINT", async () => {
+    if (interrupted) process.exit(130);
+    interrupted = true;
+    log.warn("SIGINT — ending created games then exiting");
+    for (const d of drivers) await d.end().catch(() => {});
+    writeStatus();
+    process.exit(130);
+  });
+
+  // ---- SETUP (all games created+joined+subscribed before any play starts,
+  // so the play phase is a true N-concurrent-games window) ----
+  nextPhase("setup");
+  await Promise.all(
+    drivers.map(async (d) => {
+      try {
+        await d.setup();
+        status.gamesCreated += 1;
+        status.teamsJoined += d.roster.length;
+      } catch (err) {
+        d.failReason = `setup: ${err.message}`;
+        d.error(`setup failed: ${err.message}`);
+      }
+    }),
+  );
+  const playable = drivers.filter((d) => !d.failReason);
+  log.info(`setup complete: ${playable.length}/${drivers.length} games ready`);
+
+  // Expectation sweeper (miss accounting).
+  const sweeper = setInterval(() => {
+    for (const d of drivers) d.sweepExpectations();
+  }, 1000);
+
+  // ---- PLAY ----
+  nextPhase("play");
+  await Promise.all(
+    playable.map(async (d, i) => {
+      await sleep(i * 150 + Math.floor(d.rng() * 2000)); // slight round-loop stagger
+      try {
+        await d.play(forcedFlows, () => {
+          status.roundsDone += 1;
+        });
+      } catch (err) {
+        d.failReason = `play (round ${d.roundsDone + 1}): ${err.message}`;
+        d.error(`play failed: ${err.message}`);
+      }
+    }),
+  );
+
+  // Let in-flight Realtime events land, then close the books on misses.
+  nextPhase("flush");
+  await sleep(11000);
+  clearInterval(sweeper);
+  for (const d of drivers) d.sweepExpectations(true);
+
+  // ---- VERIFY + TEARDOWN ----
+  nextPhase("verify");
+  for (const d of drivers) {
+    if (d.code) await d.verifyFinalScores().catch((err) => d.error(`verify failed: ${err.message}`));
+  }
+  nextPhase("teardown");
+  for (const d of drivers) await d.end();
+  await Promise.all(drivers.map((d) => d.closeDevices()));
+
+  // ---- REPORT ----
+  nextPhase("report");
+  const games = drivers.map((d) => d.snapshot());
+  const flowHistogram = {};
+  for (const g of games) {
+    for (const [k, v] of Object.entries(g.flowHistogram)) flowHistogram[k] = (flowHistogram[k] || 0) + v;
+  }
+  const totalActions = metrics.counters.get("actions") || 0;
+  const verdict = metrics.summarize({ games, totalActions });
+  const notes = [
+    `All traffic left one machine/IP: REST setup was paced under the backend's per-IP limits (create ${cfg.createRate}/min, join ${cfg.joinRate}/min) — real parties on distinct phones/IPs never share those buckets, so setup pacing here is a harness artifact, not a product limit. 429s seen: ${metrics.counters.get("rest:429") || 0}.`,
+    `Realtime devices attempted: ${devicesTotal}. Subscribe failures usually mean the Supabase plan's concurrent-connection quota, not an app bug.`,
+    `Latencies include this machine's RTT to Supabase (Frankfurt) / Render; treat thresholds as advisory and read the distributions.`,
+    liveGames > 0 ? `Preflight saw ${liveGames} live game(s) on the target — results may include a real party's traffic.` : `Preflight saw no live games on the target.`,
+    `Hot-path RPC 429s are impossible by design (PostgREST direct, no backend limiter); only REST setup shares the one-IP buckets.`,
+  ];
+  const config = { ...cfg, genreIds: undefined };
+  phases.push({ name: phaseStart.name, ms: Date.now() - phaseStart.t });
+
+  const reportMd = renderReportMd({ label: cfg.label, config, phases, verdict, metrics, games, flowHistogram, notes });
+  fs.writeFileSync(path.join(runDir, "report.md"), reportMd);
+  fs.writeFileSync(
+    path.join(runDir, "report.json"),
+    JSON.stringify(
+      {
+        label: cfg.label,
+        config,
+        phases,
+        verdict,
+        latencies: metrics.latencyTable(),
+        realtime: metrics.rtTable(),
+        counters: Object.fromEntries(metrics.counters),
+        violations: metrics.violations,
+        errors: metrics.errors,
+        anomalies: metrics.anomalies,
+        games,
+        flowHistogram,
+        notes,
+      },
+      null,
+      2,
+    ),
+  );
+
+  status.done = true;
+  status.verdict = verdict.overall;
+  clearInterval(statusTimer);
+  clearInterval(progressTimer);
+  writeStatus();
+
+  log.info(`report: ${path.join(runDir, "report.md")}`);
+  log.info(`LOADTEST COMPLETE verdict=${verdict.overall} label=${cfg.label}`);
+  return verdict.overall === "FAIL" ? 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// cleanup: end any leftover games from a previous (crashed/killed) run.
+
+async function cleanup(values) {
+  if (!values.dir) throw new LoadError("cleanup needs --dir <run results dir>");
+  const file = path.join(values.dir, "games.json");
+  const data = JSON.parse(fs.readFileSync(file, "utf8"));
+  const env = resolveEnv(values.target);
+  let ended = 0;
+  for (const g of data.games) {
+    if (g.ended) continue;
+    const res = await fetchJson(`${env.apiUrl}/games/${g.code}/end`, {
+      method: "POST",
+      headers: { "X-Manager-Token": g.manager_token },
+    });
+    log.info(`end ${g.code}: HTTP ${res.status}${res.status === 404 || res.status === 410 ? " (already gone)" : ""}`);
+    if ([200, 404, 410].includes(res.status)) {
+      g.ended = true;
+      ended += 1;
+    }
+    await sleep(700); // stay under the manager-REST limit
+  }
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+  log.info(`cleanup done: ${ended} game(s) resolved`);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const { command, values } = parseCli();
+  if (command === "run") return runLoadTest(values);
+  if (command === "smoke") {
+    // Tiny end-to-end validation: 1 game, 3 teams, every flow exactly once,
+    // fast pace, kick + bonus exercised. Safe to run any time (self-cleaning).
+    return runLoadTest(
+      {
+        ...values,
+        label: values.label || "smoke",
+        games: "1",
+        teams: "3",
+        rounds: String(SMOKE_FLOW_SEQUENCE.length),
+        pace: "fast",
+        kick: true,
+        seed: values.seed || "7",
+      },
+      { forcedFlows: SMOKE_FLOW_SEQUENCE },
+    );
+  }
+  if (command === "cleanup") return cleanup(values);
+  throw new LoadError(`unknown command: ${command} (expected run | smoke | cleanup)`);
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    log.error(err.stack || String(err));
+    process.exit(2);
+  });

--- a/tests/load/loadtest.mjs
+++ b/tests/load/loadtest.mjs
@@ -48,6 +48,10 @@ function parseCli() {
       "create-rate": { type: "string", default: "9" }, // per minute (< backend's 10)
       "join-rate": { type: "string", default: "27" }, // per minute (< backend's 30)
       "mgr-rate": { type: "string", default: "80" }, // per minute (< backend's 100)
+      // Cap on concurrent Realtime subscriptions (0 = subscribe everything).
+      // Supabase free tier allows ~200 concurrent connections; big checks set
+      // e.g. 180 so the run never trips the plan quota by design.
+      "rt-budget": { type: "string", default: "0" },
     },
     allowPositionals: false,
   });
@@ -127,6 +131,41 @@ async function countSongPool(env, genreIds) {
   return new Set(rows.map((r) => r.song_id).filter((id) => !unavailable.has(id))).size;
 }
 
+// Distribute a Realtime-subscription budget across games. Shed order per
+// game: display first, then manager, then team devices round-robin (never
+// below 1 subscribed team per game) — measurement audiences shrink, but every
+// device still plays via RPC/REST so correctness runs at full size.
+function planSubscriptions(games, teams, budget) {
+  const total = games * (teams + 2);
+  if (!budget || budget <= 0 || total <= budget) return { plans: null, total, subscribed: total };
+  const plans = Array.from({ length: games }, () => ({ display: true, manager: true, teamSubs: teams }));
+  let excess = total - budget;
+  for (const p of plans) {
+    if (excess <= 0) break;
+    p.display = false;
+    excess--;
+  }
+  for (const p of plans) {
+    if (excess <= 0) break;
+    p.manager = false;
+    excess--;
+  }
+  while (excess > 0) {
+    let shed = 0;
+    for (const p of plans) {
+      if (excess <= 0) break;
+      if (p.teamSubs > 1) {
+        p.teamSubs--;
+        excess--;
+        shed++;
+      }
+    }
+    if (shed === 0) break; // keep at least one subscribed team per game
+  }
+  const subscribed = plans.reduce((s, p) => s + p.teamSubs + (p.manager ? 1 : 0) + (p.display ? 1 : 0), 0);
+  return { plans, total, subscribed };
+}
+
 async function warnIfLiveGames(env) {
   try {
     const rows = await pgrest(env, "active_games?select=game_code&status=eq.playing&ended_at=is.null&limit=10");
@@ -159,6 +198,7 @@ async function runLoadTest(values, { forcedFlows = null } = {}) {
     createRate: Number(values["create-rate"]),
     joinRate: Number(values["join-rate"]),
     mgrRate: Number(values["mgr-rate"]),
+    rtBudget: Number(values["rt-budget"]),
   };
   if (!cfg.label) throw new LoadError("--label is required for run");
   const env = resolveEnv(cfg.target);
@@ -216,7 +256,13 @@ async function runLoadTest(values, { forcedFlows = null } = {}) {
 
   log.info(`load test '${cfg.label}': ${cfg.games} game(s) x ${cfg.teams} teams x ${cfg.rounds} rounds, pace=${cfg.pace}, seed=${cfg.seed}, target=${cfg.target}`);
   const devicesTotal = cfg.games * (cfg.teams + 2);
-  log.info(`simulated devices: ${devicesTotal} (${cfg.teams} teams + manager + display per game), one Realtime socket each`);
+  const subPlan = planSubscriptions(cfg.games, cfg.teams, cfg.rtBudget);
+  log.info(`simulated devices: ${devicesTotal} (${cfg.teams} teams + manager + display per game)`);
+  if (subPlan.plans) {
+    log.info(`rt-budget ${cfg.rtBudget}: subscribing ${subPlan.subscribed}/${devicesTotal} devices to Realtime (shed display->manager->teams; all devices still play via RPC)`);
+  } else {
+    log.info(`all ${devicesTotal} devices subscribe to Realtime (no --rt-budget cap)`);
+  }
   const setupEtaS = Math.round((cfg.games * 60) / cfg.createRate + (cfg.games * cfg.teams * 60) / cfg.joinRate);
   log.info(`setup ETA ~${setupEtaS}s (REST create/join paced under the backend's per-IP rate limits: ${cfg.createRate}/min create, ${cfg.joinRate}/min join)`);
 
@@ -251,6 +297,7 @@ async function runLoadTest(values, { forcedFlows = null } = {}) {
         log,
         registry,
         seed: cfg.seed + (i + 1) * 7919,
+        rtPlan: subPlan.plans ? subPlan.plans[i] : null,
       }),
   );
 
@@ -330,7 +377,9 @@ async function runLoadTest(values, { forcedFlows = null } = {}) {
   const verdict = metrics.summarize({ games, totalActions });
   const notes = [
     `All traffic left one machine/IP: REST setup was paced under the backend's per-IP limits (create ${cfg.createRate}/min, join ${cfg.joinRate}/min) — real parties on distinct phones/IPs never share those buckets, so setup pacing here is a harness artifact, not a product limit. 429s seen: ${metrics.counters.get("rest:429") || 0}.`,
-    `Realtime devices attempted: ${devicesTotal}. Subscribe failures usually mean the Supabase plan's concurrent-connection quota, not an app bug.`,
+    subPlan.plans
+      ? `Realtime subscription budget ${cfg.rtBudget}: ${subPlan.subscribed}/${devicesTotal} devices subscribed (shed to respect the plan's concurrent-connection quota; ${metrics.counters.get("subscribe:skipped_budget") || 0} skipped). With the budget in place, any subscribe FAILURE is a real finding.`
+      : `Realtime devices attempted: ${devicesTotal}. Subscribe failures usually mean the Supabase plan's concurrent-connection quota, not an app bug.`,
     `Latencies include this machine's RTT to Supabase (Frankfurt) / Render; treat thresholds as advisory and read the distributions.`,
     liveGames > 0 ? `Preflight saw ${liveGames} live game(s) on the target — results may include a real party's traffic.` : `Preflight saw no live games on the target.`,
     `Hot-path RPC 429s are impossible by design (PostgREST direct, no backend limiter); only REST setup shares the one-IP buckets.`,


### PR DESCRIPTION
## Summary
- New manual load-test harness under `tests/load/` answering: will the live stack survive several concurrent games (5/10/20 games x 10 teams) and one 30-team game, 15 rounds each, with every manager button exercised?
- Protocol-level and dependency-free: REST for create/join/bonus/end/kick, browser-identical PostgREST RPCs for the hot path, one Supabase Realtime WebSocket per simulated device (mirrors `useGameChannel` exactly, incl. hydrate + 60s resync). supabase-js is borrowed from `frontend/node_modules` via `createRequire`.
- Seeded flow engine covering 11 realistic round flows (races, splits, wrong chains, free-guess waiver, no-buzz skip, bonus, kick, extend), a local expected-score ledger verified against `award_attempt` running totals and final DB state, exactly-one-winner race invariants, latency percentiles, and end-to-end Realtime delivery/miss measurement.
- REST setup self-paces under the backend's per-IP rate limits (create 10/min, join 30/min) with 429 backoff; runs journal game codes + manager tokens so `cleanup` can always end leftovers.
- `tests/load/FINDINGS.md` is the committed findings log every run must append to (per-run reports are gitignored); `RUN-PROMPTS.md` has canned procedures incl. Grafana/pg_stat monitoring steps.
- Docs: `docs/testing-strategy.md` gains §4.6; CLAUDE.md repo layout lists `tests/load/`. `tests/load/results/` gitignored.

## Test plan
- `node --check` on all modules; import check.
- Adversarial 3-lens review (wire contracts vs migrations/hooks, concurrency/measurement, ops/docs) — 2 major + 6 minor findings all fixed (lock_set matcher bound to the fresh null->winner transition; per-device resync PRNG streams to keep --seed reproducible; paced-call expectation timing; pool count mirrors mig-045 availability; kicked-device audience pruning; monitor startup-crash detection).
- Two live smoke runs against prod (`node tests/load/loadtest.mjs smoke`: 1 game, 3 teams, all 11 flows + kick + bonus + extend, self-cleaning): second run all-PASS — buzz_in p95 93ms, select_next_song p95 82ms, Realtime delivery p95 ~610-630ms, 0/220 misses, 0 invariant violations, both games ended cleanly.