### PR TITLE
Add in-repo Render keepalive backstop (GitHub Actions)

### DIFF
--- a/.github/workflows/render-keepalive.yml
+++ b/.github/workflows/render-keepalive.yml
@@ -1,0 +1,67 @@
+# Render keepalive — in-repo backstop for the free-tier cold start.
+#
+# Render's free web service sleeps after 15 minutes idle; the first request
+# after that stalls 2–30s (felt as "sometimes long loading" when a host creates
+# a game). An external cron-job.org job (jobId 7569155) pings /health every 10
+# minutes as the PRIMARY keepalive — but it silently auto-disabled after
+# failures on 2026-06-23 and stayed dead 23 days before anyone noticed, and its
+# requests are intermittently served HTTP 503 by Render's Cloudflare edge.
+#
+# This workflow is the REDUNDANT second leg, pinging the same endpoint on the
+# same 10-minute cadence from GitHub's runner IPs (a different egress pool, so
+# the failure modes are uncorrelated). Because a Render sleep needs ~15 min with
+# zero successful pings, a cold-start window now requires BOTH keepalives to miss
+# simultaneously. Unlike cron-job.org, a lapse here is VISIBLE in the Actions tab
+# (a red run), which is the monitoring the external cron lacks.
+#
+# It is an unauthenticated GET to a public health endpoint: no secrets, and if it
+# fails nothing happens to the live site (worst case is the status-quo cold
+# start). GitHub cron is best-effort and can lag 5–15 min past the boundary; that
+# is fine here — combined with cron-job.org's ticks it still closes the window.
+
+name: Render keepalive
+
+on:
+  schedule:
+    # Every 10 minutes, matching the cron-job.org cadence. GitHub cron is
+    # best-effort and may run late; that is acceptable for a keepalive.
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+# No repo access needed — this only makes an outbound GET and writes a summary.
+permissions: {}
+
+concurrency:
+  group: render-keepalive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping Render /health
+        run: |
+          set -euo pipefail
+          url="https://api.soundclash.org/health"
+          code="000"; body=""
+          # Retry a few times: absorbs the intermittent edge 503s (which also hit
+          # cron-job.org) and gives a cold dyno time to wake, so the run only goes
+          # red when the backend is genuinely unreachable — a real "keepalive
+          # broken" alarm, not single-tick noise.
+          for attempt in 1 2 3 4 5; do
+            code=$(curl -sS -o body.txt -w '%{http_code}' --max-time 30 "$url" 2>/dev/null || echo "000")
+            body=$(cat body.txt 2>/dev/null || true)
+            echo "attempt $attempt: HTTP $code — $body"
+            # Gate on the body, not just the status line, so a healthy response is
+            # unambiguous even if the wake returned an interstitial first.
+            if printf '%s' "$body" | grep -q '"status":"ok"'; then
+              echo "Render backend is warm (HTTP $code). ✅"
+              echo "- $(date -u +%FT%TZ): OK — HTTP $code — \`$body\`" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            [ "$attempt" -lt 5 ] && sleep 10
+          done
+          echo "::error::Render /health never returned a healthy body after 5 attempts (last HTTP $code, body: ${body:-<empty>})."
+          echo "- $(date -u +%FT%TZ): FAILED — last HTTP $code" >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/docs/free-tier-budget.md
+++ b/docs/free-tier-budget.md
@@ -56,7 +56,7 @@ These numbers are pessimistic; real-world will be lower. Round up for safety.
 | Idle sleep | 15 min idle → sleep | Acceptable: FastAPI is off the buzzer hot path |
 | Cold start | ~30 s wake | Felt only on game creation after long idle |
 
-**Binding constraint**: cold-start UX. The first game-creation request after a >15min idle period stalls ~30s. Mitigation: cron-job.org pings `/health` every 14 minutes (free tier: 50 cron jobs).
+**Binding constraint**: cold-start UX. The first game-creation request after a >15min idle period stalls ~30s. Mitigation: two independent keepalives ping `/health` every 10 minutes — the external cron-job.org job (primary) and the in-repo `.github/workflows/render-keepalive.yml` GitHub Action (monitored backstop). See §2.7 for the full setup and the 2026-06/07 outage that motivated the second leg.
 
 ### 2.3 Cloudflare Pages
 
@@ -93,22 +93,48 @@ Free, no quotas relevant to this project.
 | Replays | 50 / mo | Use sparingly for debugging |
 | Team members | 1 | Solo maintainer |
 
-### 2.7 cron-job.org (Render keepalive)
+### 2.7 Render keepalive (two independent legs + a UI fallback)
 
 | Resource | Limit | Notes |
 |---|---|---|
-| Cron jobs | 50 | Use 1 |
-| Min interval | 1 minute | We use 14 min |
+| cron-job.org — cron jobs | 50 | Use 1 (jobId 7569155, account benartzi4@gmail.com) |
+| cron-job.org — min interval | 1 minute | We use **10 min** (`minutes:[0,10,20,30,40,50]`, Asia/Jerusalem) |
+| GitHub Actions — minutes | unlimited (public repo) | `render-keepalive.yml`, `*/10 * * * *` + manual dispatch |
 
-This 24/7 cron is the **primary** Render keepalive. The frontend `useKeepBackendWarm`
-hook (manager console only, while a game is `waiting`/`playing`) is a deliberate
-**visibility-aware fallback** on top of it (T-KeepWarm decision, Phase 3): it pings
-`/health` immediately on mount, on `visibilitychange → visible`, and every 10 min.
-The mount + on-visible pings cover the two cases the cron cannot: a host who
-deep-links straight into `/manager/game/<code>`, and a phone whose background timers
-were frozen while asleep and returns to a possibly-cold dyno right at Bonus/End.
-`/health` is unlimited + unauthenticated (§6), so the handful of extra GETs per game
-is free; if the cron is ever paused/misconfigured this is the safety net.
+The Render dyno sleeps after 15 min idle, so it stays warm as long as **any**
+ping lands inside each 15-min window. Two independent keepalives hit
+`GET /health` every 10 minutes:
+
+1. **cron-job.org (primary)** — an external 24/7 cron. This is the historical
+   keepalive but it is an *unmonitored* single point of failure: it silently
+   auto-disabled after repeated failures on **2026-06-23** and stayed dead for
+   **23 days** (nobody noticed until 2026-07-16), which was the root cause of the
+   "sometimes long loading" reports over that period. It was re-enabled 2026-07-16.
+   Its requests are also *intermittently* served **HTTP 503 by Render's own
+   Cloudflare edge** (Render fronts every service with Cloudflare; our DNS is
+   Namecheap, so there is no user-side Cloudflare zone to allowlist in) — the
+   block is per-egress-IP and comes and goes.
+2. **GitHub Actions `render-keepalive.yml` (monitored backstop)** — added
+   2026-07-16 for exactly this reason. It pings the same endpoint on the same
+   cadence from GitHub's runner IPs (a *different* egress pool, so its failures
+   are uncorrelated with cron-job.org's), and a lapse is **visible as a red run in
+   the Actions tab** — the monitoring the external cron lacks. A cold-start window
+   now requires *both* legs to miss simultaneously.
+
+On top of those, the frontend `useKeepBackendWarm` hook (manager console only,
+while a game is `waiting`/`playing`) is a deliberate **visibility-aware fallback**
+(T-KeepWarm decision, Phase 3): it pings `/health` on mount, on
+`visibilitychange → visible`, and every 10 min. The mount + on-visible pings cover
+the two cases a cron cannot: a host who deep-links straight into
+`/manager/game/<code>`, and a phone whose background timers were frozen while
+asleep and returns to a possibly-cold dyno right at Bonus/End. `/health` is
+unlimited + unauthenticated (§6), so the handful of extra GETs per game is free.
+
+**If "sometimes slow" ever returns, check in this order:** (a) the Actions tab —
+is `render-keepalive` running green every ~10 min? (b) cron-job.org —
+`curl -H "Authorization: Bearer $CRONJOB_API_KEY" https://api.cron-job.org/jobs`
+for `enabled`/`lastStatus` (1=OK, 4=HTTP error) on jobId 7569155, and
+`/jobs/7569155/history` for the recent run tally.
 
 ### 2.8 Domain (paid; not free)
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/render-keepalive.yml` — a monitored, in-repo second keepalive leg for the Render free-tier backend, pinging `GET https://api.soundclash.org/health` every 10 minutes (`*/10 * * * *`) plus `workflow_dispatch`. Fails the run on a non-healthy response so a lapse is **visible in the Actions tab**.

### Why

The external cron-job.org keepalive (jobId 7569155) is an unmonitored single point of failure: it silently auto-disabled after failures on **2026-06-23** and stayed dead for 23 days — the root cause of the "sometimes long loading" reports over that period. Its requests are also intermittently served HTTP 503 by Render's own Cloudflare edge (per-egress-IP). GitHub's runner IPs are a different egress pool, so this leg's failure modes are uncorrelated with cron-job.org's; a cold-start window now requires **both** legs to miss simultaneously.

- Unauthenticated GET to a public health endpoint — no secrets, `permissions: {}`.
- Retries up to 5× (absorbs a transient edge 503 or a cold-dyno wake) so red = a real "keepalive broken" alarm, not single-tick noise.
- Actions minutes are free/unlimited on a public repo; adds no new Render consumption (the service is already kept warm).

Also corrects `docs/free-tier-budget.md`: the stale "every 14 minutes" (real schedule is every 10) and documents both keepalive legs + the 2026-06/07 outage.

## Test plan

- `render-keepalive.yml` parses as valid YAML; `*/10 * * * *` + `workflow_dispatch`, single `ping` job, `permissions: {}`.
- After merge: one `workflow_dispatch` run concludes success with HTTP 200 `{"status":"ok",...}` from `/health`, and at least one `schedule`-event run concludes success on its own.
- No CHANGELOG entry (CI/infra-only, not user-visible).