### PR TITLE
Correct keepalive docs: GitHub cron is not a reliable second leg here

### DIFF
--- a/.github/workflows/render-keepalive.yml
+++ b/.github/workflows/render-keepalive.yml
@@ -1,30 +1,35 @@
-# Render keepalive — in-repo backstop for the free-tier cold start.
+# Render keepalive — on-demand warm button + coarse liveness monitor.
 #
 # Render's free web service sleeps after 15 minutes idle; the first request
 # after that stalls 2–30s (felt as "sometimes long loading" when a host creates
-# a game). An external cron-job.org job (jobId 7569155) pings /health every 10
-# minutes as the PRIMARY keepalive — but it silently auto-disabled after
-# failures on 2026-06-23 and stayed dead 23 days before anyone noticed, and its
-# requests are intermittently served HTTP 503 by Render's Cloudflare edge.
+# a game). The RELIABLE keepalive is an external cron-job.org job (jobId 7569155)
+# that pings /health every 10 minutes, on time — but it silently auto-disabled
+# after failures on 2026-06-23 and stayed dead 23 days before anyone noticed, and
+# its requests are intermittently served HTTP 503 by Render's Cloudflare edge.
 #
-# This workflow is the REDUNDANT second leg, pinging the same endpoint on the
-# same 10-minute cadence from GitHub's runner IPs (a different egress pool, so
-# the failure modes are uncorrelated). Because a Render sleep needs ~15 min with
-# zero successful pings, a cold-start window now requires BOTH keepalives to miss
-# simultaneously. Unlike cron-job.org, a lapse here is VISIBLE in the Actions tab
-# (a red run), which is the monitoring the external cron lacks.
+# This workflow is a SECONDARY safety net, NOT a reliable second keepalive leg.
+# Its nominal schedule is */10, but GitHub silently drops most scheduled triggers
+# on this repo — measured against the */15 stale-buzz-lock-scan.yml, real
+# scheduled runs land 49–204 min apart (avg ~90 min), far longer than Render's
+# 15-min sleep — so it cannot keep the dyno warm on its own. What it IS good for:
+#   (a) a reliable manual `workflow_dispatch` "warm it now" button, from GitHub's
+#       runner IPs (a different egress pool, so not co-blocked with cron-job.org);
+#   (b) a coarse liveness monitor — when a scheduled run does fire, a red run in
+#       the Actions tab flags an unreachable backend.
+# A genuinely reliable second leg would be a Supabase pg_cron + pg_net ping
+# (considered 2026-07-16, deferred: cron-job.org was healthy).
 #
 # It is an unauthenticated GET to a public health endpoint: no secrets, and if it
-# fails nothing happens to the live site (worst case is the status-quo cold
-# start). GitHub cron is best-effort and can lag 5–15 min past the boundary; that
-# is fine here — combined with cron-job.org's ticks it still closes the window.
+# fails nothing happens to the live site (worst case is the status-quo cold start).
 
 name: Render keepalive
 
 on:
   schedule:
-    # Every 10 minutes, matching the cron-job.org cadence. GitHub cron is
-    # best-effort and may run late; that is acceptable for a keepalive.
+    # Nominally every 10 min, but GitHub drops most scheduled triggers here (see
+    # header) — the reliable 10-min pinger is cron-job.org. This schedule is kept
+    # only for the occasional coarse liveness signal; `workflow_dispatch` is the
+    # dependable "warm it now" path.
     - cron: "*/10 * * * *"
   workflow_dispatch: {}
 

--- a/docs/free-tier-budget.md
+++ b/docs/free-tier-budget.md
@@ -56,7 +56,7 @@ These numbers are pessimistic; real-world will be lower. Round up for safety.
 | Idle sleep | 15 min idle → sleep | Acceptable: FastAPI is off the buzzer hot path |
 | Cold start | ~30 s wake | Felt only on game creation after long idle |
 
-**Binding constraint**: cold-start UX. The first game-creation request after a >15min idle period stalls ~30s. Mitigation: two independent keepalives ping `/health` every 10 minutes — the external cron-job.org job (primary) and the in-repo `.github/workflows/render-keepalive.yml` GitHub Action (monitored backstop). See §2.7 for the full setup and the 2026-06/07 outage that motivated the second leg.
+**Binding constraint**: cold-start UX. The first game-creation request after a >15min idle period stalls ~30s. Mitigation: the external cron-job.org job pings `/health` every 10 minutes (the one reliable keepalive), backed by an in-repo `.github/workflows/render-keepalive.yml` GitHub Action used as an on-demand "warm it now" button plus a coarse monitor (GitHub drops most of its scheduled ticks, so it is not a reliable second leg). See §2.7 for the full setup and the 2026-06/07 outage that motivated it.
 
 ### 2.3 Cloudflare Pages
 
@@ -93,33 +93,44 @@ Free, no quotas relevant to this project.
 | Replays | 50 / mo | Use sparingly for debugging |
 | Team members | 1 | Solo maintainer |
 
-### 2.7 Render keepalive (two independent legs + a UI fallback)
+### 2.7 Render keepalive (one reliable cron + an on-demand/monitor backstop + a UI fallback)
 
 | Resource | Limit | Notes |
 |---|---|---|
 | cron-job.org — cron jobs | 50 | Use 1 (jobId 7569155, account benartzi4@gmail.com) |
 | cron-job.org — min interval | 1 minute | We use **10 min** (`minutes:[0,10,20,30,40,50]`, Asia/Jerusalem) |
-| GitHub Actions — minutes | unlimited (public repo) | `render-keepalive.yml`, `*/10 * * * *` + manual dispatch |
+| GitHub Actions — minutes | unlimited (public repo) | `render-keepalive.yml`, `*/10 * * * *` (nominal) + manual dispatch |
 
-The Render dyno sleeps after 15 min idle, so it stays warm as long as **any**
-ping lands inside each 15-min window. Two independent keepalives hit
-`GET /health` every 10 minutes:
+The Render dyno sleeps after 15 min idle, so it stays warm as long as a ping
+lands inside each 15-min window. The keepalive has three layers, but only **one**
+is a reliable every-10-minutes ping:
 
-1. **cron-job.org (primary)** — an external 24/7 cron. This is the historical
-   keepalive but it is an *unmonitored* single point of failure: it silently
-   auto-disabled after repeated failures on **2026-06-23** and stayed dead for
-   **23 days** (nobody noticed until 2026-07-16), which was the root cause of the
-   "sometimes long loading" reports over that period. It was re-enabled 2026-07-16.
-   Its requests are also *intermittently* served **HTTP 503 by Render's own
-   Cloudflare edge** (Render fronts every service with Cloudflare; our DNS is
-   Namecheap, so there is no user-side Cloudflare zone to allowlist in) — the
-   block is per-egress-IP and comes and goes.
-2. **GitHub Actions `render-keepalive.yml` (monitored backstop)** — added
-   2026-07-16 for exactly this reason. It pings the same endpoint on the same
-   cadence from GitHub's runner IPs (a *different* egress pool, so its failures
-   are uncorrelated with cron-job.org's), and a lapse is **visible as a red run in
-   the Actions tab** — the monitoring the external cron lacks. A cold-start window
-   now requires *both* legs to miss simultaneously.
+1. **cron-job.org (the reliable primary)** — an external 24/7 cron that hits
+   `GET /health` every 10 minutes, on time. This is the leg that actually keeps
+   Render warm. Its one weakness is that it is an *unmonitored* single point of
+   failure: it silently auto-disabled after repeated failures on **2026-06-23**
+   and stayed dead for **23 days** (nobody noticed until 2026-07-16), which was the
+   root cause of the "sometimes long loading" reports over that period. Re-enabled
+   2026-07-16; verified healthy since (exact 10-min cadence). Its requests are also
+   *intermittently* served **HTTP 503 by Render's own Cloudflare edge** (Render
+   fronts every service with Cloudflare; our DNS is Namecheap, so there is no
+   user-side Cloudflare zone to allowlist in) — the block is per-egress-IP and
+   comes and goes, but has not produced two consecutive failed ticks in the
+   observed window (a cold-start window needs ~15 min with zero good pings).
+2. **GitHub Actions `render-keepalive.yml` (on-demand button + coarse monitor,
+   NOT a reliable keepalive)** — added 2026-07-16. Its *nominal* schedule is
+   `*/10`, but **GitHub silently drops the vast majority of scheduled triggers**
+   on this repo: measured against the `*/15` `stale-buzz-lock-scan.yml`, real
+   scheduled runs land with **49–204-minute gaps** (avg ~90 min), far longer than
+   Render's 15-min sleep. So it cannot keep the dyno warm on its own. What it *is*
+   good for: (a) a reliable **`workflow_dispatch`** "warm it now" button (verified
+   HTTP 200 from GitHub's runner IPs — a different egress pool, so not co-blocked
+   with cron-job.org), and (b) a **coarse liveness monitor** — when a scheduled run
+   *does* fire, a red run in the Actions tab flags an unreachable backend. It is
+   kept as a cheap, harmless safety net, not as a second reliable leg. (A genuinely
+   reliable second leg would be a Supabase `pg_cron` + `pg_net` ping — considered
+   2026-07-16 and deferred; cron-job.org was healthy, so the extra prod change
+   wasn't taken.)
 
 On top of those, the frontend `useKeepBackendWarm` hook (manager console only,
 while a game is `waiting`/`playing`) is a deliberate **visibility-aware fallback**
@@ -130,11 +141,13 @@ the two cases a cron cannot: a host who deep-links straight into
 asleep and returns to a possibly-cold dyno right at Bonus/End. `/health` is
 unlimited + unauthenticated (§6), so the handful of extra GETs per game is free.
 
-**If "sometimes slow" ever returns, check in this order:** (a) the Actions tab —
-is `render-keepalive` running green every ~10 min? (b) cron-job.org —
+**If "sometimes slow" ever returns, check the reliable leg first:** (a) cron-job.org —
 `curl -H "Authorization: Bearer $CRONJOB_API_KEY" https://api.cron-job.org/jobs`
 for `enabled`/`lastStatus` (1=OK, 4=HTTP error) on jobId 7569155, and
-`/jobs/7569155/history` for the recent run tally.
+`/jobs/7569155/history` for the recent run tally (this is the June-2026 failure mode:
+the job silently auto-disabled). (b) Only then the Actions tab — but remember its
+scheduled runs are sparse (hours apart), so treat a *manual* `workflow_dispatch` run
+as the definitive "is the backend reachable right now" probe, not the schedule.
 
 ### 2.8 Domain (paid; not free)
 


### PR DESCRIPTION
## Summary

Follow-up to #285. While verifying the new `render-keepalive.yml`, I measured GitHub's actual scheduled-run cadence in this repo (via the existing `*/15` `stale-buzz-lock-scan.yml`): real scheduled runs land **49–204 minutes apart** (avg ~90 min), not on the nominal cadence — GitHub silently drops most scheduled triggers. Since Render sleeps after 15 min idle, the GitHub Action **cannot keep the dyno warm on its own**.

This corrects the (now-inaccurate) framing #285 introduced:

- **`render-keepalive.yml` header + schedule comment:** reframed from "redundant second leg on the same 10-min cadence" to what it actually is — a reliable manual `workflow_dispatch` "warm it now" button plus a coarse liveness monitor. Behavior unchanged (same schedule, same ping/retry logic).
- **`docs/free-tier-budget.md` §2.2 + §2.7:** cron-job.org is documented as the one reliable 10-min keepalive; the GitHub Action as an on-demand/monitor backstop (with the measured 49–204 min gap fact); and the "check first if slow" runbook now points at cron-job.org first (its silent auto-disable was the June-2026 root cause).

No behavior change — comments and docs only. No CHANGELOG entry (infra/doc-only, not user-visible).

## Test plan

- `render-keepalive.yml` still parses as valid YAML; unchanged `schedule`/`workflow_dispatch`/`permissions: {}`/`ping` job (the manual dispatch was verified HTTP 200 in #285).
- Docs review only.