### PR TITLE
Correct keepalive interval in docs (14 min -> 10 min)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ The catalog stores only `youtube_id` and `start_time`. The browser embeds the Yo
 
 | Trade-off | Why we accept it |
 |---|---|
-| 30s cold start on Render after idle | Only affects game creation, not gameplay; mitigated by 14-min keepalive ping |
+| 30s cold start on Render after idle | Only affects game creation, not gameplay; mitigated by 10-min keepalive ping |
 | Single-region Postgres | Free tier limitation; pick region matching primary user geography |
 | No game history persistence | By user choice; matches today's on-demand mode |
 | Per-game manager token + single-tenant catalog admin password | Hosting is open (anyone can run a game); the catalog stays gated. Supabase Auth is the multi-tenant escape hatch if accounts ever ship |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -181,7 +181,7 @@ Symptoms: manager presses "Create game", waits 30+ seconds, then it works.
 
 Cause: Render free tier sleeping after 15min idle. First request wakes it.
 
-Mitigation already in place: cron-job.org pings `/health` every 14 min.
+Mitigation already in place: cron-job.org pings `/health` every 10 min.
 
 If this is happening, check:
 1. cron-job.org dashboard → is the keepalive job running? Last execution time?

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -225,13 +225,13 @@ free tier has ample headroom. Credentials + rotation: `runbook.md` §3.6.
 
 ## 8. Render Keepalive: cron-job.org
 
-**External cron pings `https://api.soundclash.org/health` every 14 minutes** to defeat Render's 15-minute idle sleep.
+**External cron pings `https://api.soundclash.org/health` every 10 minutes** to defeat Render's 15-minute idle sleep.
 
 ### Why this approach
 
 - Free, no signup friction.
-- Truly external (running this from GitHub Actions schedules would burn minutes and is the wrong tool).
-- 14-minute interval keeps Render warm; 15-minute interval risks a sleep window.
+- Truly external (a GitHub Actions schedule is not a reliable substitute: in this repo scheduled workflows fire 49–204 min apart, so `render-keepalive.yml` serves only as an on-demand warm-up button and coarse monitor).
+- 10-minute interval keeps Render warm; a 15-minute interval risks a sleep window.
 
 ### Failure mode
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -240,7 +240,7 @@ Both projects are skipped when their DSN env var is empty (so `pytest` runs and 
 
 ### 8.2 Render keepalive: cron-job.org
 
-The Render free tier sleeps after 15 min of idle. cron-job.org pings `https://api.soundclash.org/health` every 14 min to keep the worker warm.
+The Render free tier sleeps after 15 min of idle. cron-job.org pings `https://api.soundclash.org/health` every 10 min to keep the worker warm.
 
 Account credentials are kept out of the repo; see your password manager.
 


### PR DESCRIPTION
## Summary
Four docs still said the cron-job.org keepalive pings /health every 14 minutes; the actual job runs every 10 minutes. Corrected in architecture.md, runbook.md, tech-stack.md, tooling.md. Also updated tech-stack.md's stale claim that a GitHub Actions schedule would be a viable alternative (scheduled workflows in this repo fire 49-204 min apart; render-keepalive.yml is an on-demand warm-up button and coarse monitor, not a keepalive).

## Test plan
Docs-only change; no code paths affected. Verified the corrected interval against the live cron-job.org job configuration (minutes 0,10,20,30,40,50).